### PR TITLE
Demo section width based on parent rather than viewport

### DIFF
--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -87,7 +87,7 @@ pre {
   display: flex;
   flex-direction: row;
   flex-flow: wrap;
-  width: calc(100vw - 250px);
+  width: calc(100% - 250px);
 
   > .title {
     font-size: $frost-font-xl;


### PR DESCRIPTION
needed for frost-guide compatibility
# fix
