### PR TITLE
Update app.scss - protect frost-guide

### DIFF
--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -68,14 +68,14 @@ pre {
   }
 }
 
-.title {
+.dummy-body .title {
   padding-bottom: 10px;
   padding-top: 10px;
   font-family: $frost-font-family;
   font-size: $frost-font-l;
 }
 
-.list-item {
+.dummy-body .list-item {
   padding-bottom: 5px;
   padding-top: 10px;
   font-family: $frost-font-family;
@@ -83,7 +83,7 @@ pre {
 }
 
 
-.section {
+.dummy-body .section {
   display: flex;
   flex-direction: row;
   flex-flow: wrap;
@@ -119,7 +119,7 @@ pre {
 }
 
 
-.icon-demo {
+.dummy-body .icon-demo {
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;


### PR DESCRIPTION
```
-- .title {
++ .dummy-body .title {
```

^fixes the frost-guide tabs in firefox.

Also applied to other selectors which may be problematic now or in the future.
# fix
