### PR TITLE
Fixing select to avoid double firing

### DIFF
--- a/addon/components/frost-select.js
+++ b/addon/components/frost-select.js
@@ -491,7 +491,7 @@ export default Component.extend({
     let valueIndex = _.findIndex(this.get('items'), (item) => _.isEqual(item.value, selectedValue))
 
     if (valueIndex >= 0) { // Make sure we actually found the value
-      this.select(valueIndex)
+      this.set('selected', [valueIndex])
     }
   },
 


### PR DESCRIPTION
# fix

The select by value is only applicable when receiving attribute changes from an external source and was firing the onChange twice on user input
# CHANGELOG
- Changed selection by value to not fire the onChange event
