### PR TITLE
Oh hai template snippets

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -13,7 +13,13 @@ module.exports = function (defaults) {
       includePaths: [
         'addon/styles'
       ]
-    }
+    },
+    snippetPaths: [
+      'code-snippets'
+    ],
+    snippetSearchPaths: [
+      'tests/dummy'
+    ]
   })
 
   app.import('bower_components/sinonjs/sinon.js')

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "ember-cli-notifications": "^3.2.0",
     "ember-cli-sass": "^5.2.0",
     "ember-cli-uglify": "^1.2.0",
+    "ember-code-snippet": "1.3.0",
     "ember-computed-decorators": ">=0.2.2 <2.0.0",
     "ember-data": "^2.5.3",
     "ember-disable-proxy-controllers": "^1.0.1",

--- a/tests/dummy/app/pods/button/template.hbs
+++ b/tests/dummy/app/pods/button/template.hbs
@@ -1,4 +1,4 @@
-<div class="dummy-notification-container">
+<div class='dummy-notification-container'>
 {{#each notifications as |notification|}}
   {{notification-message notification=notification}}
 {{/each}}
@@ -7,47 +7,38 @@
 
 <div class='dummy-body button'>
 
-  <div class="section-title">Primary</div>
+  <div class='section-title'>Primary</div>
   <hr>
   <div class='section'>
-
     <div class='example'>
       <div class='title'>small</div>
       <div class='demo'>
+        {{! BEGIN-SNIPPET button-primary-small }}
         {{frost-button
           priority='primary'
           size='small'
           text='Text'
         }}
+        {{! END-SNIPPET }}
       </div>
       <div class='snippet'>
-        {{format-markdown "```handlebars
-{{frost-button
-  priority='primary'
-  size='small'
-  text='Text'
-}}
-```"}}
+        {{code-snippet name='button-primary-small.hbs'}}
       </div>
     </div>
 
     <div class='example'>
       <div class='title'>medium</div>
       <div class='demo'>
+        {{! BEGIN-SNIPPET button-primary-medium }}
         {{frost-button
           priority='primary'
           size='medium'
           text='Text'
         }}
+        {{! END-SNIPPET }}
       </div>
       <div class='snippet'>
-        {{format-markdown "```handlebars
-{{frost-button
-  priority='primary'
-  size='medium'
-  text='Text'
-}}
-```"}}
+        {{code-snippet name='button-primary-medium.hbs'}}
       </div>
     </div>
 
@@ -55,88 +46,69 @@
     <div class='example'>
       <div class='title'>large</div>
       <div class='demo'>
+        {{! BEGIN-SNIPPET button-primary-large }}
         {{frost-button
           priority='primary'
           size='large'
           text='Text'
         }}
+        {{! END-SNIPPET }}
       </div>
       <div class='snippet'>
-        {{format-markdown "```handlebars
-{{frost-button
-  priority='primary'
-  size='large'
-  text='Text'
-}}
-```"}}
+        {{code-snippet name='button-primary-large.hbs'}}
       </div>
     </div>
 
     <div class='example'>
       <div class='title'>disabled</div>
       <div class='demo'>
+        {{! BEGIN-SNIPPET button-primary-disabled }}
         {{frost-button
+          disabled=true
           priority='primary'
           size='medium'
-          disabled=true
           text='Text'
         }}
+        {{! END-SNIPPET }}
       </div>
       <div class='snippet'>
-        {{format-markdown "```handlebars
-{{frost-button
-  priority='primary'
-  size='medium'
-  disabled=true
-  text='Text'
-}}
-```"}}
+        {{code-snippet name='button-primary-disabled.hbs'}}
       </div>
     </div>
-
   </div>
 
-  <div class="section-title">Secondary</div>
+  <div class='section-title'>Secondary</div>
   <hr>
   <div class='section'>
-
     <div class='example'>
       <div class='title'>small</div>
       <div class='demo'>
+        {{! BEGIN-SNIPPET button-secondary-small }}
         {{frost-button
           priority='secondary'
           size='small'
           text='Text'
         }}
+        {{! END-SNIPPET }}
       </div>
       <div class='snippet'>
-        {{format-markdown "```handlebars
-{{frost-button
-  priority='secondary'
-  size='small'
-  text='Text'
-}}
-```"}}
+        {{code-snippet name='button-secondary-small.hbs'}}
       </div>
     </div>
 
     <div class='example'>
       <div class='title'>medium</div>
       <div class='demo'>
+        {{! BEGIN-SNIPPET button-secondary-medium }}
         {{frost-button
           priority='secondary'
           size='medium'
           text='Text'
         }}
+        {{! END-SNIPPET }}
       </div>
       <div class='snippet'>
-        {{format-markdown "```handlebars
-{{frost-button
-  priority='secondary'
-  size='medium'
-  text='Text'
-}}
-```"}}
+        {{code-snippet name='button-secondary-medium.hbs'}}
       </div>
     </div>
 
@@ -144,89 +116,70 @@
     <div class='example'>
       <div class='title'>large</div>
       <div class='demo'>
+        {{! BEGIN-SNIPPET button-secondary-large }}
         {{frost-button
           priority='secondary'
           size='large'
           text='Text'
         }}
+        {{! END-SNIPPET }}
       </div>
       <div class='snippet'>
-        {{format-markdown "```handlebars
-{{frost-button
-  priority='secondary'
-  size='large'
-  text='Text'
-}}
-```"}}
+        {{code-snippet name='button-secondary-large.hbs'}}
       </div>
     </div>
 
     <div class='example'>
       <div class='title'>disabled</div>
       <div class='demo'>
+        {{! BEGIN-SNIPPET button-secondary-disabled }}
         {{frost-button
+          disabled=true
           priority='secondary'
           size='medium'
-          disabled=true
           text='Text'
         }}
+        {{! END-SNIPPET }}
       </div>
       <div class='snippet'>
-        {{format-markdown "```handlebars
-{{frost-button
-  priority='secondary'
-  size='medium'
-  disabled=true
-  text='Text'
-}}
-```"}}
+        {{code-snippet name='button-secondary-disabled.hbs'}}
       </div>
     </div>
-
   </div>
 
 
-  <div class="section-title">Tertiary</div>
+  <div class='section-title'>Tertiary</div>
   <hr>
   <div class='section'>
-
     <div class='example'>
       <div class='title'>small</div>
       <div class='demo'>
+        {{! BEGIN-SNIPPET button-tertiary-small }}
         {{frost-button
           priority='tertiary'
           size='small'
           text='Text'
         }}
+        {{! END-SNIPPET }}
       </div>
       <div class='snippet'>
-        {{format-markdown "```handlebars
-{{frost-button
-  priority='tertiary'
-  size='small'
-  text='Text'
-}}
-```"}}
+        {{code-snippet name='button-tertiary-small.hbs'}}
       </div>
     </div>
 
     <div class='example'>
       <div class='title'>medium</div>
       <div class='demo'>
+        {{! BEGIN-SNIPPET button-tertiary-medium }}
         {{frost-button
           priority='tertiary'
           size='medium'
           text='Text'
         }}
+        {{! END-SNIPPET }}
       </div>
       <div class='snippet'>
-        {{format-markdown "```handlebars
-{{frost-button
-  priority='tertiary'
-  size='medium'
-  text='Text'
-}}
-```"}}
+        {{code-snippet name='button-tertiary-medium.hbs'}}
       </div>
     </div>
 
@@ -234,306 +187,236 @@
     <div class='example'>
       <div class='title'>large</div>
       <div class='demo'>
+        {{! BEGIN-SNIPPET button-tertiary-large }}
         {{frost-button
           priority='tertiary'
           size='large'
           text='Text'
         }}
+        {{! END-SNIPPET }}
       </div>
       <div class='snippet'>
-        {{format-markdown "```handlebars
-{{frost-button
-  priority='tertiary'
-  size='large'
-  text='Text'
-}}
-```"}}
+        {{code-snippet name='button-tertiary-large.hbs'}}
       </div>
     </div>
 
     <div class='example'>
       <div class='title'>disabled</div>
       <div class='demo'>
+        {{! BEGIN-SNIPPET button-tertiary-disabled }}
         {{frost-button
+          disabled=true
           priority='tertiary'
           size='medium'
-          disabled=true
           text='Text'
         }}
+        {{! END-SNIPPET }}
       </div>
       <div class='snippet'>
-        {{format-markdown "```handlebars
-{{frost-button
-  priority='tertiary'
-  size='medium'
-  disabled=true
-  text='Text'
-}}
-```"}}
+        {{code-snippet name='button-tertiary-disabled.hbs'}}
       </div>
     </div>
-
   </div>
 
 
-  <div class="section-title">Icon</div>
+  <div class='section-title'>Icon</div>
   <hr>
   <div class='section'>
-
     <div class='example'>
       <div class='title'>small</div>
       <div class='demo'>
+        {{! BEGIN-SNIPPET button-icon-small }}
         {{frost-button
+          icon='add'
           priority='primary'
           size='small'
-          icon='frost/add'
         }}
+        {{! END-SNIPPET }}
       </div>
       <div class='snippet'>
-        {{format-markdown "```handlebars
-{{frost-button
-  priority='primary'
-  size='small'
-  icon='frost/add'
-}}
-```"}}
+        {{code-snippet name='button-icon-small.hbs'}}
       </div>
     </div>
 
     <div class='example'>
       <div class='title'>medium</div>
       <div class='demo'>
+        {{! BEGIN-SNIPPET button-icon-medium }}
         {{frost-button
+          icon='add'
           priority='primary'
           size='medium'
-          icon='frost/add'
         }}
+        {{! END-SNIPPET }}
       </div>
       <div class='snippet'>
-        {{format-markdown "```handlebars
-{{frost-button
-  priority='primary'
-  size='medium'
-  icon='frost/add'
-}}
-```"}}
+        {{code-snippet name='button-icon-medium.hbs'}}
       </div>
     </div>
 
     <div class='example'>
       <div class='title'>large</div>
       <div class='demo'>
+        {{! BEGIN-SNIPPET button-icon-large }}
         {{frost-button
+          icon='add'
           priority='primary'
           size='large'
-          icon='frost/add'
         }}
+        {{! END-SNIPPET }}
       </div>
       <div class='snippet'>
-        {{format-markdown "```handlebars
-{{frost-button
-  priority='primary'
-  size='large'
-  icon='frost/add'
-}}
-```"}}
+        {{code-snippet name='button-icon-large.hbs'}}
       </div>
     </div>
 
     <div class='example'>
       <div class='title'>disabled</div>
       <div class='demo'>
+        {{! BEGIN-SNIPPET button-icon-disabled }}
         {{frost-button
+          disabled=true
+          icon='add'
           priority='primary'
           size='medium'
-          disabled=true
-          icon='frost/add'
         }}
+        {{! END-SNIPPET }}
       </div>
       <div class='snippet'>
-        {{format-markdown "```handlebars
-{{frost-button
-  priority='primary'
-  size='medium'
-  disabled=true
-  icon='frost/add'
-}}
-```"}}
+        {{code-snippet name='button-icon-disabled.hbs'}}
       </div>
     </div>
-
   </div>
 
-  <div class="section-title">Icon and Text</div>
+  <div class='section-title'>Icon and Text</div>
   <hr>
   <div class='section'>
-
     <div class='example'>
       <div class='title'>small</div>
       <div class='demo'>
+        {{! BEGIN-SNIPPET button-icon-text-small }}
         {{frost-button
+          icon='round-add'
           priority='tertiary'
           size='small'
-          icon='frost/round-add'
           text='Text'
         }}
+        {{! END-SNIPPET }}
       </div>
       <div class='snippet'>
-        {{format-markdown "```handlebars
-{{frost-button
-  priority='tertiary'
-  size='small'
-  icon='frost/round-add'
-  text='Text'
-}}
-```"}}
+        {{code-snippet name='button-icon-text-small.hbs'}}
       </div>
     </div>
 
     <div class='example'>
       <div class='title'>medium</div>
       <div class='demo'>
+        {{! BEGIN-SNIPPET button-icon-text-medium }}
         {{frost-button
+          icon='round-add'
           priority='tertiary'
           size='medium'
-          icon='frost/round-add'
           text='Text'
         }}
+        {{! END-SNIPPET }}
       </div>
       <div class='snippet'>
-        {{format-markdown "```handlebars
-{{frost-button
-  priority='tertiary'
-  size='medium'
-  icon='frost/round-add'
-  text='Text'
-}}
-```"}}
+        {{code-snippet name='button-icon-text-medium.hbs'}}
       </div>
     </div>
 
     <div class='example'>
       <div class='title'>large</div>
       <div class='demo'>
+        {{! BEGIN-SNIPPET button-icon-text-large }}
         {{frost-button
+          icon='round-add'
           priority='tertiary'
           size='large'
-          icon='frost/round-add'
           text='Text'
         }}
+        {{! END-SNIPPET }}
       </div>
       <div class='snippet'>
-        {{format-markdown "```handlebars
-{{frost-button
-  priority='tertiary'
-  size='large'
-  icon='frost/round-add'
-  text='Text'
-}}
-```"}}
+        {{code-snippet name='button-icon-text-large.hbs'}}
       </div>
     </div>
 
     <div class='example'>
       <div class='title'>disabled</div>
       <div class='demo'>
+        {{! BEGIN-SNIPPET button-icon-text-disabled }}
         {{frost-button
+          disabled=true
+          icon='round-add'
           priority='tertiary'
           size='medium'
-          disabled=true
-          icon='frost/round-add'
           text='Text'
         }}
+        {{! END-SNIPPET }}
       </div>
       <div class='snippet'>
-        {{format-markdown "```handlebars
-{{frost-button
-  priority='tertiary'
-  size='medium'
-  disabled=true
-  icon='frost/round-add'
-  text='Text'
-}}
-```"}}
+        {{code-snippet name='button-icon-text-disabled.hbs'}}
       </div>
     </div>
-
   </div>
 
-  <div class="section-title">Design</div>
+  <div class='section-title'>Design: info-bar</div>
   <hr>
   <div class='section'>
-
-    <div class="example">
-      <div class="title">info-bar</div>
-      <div class="demo">
+    <div class='example'>
+      <div class='title'>info-bar</div>
+      <div class='demo'>
+        {{! BEGIN-SNIPPET button-design-info-bar }}
         {{frost-button
           design='info-bar'
-          icon='frost/infobar-find'
+          icon='search'
           text='Text'
         }}
+        {{! END-SNIPPET }}
       </div>
-      <div class="snippet">
-        {{format-markdown "```handlebars
-{{frost-button
-  design='info-bar'
-  icon='frost/infobar-find'
-  text='Text'
-}}
-```"}}
+      <div class='snippet'>
+        {{code-snippet name='button-design-info-bar.hbs'}}
       </div>
     </div>
 
-    <div class="example">
-      <div class="title">disabled info-bar</div>
-      <div class="demo">
+    <div class='example'>
+      <div class='title'>disabled</div>
+      <div class='demo'>
+        {{! BEGIN-SNIPPET button-design-info-bar-disabled }}
         {{frost-button
           design='info-bar'
-          icon='frost/infobar-find'
-          text='Text'
           disabled=true
+          icon='search'
+          text='Text'
         }}
+        {{! END-SNIPPET }}
       </div>
-      <div class="snippet">
-        {{format-markdown "```handlebars
-{{frost-button
-  design='info-bar'
-  icon='frost/infobar-find'
-  text='Text'
-  disabled=true
-}}
-```"}}
+      <div class='snippet'>
+        {{code-snippet name='button-design-info-bar-disabled.hbs'}}
       </div>
     </div>
-
   </div>
 
- <div class="section-title">Events</div>
+  <div class='section-title'>Events</div>
   <hr>
   <div class='section'>
-    <div class="example">
-      <div class="title">onClick</div>
-      <div class="demo">
+    <div class='example'>
+      <div class='title'>onClick</div>
+      <div class='demo'>
+        {{! BEGIN-SNIPPET button-onClick }}
         {{frost-button
           priority='confirm'
           size='medium'
           text='Action'
           onClick=(action 'onClickHandler')
         }}
+        {{! END-SNIPPET }}
       </div>
-      <div class="snippet">
-        {{format-markdown "```handlebars
-{{frost-button
-  priority='primary'
-  size='medium'
-  text='Action'
-  onClick=(action 'onClickHandler')
-}}
-```"
-        }}
+      <div class='snippet'>
+        {{code-snippet name='button-onClick.hbs'}}
       </div>
     </div>
-
   </div>
 
 </div>

--- a/tests/dummy/app/styles/_button.scss
+++ b/tests/dummy/app/styles/_button.scss
@@ -1,0 +1,3 @@
+.frost-button .frost-icon-frost-search {
+  color: $frost-color-blue-1;
+}

--- a/tests/dummy/app/styles/_highlight.scss
+++ b/tests/dummy/app/styles/_highlight.scss
@@ -1,0 +1,123 @@
+// For later overrides
+
+// .hljs {
+//     display: block;
+//     overflow-x: auto;
+//     padding: 0.5em;
+//     color: #333;
+//     background: #f8f8f8;
+// }
+
+// .hljs-comment,
+// .hljs-template_comment,
+// .diff .hljs-header,
+// .hljs-javadoc {
+//     color: #998;
+//     font-style: italic;
+// }
+
+// .hljs-keyword,
+// .css .rule .hljs-keyword,
+// .hljs-winutils,
+// .javascript .hljs-title,
+// .nginx .hljs-title,
+// .hljs-subst,
+// .hljs-request,
+// .hljs-status {
+//     color: #333;
+//     font-weight: bold;
+// }
+
+// .hljs-number,
+// .hljs-hexcolor,
+// .ruby .hljs-constant {
+//     color: #099;
+// }
+
+// .hljs-string,
+// .hljs-tag .hljs-value,
+// .hljs-phpdoc,
+// .tex .hljs-formula {
+//     color: #d14;
+// }
+
+// .hljs-title,
+// .hljs-id,
+// .coffeescript .hljs-params,
+// .scss .hljs-preprocessor {
+//     color: #900;
+//     font-weight: bold;
+// }
+
+// .javascript .hljs-title,
+// .lisp .hljs-title,
+// .clojure .hljs-title,
+// .hljs-subst {
+//     font-weight: normal;
+// }
+
+// .hljs-class .hljs-title,
+// .haskell .hljs-type,
+// .vhdl .hljs-literal,
+// .tex .hljs-command {
+//     color: #458;
+//     font-weight: bold;
+// }
+
+// .hljs-tag,
+// .hljs-tag .hljs-title,
+// .hljs-rules .hljs-property,
+// .django .hljs-tag .hljs-keyword {
+//     color: #000080;
+//     font-weight: normal;
+// }
+
+// .hljs-attribute,
+// .hljs-variable,
+// .lisp .hljs-body {
+//     color: #008080;
+// }
+
+// .hljs-regexp {
+//     color: #009926;
+// }
+
+// .hljs-symbol,
+// .ruby .hljs-symbol .hljs-string,
+// .lisp .hljs-keyword,
+// .tex .hljs-special,
+// .hljs-prompt {
+//     color: #990073;
+// }
+
+// .hljs-built_in,
+// .lisp .hljs-title,
+// .clojure .hljs-built_in {
+//     color: #0086b3;
+// }
+
+// .hljs-preprocessor,
+// .hljs-pragma,
+// .hljs-pi,
+// .hljs-doctype,
+// .hljs-shebang,
+// .hljs-cdata {
+//     color: #999;
+//     font-weight: bold;
+// }
+
+// .hljs-deletion {
+//     background: #fdd;
+// }
+
+// .hljs-addition {
+//     background: #dfd;
+// }
+
+// .diff .hljs-change {
+//     background: #0086b3;
+// }
+
+// .hljs-chunk {
+//     color: #aaa;
+// }

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -2,6 +2,8 @@
 @import 'frost-app';
 @import 'typography';
 @import 'layout';
+@import 'highlight';
+@import 'button';
 
 .dummy-notification-container {
   position: fixed;


### PR DESCRIPTION
# fix
# CHANGELOG

Added ember-code-snippets to allow demo documentation to reference the code as the sample text.  Cleaned up the button demo as an example.
