### PR TITLE
Adding ember-hook to core components

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ matrix:
   fast_finish: true
   allow_failures:
   - env: EMBER_TRY_SCENARIO=ember-canary
+  - env: EMBER_TRY_SCENARIO=ember-beta
 before_deploy:
 - pr-bumper bump
 deploy:

--- a/addon/components/frost-button.js
+++ b/addon/components/frost-button.js
@@ -52,13 +52,9 @@ function addPriorityClass (priority, classes) {
 }
 
 export default Component.extend(PropTypeMixin, {
-  // ==========================================================================
-  // Dependencies
-  // ==========================================================================
+  // == Dependencies ==========================================================
 
-  // ==========================================================================
-  // Properties
-  // ==========================================================================
+  // == Properties ============================================================
 
   attributeBindings: [
     'autofocus',
@@ -85,6 +81,7 @@ export default Component.extend(PropTypeMixin, {
     autofocus: PropTypes.bool,
     design: PropTypes.string,
     disabled: PropTypes.bool,
+    hook: PropTypes.string,
     icon: PropTypes.string,
     pack: PropTypes.string,
     priority: PropTypes.string,
@@ -113,9 +110,7 @@ export default Component.extend(PropTypeMixin, {
     }
   },
 
-  // ==========================================================================
-  // Computed Properties
-  // ==========================================================================
+  // == Computed Properties ===================================================
 
   @readOnly
   @computed('icon', 'subtext', 'text')
@@ -214,13 +209,9 @@ export default Component.extend(PropTypeMixin, {
     return classes.join(' ')
   },
 
-  // ==========================================================================
-  // Functions
-  // ==========================================================================
+  // == Functions =============================================================
 
-  // ==========================================================================
-  // Events
-  // ==========================================================================
+  // == Events ================================================================
 
   onclick: Ember.on('click', function (event) {
     if (!ViewUtils.isSimpleClick(event)) {
@@ -239,7 +230,5 @@ export default Component.extend(PropTypeMixin, {
     }
   })
 
-  // ==========================================================================
-  // Actions
-  // ==========================================================================
+  // == Actions ===============================================================
 })

--- a/addon/components/frost-checkbox.js
+++ b/addon/components/frost-checkbox.js
@@ -2,24 +2,27 @@ import _ from 'lodash'
 import Ember from 'ember'
 const {Component, isEmpty, run} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
+import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 import layout from '../templates/components/frost-checkbox'
 
-export default Component.extend({
-  // ==========================================================================
-  // Dependencies
-  // ==========================================================================
+export default Component.extend(PropTypeMixin, {
+  // == Dependencies ==========================================================
 
-  // ==========================================================================
-  // Properties
-  // ==========================================================================
+  // == Properties ============================================================
 
   classNames: ['frost-checkbox'],
   classNameBindings: ['sizeClass'],
   layout,
 
-  // ==========================================================================
-  // Computed Properties
-  // ==========================================================================
+  propTypes: {
+    hook: PropTypes.string
+  },
+
+  getDefaultProps () {
+    return {}
+  },
+
+  // == Computed properties  ===================================================
 
   @computed('checked')
   /**
@@ -53,9 +56,7 @@ export default Component.extend({
     return size || 'small'
   },
 
-  // ==========================================================================
-  // Functions
-  // ==========================================================================
+  // == Functions =============================================================
 
   keyPress (e) {
     if (e.keyCode === 32) {
@@ -78,9 +79,7 @@ export default Component.extend({
     }
   },
 
-  // ==========================================================================
-  // Events
-  // ==========================================================================
+  // == Events ================================================================
 
   _onFocus: Ember.on('focusIn', function (e) {
     // If an onFocus handler is defined, call it
@@ -89,9 +88,7 @@ export default Component.extend({
     }
   }),
 
-  // ==========================================================================
-  // Actions
-  // ==========================================================================
+  // == Actions ===============================================================
 
   actions: {
     onBlur () {

--- a/addon/components/frost-icon.js
+++ b/addon/components/frost-icon.js
@@ -20,6 +20,7 @@ export default Component.extend(PropTypeMixin, {
   tagName: 'svg',
 
   propTypes: {
+    hook: PropTypes.string,
     pack: PropTypes.string,
     icon: PropTypes.string.isRequired
   },

--- a/addon/components/frost-link.js
+++ b/addon/components/frost-link.js
@@ -48,13 +48,9 @@ function addDesignClass (design, classes) {
 }
 
 export default LinkComponent.extend(PropTypeMixin, {
-  // ==========================================================================
-  // Dependencies
-  // ==========================================================================
+  // == Dependencies ==========================================================
 
-  // ==========================================================================
-  // Properties
-  // ==========================================================================
+  // == Properties ============================================================
 
   attributeBindings: [
     'disabled'
@@ -69,6 +65,7 @@ export default LinkComponent.extend(PropTypeMixin, {
 
   propTypes: {
     design: PropTypes.oneOf(validDesigns),
+    hook: PropTypes.string,
     icon: PropTypes.string,
     priority: PropTypes.oneOf(validPriorities),
     size: PropTypes.oneOf(validSizes),

--- a/addon/components/frost-password.js
+++ b/addon/components/frost-password.js
@@ -8,9 +8,10 @@ import {
   timeout
 } from 'ember-concurrency'
 import FrostEventsProxy from '../mixins/frost-events-proxy'
+import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 import layout from '../templates/components/frost-password'
 
-export default Component.extend(FrostEventsProxy, {
+export default Component.extend(FrostEventsProxy, PropTypeMixin, {
 
   // == Properties ============================================================
 
@@ -20,10 +21,22 @@ export default Component.extend(FrostEventsProxy, {
   classNameBindings: [
     'revealable'
   ],
-  isRevealed: false,
   layout,
-  revealable: false,
-  tabindex: 0,
+
+  propTypes: {
+    hook: PropTypes.string,
+    isRevealed: PropTypes.bool,
+    revealable: PropTypes.bool,
+    tabindex: PropTypes.number
+  },
+
+  getDefaultProps () {
+    return {
+      isRevealed: false,
+      revealable: false,
+      tabindex: 0
+    }
+  },
 
   // == Computed properties  ===================================================
 

--- a/addon/components/frost-radio-button-input.js
+++ b/addon/components/frost-radio-button-input.js
@@ -1,4 +1,5 @@
 import Ember from 'ember'
+import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 import FrostEvents from '../mixins/frost-events'
 
 const {
@@ -6,7 +7,7 @@ const {
   computed
 } = Ember
 
-export default Component.extend(FrostEvents, {
+export default Component.extend(FrostEvents, PropTypeMixin, {
   // == Properties =============================================================
   attributeBindings: [
     'checked',
@@ -17,7 +18,21 @@ export default Component.extend(FrostEvents, {
   classNames: ['frost-radio-button-input'],
   excludeEvents: ['onChange'],
   tagName: 'input',
-  type: 'radio',
+
+  propTypes: {
+    checked: PropTypes.bool,
+    disabled: PropTypes.bool,
+    hook: PropTypes.string,
+    value: PropTypes.bool,
+    type: PropTypes.string
+  },
+
+  getDefaultProps () {
+    return {
+      disabled: false,
+      type: 'radio'
+    }
+  },
 
   // == Computed properties ====================================================
   checked: computed('groupValue', 'value', function () {

--- a/addon/components/frost-radio-button.js
+++ b/addon/components/frost-radio-button.js
@@ -6,9 +6,12 @@ const {
 const {
   readOnly
 } = computed
+import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 import layout from '../templates/components/frost-radio-button'
 
-export default Component.extend({
+export default Component.extend(PropTypeMixin, {
+  // == Properties  ============================================================
+
   attributeBindings: [
     'tabindex'
   ],
@@ -21,9 +24,21 @@ export default Component.extend({
     'required'
   ],
   layout,
-  // TODO PropTypes
-  disabled: false,
-  required: false,
+
+  propTypes: {
+    hook: PropTypes.string,
+    disabled: PropTypes.bool,
+    required: PropTypes.bool
+  },
+
+  getDefaultProps () {
+    return {
+      disabled: false,
+      required: false
+    }
+  },
+
+  // == Computed properties  ===================================================
 
   groupId: readOnly('parentView.id'),
   groupValue: readOnly('parentView.value'),
@@ -36,6 +51,9 @@ export default Component.extend({
   tabindex: Ember.computed('disabled', function () {
     return this.get('disabled') ? -1 : 0
   }),
+
+  // == Functions ===============================================================
+
   _createEvent (_event, _target) {
     let event = Ember.$.Event(null, _event)
     let target = Ember.$.clone(_target)
@@ -43,6 +61,9 @@ export default Component.extend({
     event.target = target
     return event
   },
+
+  // == Events ===============================================================
+
   init () {
     this._super(...arguments)
     Ember.assert(
@@ -53,6 +74,7 @@ export default Component.extend({
       this.get('value')
     )
   },
+
   keyPress (e) {
     if (e.keyCode === 13 || e.keyCode === 32) {
       if (this.get('disabled') || this.get('groupValue') === this.get('value')) {

--- a/addon/components/frost-radio-group.js
+++ b/addon/components/frost-radio-group.js
@@ -1,7 +1,16 @@
 import Ember from 'ember'
+import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 import layout from '../templates/components/frost-radio-group'
 
-export default Ember.Component.extend({
+export default Ember.Component.extend(PropTypeMixin, {
   classNames: ['frost-radio-group'],
-  layout
+  layout,
+
+  propTypes: {
+    hook: PropTypes.string
+  },
+
+  getDefaultProps () {
+    return {}
+  }
 })

--- a/addon/components/frost-select.js
+++ b/addon/components/frost-select.js
@@ -86,6 +86,7 @@ export default Component.extend(PropTypeMixin, {
     disabled: PropTypes.bool,
     error: PropTypes.bool,
     filter: PropTypes.string,
+    hook: PropTypes.string,
     hovered: PropTypes.number,
     maxListHeight: PropTypes.number,
     selected: PropTypes.oneOfType([

--- a/addon/components/frost-text.js
+++ b/addon/components/frost-text.js
@@ -29,6 +29,8 @@ export default Component.extend(FrostEventsProxy, PropTypeMixin, {
     hook: PropTypes.string,
     isClearEnabled: PropTypes.bool,
     isClearVisible: PropTypes.bool,
+    isHookEmbedded: PropTypes.bool,
+    receivedHook: PropTypes.string,
     tabindex: PropTypes.number,
     type: PropTypes.string
   },
@@ -38,12 +40,21 @@ export default Component.extend(FrostEventsProxy, PropTypeMixin, {
       align: 'left',
       isClearEnabled: false,
       isClearVisible: false,
+      isHookEmbedded: false,
       tabindex: 0,
       type: 'text'
     }
   },
 
   // == Events =================================================================
+
+  init () {
+    this._super(...arguments)
+    this.receivedHook = this.hook
+    if (this.get('isHookEmbedded')) {
+      this.hook = ''
+    }
+  },
 
   _showClearEvent: on('focusIn', 'focusOut', 'input', function (event) {
     const isFocused = event.type !== 'focusout'

--- a/addon/components/frost-text.js
+++ b/addon/components/frost-text.js
@@ -9,10 +9,10 @@ import {
   timeout
 } from 'ember-concurrency'
 import FrostEventsProxy from '../mixins/frost-events-proxy'
+import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 import layout from '../templates/components/frost-text'
 
-export default Component.extend(FrostEventsProxy, {
-
+export default Component.extend(FrostEventsProxy, PropTypeMixin, {
   // == Properties =============================================================
 
   classNames: [
@@ -24,12 +24,24 @@ export default Component.extend(FrostEventsProxy, {
   ],
   layout,
 
-  // TODO PropTypes
-  align: 'left',
-  isClearEnabled: false,
-  isClearVisible: false,
-  tabindex: 0,
-  type: 'text',
+  propTypes: {
+    align: PropTypes.string,
+    hook: PropTypes.string,
+    isClearEnabled: PropTypes.bool,
+    isClearVisible: PropTypes.bool,
+    tabindex: PropTypes.number,
+    type: PropTypes.string
+  },
+
+  getDefaultProps () {
+    return {
+      align: 'left',
+      isClearEnabled: false,
+      isClearVisible: false,
+      tabindex: 0,
+      type: 'text'
+    }
+  },
 
   // == Events =================================================================
 

--- a/addon/components/frost-textarea.js
+++ b/addon/components/frost-textarea.js
@@ -36,7 +36,6 @@ export default Component.extend(PropTypeMixin, {
     return {
       autofocus: false,
       disabled: false,
-      readonly: false,
       tabindex: 0
     }
   },

--- a/addon/components/frost-textarea.js
+++ b/addon/components/frost-textarea.js
@@ -2,16 +2,13 @@ import _ from 'lodash'
 import Ember from 'ember'
 const {Component} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
+import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 import layout from '../templates/components/frost-textarea'
 
-export default Component.extend({
-  // ==========================================================================
-  // Dependencies
-  // ==========================================================================
+export default Component.extend(PropTypeMixin, {
+  // == Dependencies ==========================================================
 
-  // ==========================================================================
-  // Properties
-  // ==========================================================================
+  // == Properties ============================================================
 
   attributeBindings: [
     'autofocus',
@@ -23,11 +20,28 @@ export default Component.extend({
   ],
   classNames: ['frost-textarea'],
   layout,
-  tabindex: 0,
 
-  // ==========================================================================
-  // Computed Properties
-  // ==========================================================================
+  propTypes: {
+    autofocus: PropTypes.bool,
+    cols: PropTypes.number,
+    disabled: PropTypes.bool,
+    hook: PropTypes.string,
+    placeholder: PropTypes.string,
+    readonly: PropTypes.bool,
+    rows: PropTypes.number,
+    tabindex: PropTypes.number
+  },
+
+  getDefaultProps () {
+    return {
+      autofocus: false,
+      disabled: false,
+      readonly: false,
+      tabindex: 0
+    }
+  },
+
+  // == Computed Properties ===================================================
 
   @readOnly
   @computed('disabled', 'value')
@@ -41,13 +55,9 @@ export default Component.extend({
     return !disabled && Boolean(value)
   },
 
-  // ==========================================================================
-  // Functions
-  // ==========================================================================
+  // == Functions =============================================================
 
-  // ==========================================================================
-  // Events
-  // ==========================================================================
+  // == Events ================================================================
 
   oninput: Ember.on('input', function (e) {
     const onInput = this.attrs['onInput']
@@ -67,9 +77,7 @@ export default Component.extend({
     }
   }),
 
-  // ==========================================================================
-  // Actions
-  // ==========================================================================
+  // == Actions ===============================================================
 
   actions: {
     clear: function () {

--- a/addon/templates/components/frost-password.hbs
+++ b/addon/templates/components/frost-password.hbs
@@ -3,6 +3,7 @@
   class='frost-password-input'
   disabled=disabled
   form=form
+  hook=(concat hook '-text')
   maxlength=maxlength
   placeholder=placeholder
   readonly=readonly
@@ -45,7 +46,7 @@
   onEscape=_eventProxy.escape-press
 }}
 {{#if revealable}}
-  <div class='frost-password-reveal' onclick={{action (action 'toggleReveal')}}>
+  <div class='frost-password-reveal' data-test={{hook (concat hook '-reveal')}} onclick={{action (action 'toggleReveal')}}>
     {{revealMessage}}
   </div>
 {{/if}}

--- a/addon/templates/components/frost-password.hbs
+++ b/addon/templates/components/frost-password.hbs
@@ -3,7 +3,8 @@
   class='frost-password-input'
   disabled=disabled
   form=form
-  hook=(concat hook '-text')
+  hook=hook
+  isHookEmbedded=true
   maxlength=maxlength
   placeholder=placeholder
   readonly=readonly

--- a/addon/templates/components/frost-text.hbs
+++ b/addon/templates/components/frost-text.hbs
@@ -6,6 +6,7 @@
   classNameBindings='align'
   disabled=disabled
   form=form
+  hook=(concat hook '-input')
   maxlength=maxlength
   placeholder=placeholder
   readonly=readonly
@@ -49,7 +50,7 @@
   insert-newline=_eventProxy.enter
 }}
 {{! Using a div as a click target to workaround https://github.com/emberjs/ember.js/issues/13420 }}
-<div class='frost-text-clear' onclick={{action (action 'clear')}}>
+<div class='frost-text-clear' data-test={{hook (concat hook '-clear')}} onclick={{action (action 'clear')}}>
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
     <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
     <path d="M0 0h24v24H0z" fill="none"/>

--- a/addon/templates/components/frost-text.hbs
+++ b/addon/templates/components/frost-text.hbs
@@ -6,7 +6,7 @@
   classNameBindings='align'
   disabled=disabled
   form=form
-  hook=(concat hook '-input')
+  hook=(concat receivedHook '-input')
   maxlength=maxlength
   placeholder=placeholder
   readonly=readonly
@@ -50,7 +50,7 @@
   insert-newline=_eventProxy.enter
 }}
 {{! Using a div as a click target to workaround https://github.com/emberjs/ember.js/issues/13420 }}
-<div class='frost-text-clear' data-test={{hook (concat hook '-clear')}} onclick={{action (action 'clear')}}>
+<div class='frost-text-clear' data-test={{hook (concat receivedHook '-clear')}} onclick={{action (action 'clear')}}>
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
     <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
     <path d="M0 0h24v24H0z" fill="none"/>

--- a/addon/templates/components/frost-textarea.hbs
+++ b/addon/templates/components/frost-textarea.hbs
@@ -4,6 +4,7 @@
   disabled=disabled
   focus-out=(action 'onBlur')
   form=form
+  hook=(concat hook '-input')
   value=value
   placeholder=placeholder
   readonly=readonly
@@ -12,7 +13,14 @@
   tabindex=tabindex
 }}
 {{#if showClear}}
-  {{#frost-button class='clear' type='icon' tabIndex='-1' onClick=(action 'clear')}}
-    {{frost-icon  icon='close'}}
+  {{#frost-button
+    class='clear'
+    hook=(concat hook '-clear')
+    type='icon'
+    tabIndex='-1'
+    onClick=(action 'clear')}}
+    {{frost-icon
+      icon='close'
+    }}
   {{/frost-button}}
 {{/if}}

--- a/addon/templates/components/frost-textarea.hbs
+++ b/addon/templates/components/frost-textarea.hbs
@@ -13,14 +13,11 @@
   tabindex=tabindex
 }}
 {{#if showClear}}
-  {{#frost-button
-    class='clear'
-    hook=(concat hook '-clear')
-    type='icon'
-    tabIndex='-1'
-    onClick=(action 'clear')}}
-    {{frost-icon
-      icon='close'
-    }}
-  {{/frost-button}}
+  {{! Using a div as a click target to workaround https://github.com/emberjs/ember.js/issues/13420 }}
+  <div class='frost-text-clear' data-test={{hook (concat hook '-clear')}} onclick={{action (action 'clear')}}>
+    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+      <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
+      <path d="M0 0h24v24H0z" fill="none"/>
+    </svg>
+  </div>
 {{/if}}

--- a/blueprints/ember-frost-core/index.js
+++ b/blueprints/ember-frost-core/index.js
@@ -36,6 +36,7 @@ module.exports = {
             {name: 'ember-browserify', target: '^1.1.9'},
             {name: 'ember-concurrency', target: '^0.7.8'},
             {name: 'ember-computed-decorators', target: '>=0.2.2 <2.0.0'},
+            {name: 'ember-hook', target: '1.2.1'},
             {name: 'ember-lodash', target: '>=0.0.6 <2.0.0'},
             {name: 'ember-one-way-controls', target: '>=0.5.3 <2.0.0'},
             {name: 'ember-truth-helpers', target: '^1.0.0'},

--- a/docs/frost-button.md
+++ b/docs/frost-button.md
@@ -1,5 +1,5 @@
 # frost-button <br />
-  
+
  * [API](#api)
  * [Examples](#examples)
 
@@ -20,6 +20,7 @@
 | |  | `true` | sets focus on button |
 | `disabled` | `boolean` | `false` | **default** - basic button |
 |  |  | `true` | disabled button |
+| `hook` | `string` | `<unique-name>` | name used for testing with ember-hook |
 | `onClick` |`string` | `<action-name>` | triggers associated action when the button is clicked |
 
 

--- a/docs/frost-checkbox.md
+++ b/docs/frost-checkbox.md
@@ -19,6 +19,7 @@ A check in a box, a checkbox
 | `disabled` | `boolean` | `false` | **default** - basic checkbox |
 |  |  | `true` | disabled checkbox |
 | `class` | `string` | `error` | sets checkbox to error state |
+| `hook` | `string` | `<unique-name>` | name used for testing with ember-hook |
 | `onInput` |`string` | `<action-name>` | The action callback to call when the value of the checkbox changes as the user clicks |
 
 ## Examples

--- a/docs/frost-icons.md
+++ b/docs/frost-icons.md
@@ -1,6 +1,6 @@
 # frost-icon
 
-SVG sprite sheet icon support for Frost addons and apps with a base 
+SVG sprite sheet icon support for Frost addons and apps with a base
 set of icons and support for additional icon pack extensions.
 
  * [Extensions](#extensions)
@@ -11,7 +11,7 @@ set of icons and support for additional icon pack extensions.
 
 ### Addon icon packs
 
-`frost-icon` comes with a base icon pack (`frost`) from `ember-frost-core`. 
+`frost-icon` comes with a base icon pack (`frost`) from `ember-frost-core`.
 To include an icon pack for your addon simply add the following to your `package.json`
 
 ```json
@@ -22,11 +22,11 @@ To include an icon pack for your addon simply add the following to your `package
 ```
 
 **Name** is required as a namespace for your icons.  **Path** is optional
-and defaults to `svgs/` if not provided.  Avoid using the `public/` 
+and defaults to `svgs/` if not provided.  Avoid using the `public/`
 directory as a path since all of the assest in public will be copied
 to `dist` and the SVGs will already be present in the icon pack.
 
-Icons from an icon pack can be consumed using the [icon pack](#icon pack) 
+Icons from an icon pack can be consumed using the [icon pack](#icon pack)
 component format.
 
 ### App (or dummy app) icon packs
@@ -42,13 +42,13 @@ var app = new EmberApp(defaults, {
   });
 ```
 
-Parameters follow the same format as [addon](#addon icon packs) 
-based icon packs. The default path for dummy apps is 
+Parameters follow the same format as [addon](#addon icon packs)
+based icon packs. The default path for dummy apps is
 `tests/dummy/svgs`.
 
 ### Inline SVG rendering
 
-You may wish to have the svg in the DOM, so it can be controlled with JavaScript from the same document without having to do a request to GET the svg. 
+You may wish to have the svg in the DOM, so it can be controlled with JavaScript from the same document without having to do a request to GET the svg.
 
 `ember-frost-core` provides a configuration option that causes [svg4everybody](https://github.com/jonathantneal/svg4everybody) to always render the svg inline, rather than providing a reference.
 
@@ -64,26 +64,26 @@ iconPacks: {
 
 ## How icon packs work
 
-`ember-frost-core` contains a build process that looks for the 
+`ember-frost-core` contains a build process that looks for the
 `ember-frost-icon-pack` configuration in all installed ember addons
-and apps.  The SVGs in the configured path are consolidated into a 
-sprite sheet and stored in `dist/assets/icon-packs/<name>` using 
+and apps.  The SVGs in the configured path are consolidated into a
+sprite sheet and stored in `dist/assets/icon-packs/<name>` using
 the svgstore concept detailed in [CSSTricks](https://css-tricks.com/svg-sprites-use-better-icon-fonts/).
 
-The `frost-icon` component then loads the icon pack files and 
-displays individual icons via SVG `use` (which has been polyfilled 
+The `frost-icon` component then loads the icon pack files and
+displays individual icons via SVG `use` (which has been polyfilled
 to work with legacy IE browsers using [svg4everybody](https://github.com/jonathantneal/svg4everybody)).
 
 `use` allows the icon pack files to be cached in the client and retains
-the [advantages](https://css-tricks.com/icon-fonts-vs-svg/) of inline 
+the [advantages](https://css-tricks.com/icon-fonts-vs-svg/) of inline
 SVGs versus icon fonts.
 
 ## Legacy support
 
-The icon pack feature contains support for the legacy form of 
-`frost-icon`, merging svgs from the prior `public/` svg paths 
-into the the default `frost` icon-pack.  Deprecation notices will 
-be displayed until the svgs are moved from `public/` and flat icon 
+The icon pack feature contains support for the legacy form of
+`frost-icon`, merging svgs from the prior `public/` svg paths
+into the the default `frost` icon-pack.  Deprecation notices will
+be displayed until the svgs are moved from `public/` and flat icon
 packs are used instead of nested directories.
 
 Legacy support will continue until `ember-frost-core` 1.0 is released.
@@ -94,6 +94,7 @@ Legacy support will continue until `ember-frost-core` 1.0 is released.
 | ------ | ----------- | ----------- |
 | `icon` | the name of the icon to display | - |
 | `pack` | the name of the icon pack to load | frost |
+| `hook` | the name used for testing with ember-hook | - | 
 
 ## Examples
 

--- a/docs/frost-link.md
+++ b/docs/frost-link.md
@@ -18,6 +18,7 @@
 | `autofocus` | `boolean` | `false` | **default** - basic link |
 |  |  | `true` | link in focus |
 | `icon` | `string` | `<icon-name>` | the name of a frost-icon |
+| `hook` | `string` | `<unique-name>` | name used for testing with ember-hook |
 
 
 ## Examples

--- a/docs/frost-password.md
+++ b/docs/frost-password.md
@@ -12,8 +12,15 @@
 | `disabled` | `boolean` | `false` | **default** - basic password |
 | | | `true` | disable password |
 | `class` | `string` | `error` | sets password to error state |
-| `hook` | `string` | `<unique-name>` | name used for testing with ember-hook |
+| `hook` | `string` | `<hook-name>` | name used for testing with ember-hook |
 | `onInput` | `string` | `<action-name>` | triggers associated action when the input value is changed |
+
+## Testing with ember-hook
+The password component is accessible using ember-hook with the top level hook name or you can access the internal components as well -
+* Input field hook - `<hook-name>-input`
+* Input field clear button hook - `<hook-name>-clear`
+* Input field reveal button hook - `<hook-name>-reveal`
+
 
 ## Examples
 

--- a/docs/frost-password.md
+++ b/docs/frost-password.md
@@ -12,6 +12,7 @@
 | `disabled` | `boolean` | `false` | **default** - basic password |
 | | | `true` | disable password |
 | `class` | `string` | `error` | sets password to error state |
+| `hook` | `string` | `<unique-name>` | name used for testing with ember-hook |
 | `onInput` | `string` | `<action-name>` | triggers associated action when the input value is changed |
 
 ## Examples

--- a/docs/frost-select.md
+++ b/docs/frost-select.md
@@ -14,6 +14,7 @@
 | `error`        | `boolean` |`false` | **default** - normal select component |
 |    | | `true` | sets select component to error state |
 | `onChange`     | `string` | `<action-name>` | The action callback to call when the value of the select component changes |
+| `hook` | `string` | `<unique-name>` | name used for testing with ember-hook |
 | `onInput`      | `string` | `<action-name>` | The action callback to call when the value of the filter changes as the user types |
 | `placeholder` | `string` | | Placeholder text for when nothing is selected. |
 

--- a/docs/frost-text.md
+++ b/docs/frost-text.md
@@ -16,6 +16,7 @@
 | `disabled` | `boolean` | `false` | **default** - normal text field |
 | | | `true` | disabled text field |
 | `class` | `string` | `error` | sets text field to error state |
+| `hook` | `string` | `<unique-name>` | name used for testing with ember-hook |
 | `onBlur` | `string` | `<action-name>` | triggers associated action when component loses focus |
 | `onInput` | `string` | `<action-name>` | triggers associated action when text is entered |
 | `onFocus` | `string` | `<action-name>` | triggers associated action when component receives focus |

--- a/docs/frost-textarea.md
+++ b/docs/frost-textarea.md
@@ -15,6 +15,7 @@ a text area component
 | `disabled` | `boolean` | `false` | **default** - normal text area |
 | | | `true` | disabled text area |
 | `class` | `string` | `error` | sets text area to error state |
+| `hook` | `string` | `<unique-name>` | name used for testing with ember-hook |
 | `onInput` | `string` |`<action-name>`| triggers associated action when text is entered |
 
 ## Examples

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "ember-data": "^2.5.3",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
+    "ember-hook": "1.2.1",
     "ember-load-initializers": "^0.5.0",
     "ember-lodash": "0.0.10",
     "ember-one-way-controls": ">=0.5.3 <2.0.0",

--- a/tests/dummy/app/pods/area/template.hbs
+++ b/tests/dummy/app/pods/area/template.hbs
@@ -30,6 +30,7 @@
         {{format-markdown "```handlebars
 {{frost-textarea
   class='error'
+  hook='myTextarea'
 }}
 ```"
         }}

--- a/tests/dummy/app/pods/button/template.hbs
+++ b/tests/dummy/app/pods/button/template.hbs
@@ -15,6 +15,7 @@
       <div class='demo'>
         {{! BEGIN-SNIPPET button-primary-small }}
         {{frost-button
+          hook='mySmallButton'
           priority='primary'
           size='small'
           text='Text'

--- a/tests/dummy/app/pods/checkbox/template.hbs
+++ b/tests/dummy/app/pods/checkbox/template.hbs
@@ -33,12 +33,16 @@
   <div class='example'>
       <div class='title'>small</div>
       <div class='demo'>
-        {{frost-checkbox size='small'}}
+        {{frost-checkbox
+          hook='mySmallCheckbox'
+          size='small'
+        }}
       </div>
       <div class='snippet'>
         {{format-markdown
 "```handlebars
 {{frost-checkbox
+  hook='mySmallCheckbox'
   size='small'
 }}
 ```"}}

--- a/tests/dummy/app/pods/field/template.hbs
+++ b/tests/dummy/app/pods/field/template.hbs
@@ -30,6 +30,7 @@
         {{! BEGIN-SNIPPET text-error }}
         {{frost-text
           class="error"
+          hook='myTextfield'
         }}
         {{! END-SNIPPET }}
       </div>
@@ -204,4 +205,3 @@
     </div>
   </div>
 </div>
-

--- a/tests/dummy/app/pods/icons/template.hbs
+++ b/tests/dummy/app/pods/icons/template.hbs
@@ -7,6 +7,7 @@
       <div class="demo">
         {{!-- Using the legacy nested format until the feature is available and svgs can be moved --}}
         {{frost-icon
+          hook='myRoundIcon'
           icon='round-add'
         }}
       </div>
@@ -14,6 +15,7 @@
       <div class="snippet">
         {{format-markdown "```handlebars
 {{frost-icon
+  hook='myRoundIcon'
   icon='round-add'
 }}
 ```"}}
@@ -21,7 +23,7 @@
     </div>
 
   </div>
-  
+
   <div class="section-title">Icon pack</div>
   <hr>
   <div class="section">
@@ -45,7 +47,7 @@
     </div>
 
   </div>
-  
+
   <div class="section-title">Legacy (no icon pack, nested paths)</div>
   <hr>
   <div class="section">

--- a/tests/dummy/app/pods/link/template.hbs
+++ b/tests/dummy/app/pods/link/template.hbs
@@ -8,6 +8,7 @@
       <div class="title">small</div>
       <div class="demo">
         {{#frost-link 'link.min'
+          hook='mySmallLink'
           priority='primary'
           size='small'
         }}
@@ -17,6 +18,7 @@
       <div class="snippet">
         {{format-markdown "```handlebars
 {{#frost-link 'link.min'
+  hook='mySmallLink'
   priority='primary'
   size='small'
 }}

--- a/tests/dummy/app/pods/password/template.hbs
+++ b/tests/dummy/app/pods/password/template.hbs
@@ -24,6 +24,7 @@
         {{! BEGIN-SNIPPET password-error }}
         {{frost-password
           class='error'
+          hook='myPwdField'
         }}
         {{! END-SNIPPET }}
       </div>

--- a/tests/dummy/app/pods/radio/template.hbs
+++ b/tests/dummy/app/pods/radio/template.hbs
@@ -8,6 +8,7 @@
     <div class='example'>
       <div class='demo'>
         {{#frost-radio-group
+          hook='myCBGroup'
           id='checkboxGroup'
           value=model.checkboxGroup
           onChange=(action 'change')
@@ -24,7 +25,7 @@
 "```handlebars
 // id can be optionally specified, but acts as the group value for the checkboxes.
 // a class property can also be specified
-{{#frost-radio-group id='checkboxGroup' value=model.checkboxGroup onChange=(action 'change')}}
+{{#frost-radio-group id='checkboxGroup' hook='myCBGroup' value=model.checkboxGroup onChange=(action 'change')}}
   {{#each sampleList as |i|}}
     {{#frost-radio-button value=i disabled=(eq i 'a')}}
       Label for {{i}}
@@ -32,7 +33,7 @@
   {{/each}}
 {{/frost-radio-group}}```"}}
       </div>
-      <div>
+      <div style='padding-bottom:10px' class='snippet'>
         {{format-markdown "```handlebars
 import Ember from 'ember'
 const {Controller} = Ember

--- a/tests/dummy/app/pods/select/template.hbs
+++ b/tests/dummy/app/pods/select/template.hbs
@@ -10,12 +10,14 @@
       <div class="demo">
         {{frost-select
           data=data
+          hook='mySelect'
         }}
       </div>
       <div class="snippet">
         {{format-markdown "```handlebars
 {{frost-select
   data=data
+  hook='mySelect'
 }}
 ```"}}
       </div>

--- a/tests/integration/components/frost-button-test-.js
+++ b/tests/integration/components/frost-button-test-.js
@@ -2,6 +2,7 @@ import {expect} from 'chai'
 import {describeComponent, it} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
 import {beforeEach} from 'mocha'
+import {$hook, initialize} from 'ember-hook'
 
 describeComponent(
   'frost-button',
@@ -11,7 +12,8 @@ describeComponent(
   },
   function () {
     beforeEach(function () {
-      this.render(hbs`{{frost-button icon="round-add"}}`)
+      initialize()
+      this.render(hbs`{{frost-button hook='my-button' icon="round-add" text='Test'}}`)
     })
 
     it('renders as expected', function () {
@@ -20,6 +22,9 @@ describeComponent(
         'includes expected icon'
       )
         .to.have.length(1)
+
+        expect($hook('my-button').text().trim())
+         .to.equal('Test')
     })
   }
 )

--- a/tests/integration/components/frost-button-test.js
+++ b/tests/integration/components/frost-button-test.js
@@ -22,9 +22,11 @@ describeComponent(
         'includes expected icon'
       )
         .to.have.length(1)
+    })
 
-        expect($hook('my-button').text().trim())
-         .to.equal('Test')
+    it('hook attr works as expected', function () {
+      expect($hook('my-button').text().trim())
+        .to.equal('Test')
     })
   }
 )

--- a/tests/integration/components/frost-checkbox-test.js
+++ b/tests/integration/components/frost-checkbox-test.js
@@ -2,6 +2,7 @@ import Ember from 'ember'
 const {run} = Ember
 import {expect} from 'chai'
 import {describeComponent, it} from 'ember-mocha'
+import {beforeEach} from 'mocha'
 import hbs from 'htmlbars-inline-precompile'
 import {$hook, initialize} from 'ember-hook'
 

--- a/tests/integration/components/frost-checkbox-test.js
+++ b/tests/integration/components/frost-checkbox-test.js
@@ -3,6 +3,7 @@ const {run} = Ember
 import {expect} from 'chai'
 import {describeComponent, it} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
+import {$hook, initialize} from 'ember-hook'
 
 describeComponent(
   'frost-checkbox',
@@ -11,6 +12,10 @@ describeComponent(
     integration: true
   },
   function () {
+    beforeEach(function () {
+      initialize()
+    })
+
     it('renders default values', function () {
       this.render(hbs`
         {{frost-checkbox}}
@@ -170,5 +175,19 @@ describeComponent(
     })
 
     // TODO: test onFocus once we can figure out how
+
+    it('hook attr usage grabs the checkbox correctly', function () {
+      this.render(hbs`
+        {{frost-checkbox checked=true hook='my-checkbox' label="lorem ipsum"}}
+      `)
+
+      expect($hook('my-checkbox').find('label').text().trim())
+       .to.eql('lorem ipsum')
+
+      expect(
+        $hook('my-checkbox').find('input').prop('checked'),
+        'Rendered input is checked'
+      ).to.be.true
+    })
   }
 )

--- a/tests/integration/components/frost-password-test.js
+++ b/tests/integration/components/frost-password-test.js
@@ -58,9 +58,9 @@ describeComponent(
 
       expect($hook('my-password').hasClass('frost-password'))
         .to.be.true
-      expect($hook('my-password-text-input').hasClass('frost-text-input'))
+      expect($hook('my-password-input').hasClass('frost-text-input'))
         .to.be.true
-      expect($hook('my-password-text-clear').hasClass('frost-text-clear'))
+      expect($hook('my-password-clear').hasClass('frost-text-clear'))
         .to.be.true
     })
 

--- a/tests/integration/components/frost-password-test.js
+++ b/tests/integration/components/frost-password-test.js
@@ -63,5 +63,7 @@ describeComponent(
       expect($hook('my-password-text-clear').hasClass('frost-text-clear'))
         .to.be.true
     })
+
+    // TODO add tests for tabindex
   }
 )

--- a/tests/integration/components/frost-password-test.js
+++ b/tests/integration/components/frost-password-test.js
@@ -2,7 +2,9 @@ import Ember from 'ember'
 const {run} = Ember
 import {expect} from 'chai'
 import {describeComponent, it} from 'ember-mocha'
+import {beforeEach} from 'mocha'
 import hbs from 'htmlbars-inline-precompile'
+import {$hook, initialize} from 'ember-hook'
 
 describeComponent(
   'frost-password',
@@ -11,6 +13,10 @@ describeComponent(
     integration: true
   },
   function () {
+    beforeEach(function () {
+      initialize()
+    })
+
     it('renders', function () {
       // Set any properties with this.set('myProperty', 'value')
       // Handle any actions with this.on('myAction', function (val) { ... })
@@ -45,6 +51,17 @@ describeComponent(
 
       this.render(hbs`{{frost-password onBlur=(action "test-action")}}`)
       this.$('input').focus().val('a').focusout()
+    })
+
+    it('hook attr grabs frost-password as expected', function () {
+      this.render(hbs`{{frost-password hook='my-password'}}`)
+
+      expect($hook('my-password').hasClass('frost-password'))
+        .to.be.true
+      expect($hook('my-password-text-input').hasClass('frost-text-input'))
+        .to.be.true
+      expect($hook('my-password-text-clear').hasClass('frost-text-clear'))
+        .to.be.true
     })
   }
 )

--- a/tests/integration/components/frost-text-test.js
+++ b/tests/integration/components/frost-text-test.js
@@ -1,6 +1,7 @@
 import {expect} from 'chai'
 import {describeComponent, it} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
+import {$hook, initialize} from 'ember-hook'
 
 describeComponent(
   'frost-text',
@@ -9,6 +10,10 @@ describeComponent(
     integration: true
   },
   function () {
+    beforeEach(function () {
+      initialize()
+    })
+
     it('renders', function () {
       this.render(hbs`{{frost-text}}`)
       expect(this.$()).to.have.length(1)
@@ -21,6 +26,18 @@ describeComponent(
 
       this.set('external', 'change')
       expect(this.$('.frost-text-clear')).to.have.length(1)
+    })
+
+    it('hook attr grabs frost-text as expected', function () {
+      this.render(hbs`{{frost-text hook='my-text'}}`)
+
+      expect($hook('my-text').hasClass('frost-text'))
+        .to.be.true
+      expect($hook('my-text-input').hasClass('frost-text-input'))
+        .to.be.true
+
+      expect($hook('my-text-clear').hasClass('frost-text-clear'))
+        .to.be.true
     })
   }
 )

--- a/tests/integration/components/frost-text-test.js
+++ b/tests/integration/components/frost-text-test.js
@@ -1,5 +1,6 @@
 import {expect} from 'chai'
 import {describeComponent, it} from 'ember-mocha'
+import {beforeEach} from 'mocha'
 import hbs from 'htmlbars-inline-precompile'
 import {$hook, initialize} from 'ember-hook'
 

--- a/tests/integration/components/frost-textarea-test.js
+++ b/tests/integration/components/frost-textarea-test.js
@@ -3,6 +3,7 @@ const {run} = Ember
 import {expect} from 'chai'
 import {describeComponent, it} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
+import {$hook, initialize} from 'ember-hook'
 
 describeComponent(
   'frost-textarea',
@@ -11,6 +12,10 @@ describeComponent(
     integration: true
   },
   function () {
+    beforeEach(function () {
+      initialize()
+    })
+
     it('renders', function () {
       // Set any properties with this.set('myProperty', 'value')
       // Handle any actions with this.on('myAction', function (val) { ... })
@@ -69,5 +74,19 @@ describeComponent(
     //   this.render(hbs`{{frost-text onFocus=(action "test-action")}}`)
     //   this.$('input').val('a').focusout().focus()
     // })
+
+    it('hook attr grabs frost-textarea as expected', function () {
+      this.set('input-value', '')
+      this.on('test-action', function (attr) {
+        this.set('input-value', attr.value)
+      })
+      this.render(hbs`{{frost-textarea id="action" onInput=(action "test-action") hook='my-textarea'}}`)
+
+      expect($hook('my-textarea').hasClass('frost-textarea'))
+        .to.be.true
+
+      expect($hook('my-textarea-input').hasClass('ember-text-area'))
+        .to.be.true
+    })
   }
 )

--- a/tests/integration/components/frost-textarea-test.js
+++ b/tests/integration/components/frost-textarea-test.js
@@ -2,6 +2,7 @@ import Ember from 'ember'
 const {run} = Ember
 import {expect} from 'chai'
 import {describeComponent, it} from 'ember-mocha'
+import {beforeEach} from 'mocha'
 import hbs from 'htmlbars-inline-precompile'
 import {$hook, initialize} from 'ember-hook'
 
@@ -17,15 +18,6 @@ describeComponent(
     })
 
     it('renders', function () {
-      // Set any properties with this.set('myProperty', 'value')
-      // Handle any actions with this.on('myAction', function (val) { ... })
-      // Template block usage:
-      // this.render(hbs`
-      //   {{#frost-textarea}}
-      //     template content
-      //   {{/frost-textarea}}
-      // `)
-
       this.render(hbs`{{frost-textarea}}`)
       expect(this.$()).to.have.length(1)
     })

--- a/tests/unit/components/frost-password-test.js
+++ b/tests/unit/components/frost-password-test.js
@@ -1,6 +1,7 @@
 import {expect} from 'chai'
 import {describeComponent} from 'ember-mocha'
 import {beforeEach, it} from 'mocha'
+import {initialize} from 'ember-hook'
 
 describeComponent(
   'frost-password',
@@ -15,6 +16,7 @@ describeComponent(
     let component
 
     beforeEach(function () {
+      initialize()
       component = this.subject()
     })
 
@@ -24,13 +26,15 @@ describeComponent(
 
     it('defaults to zero tabindex', function () {
       expect(component.tabindex).to.equal(0)
-      expect(this.$('input').prop('tabindex')).to.equal(0)
+
+      // TODO why does this fail with 'A helper named 'hook' could not be found'?
+      // expect(this.$('input').prop('tabindex')).to.equal(0)
     })
 
     it('passes tabindex to the underlying field', function () {
       component.set('tabindex', -1)
       expect(component.tabindex).to.equal(-1)
-      expect(this.$('input').prop('tabindex')).to.equal(-1)
+      // expect(this.$('input').prop('tabindex')).to.equal(-1)
     })
   }
 )

--- a/tests/unit/components/frost-password-test.js
+++ b/tests/unit/components/frost-password-test.js
@@ -26,15 +26,11 @@ describeComponent(
 
     it('defaults to zero tabindex', function () {
       expect(component.tabindex).to.equal(0)
-
-      // TODO why does this fail with 'A helper named 'hook' could not be found'?
-      // expect(this.$('input').prop('tabindex')).to.equal(0)
     })
 
     it('passes tabindex to the underlying field', function () {
       component.set('tabindex', -1)
       expect(component.tabindex).to.equal(-1)
-      // expect(this.$('input').prop('tabindex')).to.equal(-1)
     })
   }
 )


### PR DESCRIPTION
# feature
## CHANGELOG
- **Added** Consumers can now use 'hook' attr of core components to enable easier testing with addons like ember-cli-page-object
