### PR TITLE
Fix Ember 2.6.0 deprecation

### DIFF
--- a/addon/components/frost-text.js
+++ b/addon/components/frost-text.js
@@ -35,9 +35,12 @@ export default Ember.Component.extend({
     }
   }),
 
-  didInitAttrs () {
-    this.set('right', this.get('align') === 'right')
-    this.set('center', this.get('align') === 'center')
+  init () {
+    this._super(...arguments)
+    this.setProperties({
+      center: this.get('align') === 'center',
+      right: this.get('align') === 'right'
+    })
   },
 
   actions: {


### PR DESCRIPTION
# PATCH
# CHANGELOG
- **Fixed** deprecation warning from Ember 2.6.0 to stop using `didInitAttrs` hook and instead use `init`.
