### PR TITLE
Textarea blur

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # misc
 /.sass-cache
+/.idea
 /connect.lock
 /coverage/*
 /libpeerconnection.log

--- a/addon/components/frost-button.js
+++ b/addon/components/frost-button.js
@@ -93,6 +93,7 @@ export default Ember.Component.extend({
     'autofocus',
     'disabled',
     'type',
+    'tabIndex',
     'title'
   ],
 
@@ -221,6 +222,13 @@ export default Ember.Component.extend({
 
     if (!this.get('disabled') && _.isFunction(this.attrs['onClick'])) {
       this.attrs['onClick'](this.get('id'))
+    }
+  }),
+
+  _onFocus: Ember.on('focusIn', function (e) {
+    // If an onFocus handler is defined, call it
+    if (this.attrs.onFocus) {
+      this.attrs.onFocus()
     }
   })
 })

--- a/addon/components/frost-checkbox.js
+++ b/addon/components/frost-checkbox.js
@@ -41,6 +41,13 @@ export default Ember.Component.extend({
     return `${id}_input`
   }),
 
+  _onFocus: Ember.on('focusIn', function (e) {
+    // If an onFocus handler is defined, call it
+    if (this.attrs.onFocus) {
+      this.attrs.onFocus()
+    }
+  }),
+
   actions: {
     onBlur () {
       const onBlur = this.get('onBlur')

--- a/addon/components/frost-password.js
+++ b/addon/components/frost-password.js
@@ -40,6 +40,13 @@ export default Ember.Component.extend({
     return this.get('revealable') && this.get('isCapsOn') && this.get('isRevealerVisible')
   }),
 
+  _onFocus: Ember.on('focusIn', function (e) {
+    // If an onFocus handler is defined, call it
+    if (this.attrs.onFocus) {
+      this.attrs.onFocus()
+    }
+  }),
+
   actions: {
     onBlur () {
       const onBlur = this.get('onBlur')

--- a/addon/components/frost-select.js
+++ b/addon/components/frost-select.js
@@ -489,6 +489,10 @@ export default Ember.Component.extend({
     onFocus () {
       this.openList()
       this.set('focus', true)
+      // If an onFocus event handler is defined, call it
+      if (this.attrs.onFocus) {
+        this.attrs.onFocus()
+      }
       return false
     },
 

--- a/addon/components/frost-text.js
+++ b/addon/components/frost-text.js
@@ -25,8 +25,13 @@ export default Ember.Component.extend({
     }
   }),
 
-  onFocus: Ember.on('focusIn', function (e) {
+  _onFocus: Ember.on('focusIn', function (e) {
+    // Selects the text when the frost-text field is selected
     e.target.select()
+    // If an onFocus handler is defined, call it
+    if (this.attrs.onFocus) {
+      this.attrs.onFocus()
+    }
   }),
 
   didInitAttrs () {

--- a/addon/components/frost-textarea.js
+++ b/addon/components/frost-textarea.js
@@ -26,6 +26,13 @@ export default Ember.Component.extend({
     }
   }),
 
+  _onFocus: Ember.on('focusIn', function () {
+    // If an onFocus handler is defined, call it
+    if (this.attrs.onFocus) {
+      this.attrs.onFocus()
+    }
+  }),
+
   actions: {
     clear: function () {
       this.set('value', '')

--- a/addon/templates/components/frost-password.hbs
+++ b/addon/templates/components/frost-password.hbs
@@ -11,6 +11,7 @@
       {{#frost-button
         size='none'
         priority='none'
+        tabIndex='-1'
         onClick=(action "toggleReveal")}}
         {{frost-icon icon=revealIcon}}
       {{/frost-button}}

--- a/addon/templates/components/frost-textarea.hbs
+++ b/addon/templates/components/frost-textarea.hbs
@@ -11,7 +11,7 @@
   wrap=wrap
 }}
 {{#if showClear}}
-  {{#frost-button class='clear' type='icon' onClick=(action 'clear')}}
+  {{#frost-button class='clear' type='icon' tabIndex='-1' onClick=(action 'clear')}}
     {{frost-icon  icon='frost/close'}}
   {{/frost-button}}
 {{/if}}

--- a/tests/dummy/app/pods/area/controller.js
+++ b/tests/dummy/app/pods/area/controller.js
@@ -12,6 +12,15 @@ export default Ember.Controller.extend({
       })
     },
 
+    onFocusHandler () {
+      this.notifications.addNotification({
+        message: 'focus event',
+        type: 'success',
+        autoClear: true,
+        clearDuration: 2000
+      })
+    },
+
     onInputHandler (attrs) {
       console.log('text area value: ' + attrs.value)
       this.notifications.addNotification({

--- a/tests/dummy/app/pods/area/template.hbs
+++ b/tests/dummy/app/pods/area/template.hbs
@@ -99,16 +99,18 @@
   <div class="section">
 
     <div class="example">
-      <div class="title">onBlur</div>
+      <div class="title">onFocus, onBlur</div>
       <div class="demo">
         {{frost-textarea
           onBlur=(action "onBlurHandler")
+          onFocus=(action "onFocusHandler")
         }}
       </div>
       <div class="snippet">
         {{format-markdown "```handlebars
 {{frost-textarea
   onBlur=(action 'onBlurHandler')
+  onFocus=(action 'onFocusHandler')
 }}
 ```"
         }}

--- a/tests/dummy/app/pods/field/controller.js
+++ b/tests/dummy/app/pods/field/controller.js
@@ -13,6 +13,15 @@ export default Ember.Controller.extend({
       })
     },
 
+    onFocusHandler () {
+      this.notifications.addNotification({
+        message: 'focus event',
+        type: 'success',
+        autoClear: true,
+        clearDuration: 2000
+      })
+    },
+
     onInputHandler (attrs) {
       console.log('field value: ' + attrs.value)
       this.notifications.addNotification({

--- a/tests/dummy/app/pods/field/template.hbs
+++ b/tests/dummy/app/pods/field/template.hbs
@@ -127,17 +127,19 @@
   <div class='section'>
 
     <div class="example">
-      <div class="title">onBlur</div>
+      <div class="title">onFocus, onBlur</div>
       <div class="demo">
         {{frost-text
           onBlur=(action 'onBlurHandler')
+          onFocus=(action 'onFocusHandler')
         }}
       </div>
       <div class="snippet">
         {{format-markdown "```handlebars
-    {{frost-text
-    onBlur=(action 'onBlurHandler')
-    }}
+{{frost-text
+  onBlur=(action 'onBlurHandler')
+  onFocus=(action 'onFocusHandler')
+}}
     ```"
         }}
       </div>

--- a/tests/integration/components/frost-checkbox-test.js
+++ b/tests/integration/components/frost-checkbox-test.js
@@ -54,5 +54,7 @@ describeComponent(
       this.render(hbs`{{frost-checkbox onBlur=(action "test-action")}}`)
       this.$('label').trigger('blur')
     })
+
+    // TODO: test onFocus once we can figure out how
   }
 )

--- a/tests/integration/components/frost-text-test.js
+++ b/tests/integration/components/frost-text-test.js
@@ -59,5 +59,15 @@ describeComponent(
       this.render(hbs`{{frost-text onBlur=(action "test-action")}}`)
       this.$('input').focus().val('a').focusout()
     })
+
+    // it('calls onFocus callback when focused', function (done) {
+    //   this.on('test-action', function () {
+    //     done()
+    //   })
+    //
+    //   this.render(hbs`<div class="dummy"></div>{{frost-text onFocus=(action "test-action")}}`)
+    //   Ember.run(() => this.$('.dummy').focus())
+    //   Ember.run(() => this.$('input').focus().val('a'))
+    // })
   }
 )

--- a/tests/integration/components/frost-textarea-test.js
+++ b/tests/integration/components/frost-textarea-test.js
@@ -58,5 +58,14 @@ describeComponent(
       this.render(hbs`{{frost-textarea onBlur=(action "test-action")}}`)
       this.$('textarea').focus().val('a').focusout()
     })
+
+    // it('calls onFocus callback when focused', function (done) {
+    //   this.on('test-action', function () {
+    //     done()
+    //   })
+    //
+    //   this.render(hbs`{{frost-text onFocus=(action "test-action")}}`)
+    //   this.$('input').val('a').focusout().focus()
+    // })
   }
 )


### PR DESCRIPTION
# PATCH

Previously an onFocus attribute to a frost-text would overwrite its internal handler that selects the text. Most other widgets did not support onFocus. Fix that and add it to the demo. Can't figure out how to test it though.
Also set tabIndex=-1 so that tabbing skips the textarea clear button and the password reveal button.
@sglanzer @sandersky 
