### PR TITLE
Add ember-truth-helpers to blueprints to resolve #72

### DIFF
--- a/blueprints/ember-frost-core/index.js
+++ b/blueprints/ember-frost-core/index.js
@@ -28,7 +28,8 @@ module.exports = {
           packages: [
             {name: 'ember-computed-decorators', target: '>=0.2.2 <2.0.0'},
             {name: 'ember-lodash', target: '>=0.0.6 <2.0.0'},
-            {name: 'ember-one-way-controls', target: '>=0.5.3 <2.0.0'}
+            {name: 'ember-one-way-controls', target: '>=0.5.3 <2.0.0'},
+            {name: 'ember-truth-helpers', target: '^1.0.0'}
           ]
         })
       })


### PR DESCRIPTION
# PATCH

This makes `ember-frost-core` consumable by a newly scaffolded Ember app via the following:

``` bash
ember new foo-bar
cd foo-bar
ember install ember-frost-core
npm test
npm start
```
