### PR TITLE
fix clear icon style to show it inside the area

### DIFF
--- a/addon/styles/_frost-textarea.scss
+++ b/addon/styles/_frost-textarea.scss
@@ -53,6 +53,7 @@ $disabled-bg: $frost-color-input-disabled-bg;
     margin: 5px 0 0 -45px;
     width: 35px;
     > svg {
+      width: 26px;
       height: 26px;
       fill: $frost-color-grey-6;
       cursor: pointer;

--- a/addon/styles/_frost-textarea.scss
+++ b/addon/styles/_frost-textarea.scss
@@ -50,7 +50,7 @@ $disabled-bg: $frost-color-input-disabled-bg;
 
   .clear {
     z-index: 1;
-    margin: 5px 0 0 -45px;
+    margin: 5px 0 0 -40px;
     width: 35px;
     > svg {
       width: 26px;


### PR DESCRIPTION
# fix
# CHANGELOG
- FIXED frost-textarea clear icon style to show it inside the text area
