### PR TITLE
fix height setup

### DIFF
--- a/addon/styles/_flex.scss
+++ b/addon/styles/_flex.scss
@@ -1,6 +1,6 @@
 html,
 body,
-body > .ember-view {
+body > .ember-view:not(.liquid-target-container), .setupHeight.ember-view {
   height: 100%; // 100% height is used for vertical flexbox
 }
 
@@ -9,3 +9,4 @@ body > .ember-view {
     flex: (#{$x});
   }
 }
+


### PR DESCRIPTION
# fix

to avoid overriding any liquid containers that are first children of `<body>`
'setupHeight' is a custom class that can be applied by consumers to their app containers in case they have an obscure setup that doesn't fall in this rule. 
