### PR TITLE
Fix for apps without a icon pack or legacy icon path

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ module.exports = {
         const addonIconPackPath = path.join(addonPackage.path, iconPackPath)
 
         var svgFunnel
-        if (iconPack.name === 'frost' && isLegacy) {
+        if (iconPack.name === 'frost' && isLegacy && fs.existsSync(path.join(this.project.root, 'public/svgs'))) {
           svgFunnel = mergeTrees([
             new Funnel(addonIconPackPath, {
               include: [new RegExp(/\.svg$/)]


### PR DESCRIPTION
# fix
# CHANGELOG

Fixed a broken build when a consuming app doesn't specify an application icon pack and doesn't contain the legacy `public/svgs` icons path
