### PR TITLE
Make sure getDefaultProps() is called in integration tests

### DIFF
--- a/addon/components/frost-button.js
+++ b/addon/components/frost-button.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import Ember from 'ember'
 const {Component, Logger, ViewUtils} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
-import {PropTypes} from 'ember-prop-types'
+import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 import layout from '../templates/components/frost-button'
 
 /**
@@ -51,7 +51,7 @@ function addPriorityClass (priority, classes) {
   }
 }
 
-export default Component.extend({
+export default Component.extend(PropTypeMixin, {
   // ==========================================================================
   // Dependencies
   // ==========================================================================

--- a/addon/components/frost-icon.js
+++ b/addon/components/frost-icon.js
@@ -2,10 +2,10 @@ import _ from 'lodash'
 import Ember from 'ember'
 const {Component, deprecate} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
-import {PropTypes} from 'ember-prop-types'
+import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 import layout from '../templates/components/frost-icon'
 
-export default Component.extend({
+export default Component.extend(PropTypeMixin, {
   // ==========================================================================
   // Dependencies
   // ==========================================================================

--- a/addon/components/frost-link.js
+++ b/addon/components/frost-link.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import Ember from 'ember'
 const {deprecate, LinkComponent, Logger} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
-import {PropTypes} from 'ember-prop-types'
+import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 import layout from '../templates/components/frost-link'
 
 const validDesigns = [
@@ -47,7 +47,7 @@ function addDesignClass (design, classes) {
   }
 }
 
-export default LinkComponent.extend({
+export default LinkComponent.extend(PropTypeMixin, {
   // ==========================================================================
   // Dependencies
   // ==========================================================================

--- a/addon/components/frost-select.js
+++ b/addon/components/frost-select.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import Ember from 'ember'
 const {A, Component} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
-import {PropTypes} from 'ember-prop-types'
+import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 import layout from '../templates/components/frost-select'
 import Redux from 'npm:redux'
 import {
@@ -52,7 +52,7 @@ function handleOutsideClick (event) {
   }
 }
 
-export default Component.extend({
+export default Component.extend(PropTypeMixin, {
   // ==========================================================================
   // Dependencies
   // ==========================================================================

--- a/tests/integration/components/frost-button-test-.js
+++ b/tests/integration/components/frost-button-test-.js
@@ -1,6 +1,7 @@
 import {expect} from 'chai'
 import {describeComponent, it} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
+import {beforeEach} from 'mocha'
 
 describeComponent(
   'frost-button',
@@ -9,18 +10,16 @@ describeComponent(
     integration: true
   },
   function () {
-    it('renders', function () {
-      // Set any properties with this.set('myProperty', 'value');
-      // Handle any actions with this.on('myAction', function(val) { ... });
-      // Template block usage:
-      // this.render(hbs`
-      //   {{#frost-button}}
-      //     template content
-      //   {{/frost-button}}
-      // `);
+    beforeEach(function () {
+      this.render(hbs`{{frost-button icon="round-add"}}`)
+    })
 
-      this.render(hbs`{{frost-button}}`)
-      expect(this.$()).to.have.length(1)
+    it('renders as expected', function () {
+      expect(
+        this.$('.frost-icon-frost-round-add'),
+        'includes expected icon'
+      )
+        .to.have.length(1)
     })
   }
 )


### PR DESCRIPTION
# PATCH
# CHANGELOG
- **Fixed** components that use `ember-prop-types` to work as expected in integration tests by explicitly consuming the `ember-prop-types` mixin instead of relying on the initializer which isn't executed in an integration test environment.
