### PR TITLE
Add `tabindex` support to text components

### DIFF
--- a/addon/components/frost-password.js
+++ b/addon/components/frost-password.js
@@ -12,6 +12,7 @@ export default Ember.Component.extend({
   revealed: false,
   revealIcon: 'frost/show',
   type: 'password',
+  tabindex: 0,
 
   focusOut: Ember.on('focusOut', function () {
     this.set('isCapsOn', false)

--- a/addon/components/frost-text.js
+++ b/addon/components/frost-text.js
@@ -9,6 +9,7 @@ export default Ember.Component.extend({
   layout: layout,
 
   showClear: false,
+  tabindex: 0,
 
   onChange: Ember.on('input', function (e) {
     const id = this.get('id')

--- a/addon/components/frost-textarea.js
+++ b/addon/components/frost-textarea.js
@@ -8,6 +8,7 @@ export default Ember.Component.extend({
   layout: layout,
 
   showClear: false,
+  tabindex: 0,
 
   oninput: Ember.on('input', function (e) {
     if (_.isFunction(this.attrs['onInput'])) {

--- a/addon/templates/components/frost-password.hbs
+++ b/addon/templates/components/frost-password.hbs
@@ -6,6 +6,7 @@
     type=type
     onBlur=(action 'onBlur')
     onInput=(action "onInput")
+    tabindex=tabindex
     disabled=disabled}}
   {{#if revealable}}
     {{#if isRevealerVisible}}

--- a/addon/templates/components/frost-text.hbs
+++ b/addon/templates/components/frost-text.hbs
@@ -5,6 +5,7 @@
   focus-out=(action 'onBlur')
   value=value
   placeholder=placeholder
+  tabindex=tabindex
   readonly=readonly}}
 {{#if showClear}}
   {{!frost-icon class='clear' icon='frost/close'}}

--- a/addon/templates/components/frost-textarea.hbs
+++ b/addon/templates/components/frost-textarea.hbs
@@ -9,6 +9,7 @@
   readonly=readonly
   rows=rows
   wrap=wrap
+  tabindex=tabindex
 }}
 {{#if showClear}}
   {{#frost-button class='clear' type='icon' tabIndex='-1' onClick=(action 'clear')}}

--- a/tests/dummy/app/pods/area/template.hbs
+++ b/tests/dummy/app/pods/area/template.hbs
@@ -91,6 +91,24 @@
         }}
       </div>
     </div>
+    <div class="example">
+      <div class="title">tabindex</div>
+      <div class="demo">
+        {{frost-textarea
+          placeholder='Un-tabbable'
+          tabindex='-1'
+        }}
+      </div>
+      <div class="snippet">
+        {{format-markdown "```handlebars
+{{frost-textarea
+  placeholder='Un-tabbable'
+  tabindex='-1'
+}}
+  ```"
+        }}
+      </div>
+    </div>
 
   </div>
 

--- a/tests/dummy/app/pods/field/template.hbs
+++ b/tests/dummy/app/pods/field/template.hbs
@@ -122,6 +122,23 @@
       </div>
   </div>
 
+  <div class="example">
+    <div class="title">tabindex</div>
+    <div class="demo">
+      {{frost-text
+        tabindex='-1'
+      }}
+    </div>
+    <div class="snippet">
+      {{format-markdown "```handlebars
+{{frost-text
+  tabindex='-1'
+}}
+```"
+      }}
+    </div>
+  </div>
+
   <div class="section-title">Events</div>
   <hr>
   <div class='section'>

--- a/tests/dummy/app/pods/link/template.hbs
+++ b/tests/dummy/app/pods/link/template.hbs
@@ -94,6 +94,30 @@
       </div>
     </div>
 
+    <div class="example">
+      <div class="title">tabindex</div>
+      <div class="demo">
+        {{#frost-link 'link.min'
+          priority='primary'
+          size='small'
+          tabindex='-1'
+        }}
+          Primary
+        {{/frost-link}}
+      </div>
+      <div class="snippet">
+        {{format-markdown "```handlebars
+{{#frost-link 'link.min'
+  priority='primary'
+  size='small'
+  tabindex='-1'
+}}
+  Primary
+{{/frost-link}}
+```"}}
+      </div>
+    </div>
+
   </div>
 
   <div class="section-title">Secondary</div>
@@ -183,6 +207,30 @@
   priority='secondary'
   size='small'
   disabled=true
+}}
+  Secondary
+{{/frost-link}}
+```"}}
+      </div>
+    </div>
+
+    <div class="example">
+      <div class="title">tabindex</div>
+      <div class="demo">
+        {{#frost-link 'link.min'
+          priority='secondary'
+          size='small'
+          tabindex='-1'
+        }}
+          Secondary
+        {{/frost-link}}
+      </div>
+      <div class="snippet">
+        {{format-markdown "```handlebars
+{{#frost-link 'link.min'
+  priority='secondary'
+  size='small'
+  tabindex='-1'
 }}
   Secondary
 {{/frost-link}}

--- a/tests/dummy/app/pods/password/template.hbs
+++ b/tests/dummy/app/pods/password/template.hbs
@@ -62,22 +62,38 @@
   <hr>
 
   <div class="section">
-  <div class="example">
-    <div class="title">revealable</div>
-    <div class="demo">
-      {{frost-password
-        revealable=true
-      }}
-    </div>
-    <div class="snippet">
-      {{format-markdown "```handlebars
+    <div class="example">
+      <div class="title">revealable</div>
+      <div class="demo">
+        {{frost-password
+          revealable=true
+        }}
+      </div>
+      <div class="snippet">
+        {{format-markdown "```handlebars
 {{frost-password
   revealable=true
 }}
 ```"
-      }}
+        }}
+      </div>
     </div>
-  </div>
+    <div class="example">
+      <div class="title">tabindex</div>
+      <div class="demo">
+        {{frost-password
+          tabindex='-1'
+        }}
+      </div>
+      <div class="snippet">
+        {{format-markdown "```handlebars
+{{frost-password
+  tabindex='-1'
+}}
+```"
+        }}
+      </div>
+    </div>
 </div>
 
 <div class="section-title">Events</div>

--- a/tests/unit/components/frost-password-test.js
+++ b/tests/unit/components/frost-password-test.js
@@ -6,7 +6,9 @@ import {beforeEach, describe, it} from 'mocha'
 describeComponent(
   'frost-password',
   'FrostPasswordComponent',
-  {},
+  {
+    needs: ['component:frost-text']
+  },
   function () {
     let component
 
@@ -30,6 +32,17 @@ describeComponent(
           component.get('actions.onBlur').call(component)
         }).not.to.throw(Error)
       })
+    })
+
+    it('defaults to zero tabindex', function () {
+      expect(component.tabindex).to.equal(0)
+      expect(this.$('input').prop('tabindex')).to.equal(0)
+    })
+
+    it('passes tabindex to the underlying field', function () {
+      component.set('tabindex', -1)
+      expect(component.tabindex).to.equal(-1)
+      expect(this.$('input').prop('tabindex')).to.equal(-1)
     })
   }
 )

--- a/tests/unit/components/frost-text-test.js
+++ b/tests/unit/components/frost-text-test.js
@@ -31,5 +31,16 @@ describeComponent(
         }).not.to.throw(Error)
       })
     })
+
+    it('defaults to zero tabindex', function () {
+      expect(component.tabindex).to.equal(0)
+      expect(this.$('input').prop('tabindex')).to.equal(0)
+    })
+
+    it('passes tabindex to the underlying field', function () {
+      component.set('tabindex', -1)
+      expect(component.tabindex).to.equal(-1)
+      expect(this.$('input').prop('tabindex')).to.equal(-1)
+    })
   }
 )

--- a/tests/unit/components/frost-textarea-test.js
+++ b/tests/unit/components/frost-textarea-test.js
@@ -31,5 +31,16 @@ describeComponent(
         }).not.to.throw(Error)
       })
     })
+
+    it('defaults to zero tabindex', function () {
+      expect(component.tabindex).to.equal(0)
+      expect(this.$('textarea').prop('tabindex')).to.equal(0)
+    })
+
+    it('passes tabindex to the underlying field', function () {
+      component.set('tabindex', -1)
+      expect(component.tabindex).to.equal(-1)
+      expect(this.$('textarea').prop('tabindex')).to.equal(-1)
+    })
   }
 )


### PR DESCRIPTION
# MINOR

This PR ensures that a `tabindex` property passed to `frost-text`, `frost-textarea`, and `frost-password` components is passed to the underlying `{{input}}` in our templates. (This feature already works as expected with `frost-link`, as it inherits from `Ember.LinkComponent`, but I added a demo invocation of it as well.)
