### PR TITLE
Fix size of reveal icon for frost-password

### DIFF
--- a/addon/components/frost-password.js
+++ b/addon/components/frost-password.js
@@ -10,7 +10,7 @@ export default Ember.Component.extend({
   isRevealerVisible: false,
   revealable: false,
   revealed: false,
-  revealIcon: 'frost/show',
+  revealIcon: 'show',
   type: 'password',
   tabindex: 0,
 

--- a/addon/styles/_frost-password.scss
+++ b/addon/styles/_frost-password.scss
@@ -8,6 +8,10 @@
   }
 
   &.revealable {
+    .frost-icon {
+      max-height: 16px;
+      max-width: 16px;
+    }
 
     .frost-text .clear {
       margin-left: -40px;


### PR DESCRIPTION
# PATCH
# CHANGELOG
- **Fixed** size of reveal icon for `frost-password`.
- **Updated** `frost-password` to use updated icon path for reveal icon.
