### PR TITLE
Fixing the text clear button to append on insert

### DIFF
--- a/addon/components/frost-text.js
+++ b/addon/components/frost-text.js
@@ -27,7 +27,7 @@ export default TextField.extend(FrostEvents, {
 
   // == Event hooks ============================================================
 
-  didRender () {
+  didInsertElement() {
     schedule('render', this, function () {
       this.$().after(`
         <svg class='frost-text-clear' fill="#000000" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">

--- a/tests/integration/components/frost-text-test.js
+++ b/tests/integration/components/frost-text-test.js
@@ -17,5 +17,14 @@ describeComponent(
       this.render(hbs`{{frost-text}}`)
       expect(this.$()).to.have.length(1)
     })
+
+    it('only renders the clear icon in insert', function() {
+      this.set('external', 'temp')
+      this.render(hbs`{{frost-text value=external}}`)
+      expect(this.$('.frost-text-clear')).to.have.length(1)
+
+      this.set('external', 'change')
+      expect(this.$('.frost-text-clear')).to.have.length(1)
+    })
   }
 )


### PR DESCRIPTION
# fix
# CHANGELOG

Fixed the text clear icon to only append to the DOM on insertion of the text field (was occurring on every render/re-render)
