### PR TITLE
Adding onEnter to frost-text to trigger actions using the enter key

### DIFF
--- a/addon/templates/components/frost-text.hbs
+++ b/addon/templates/components/frost-text.hbs
@@ -3,6 +3,7 @@
   autofocus=autofocus
   disabled=disabled
   focus-out=(action 'onBlur')
+  insert-newline=onEnter
   value=value
   placeholder=placeholder
   tabindex=tabindex


### PR DESCRIPTION
# fix
# CHANGELOG

Added onEnter to frost-text so that actions can be triggered using the enter key when the input is in focus
