### PR TITLE
pin ember-cli-sass until version mismatch is fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "ember-cli-mirage": "0.2.1",
     "ember-cli-mocha": "^0.10.0",
     "ember-cli-notifications": "^3.2.0",
-    "ember-cli-sass": "^5.2.0",
+    "ember-cli-sass": "5.4.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-code-snippet": "1.3.0",
@@ -151,7 +151,7 @@
     "ember-browserify": "^1.1.9",
     "ember-cli-babel": "^5.1.5",
     "ember-cli-htmlbars": "^1.0.1",
-    "ember-cli-sass": "^5.2.0",
+    "ember-cli-sass": "5.4.0",
     "ember-prop-types": "^2.1.0",
     "svg4everybody": "^2.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "ember-cli-mirage": "0.2.1",
     "ember-cli-mocha": "^0.10.0",
     "ember-cli-notifications": "^3.2.0",
-    "ember-cli-sass": "5.4.0",
+    "ember-cli-sass": ">=5.1.0 <= 5.4.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-code-snippet": "1.3.0",
@@ -151,7 +151,7 @@
     "ember-browserify": "^1.1.9",
     "ember-cli-babel": "^5.1.5",
     "ember-cli-htmlbars": "^1.0.1",
-    "ember-cli-sass": "5.4.0",
+    "ember-cli-sass": ">=5.1.0 <= 5.4.0",
     "ember-prop-types": "^2.1.0",
     "svg4everybody": "^2.0.3"
   },


### PR DESCRIPTION
# patch

Closes: https://github.com/ciena-frost/ember-frost-core/issues/161
# CHANGELOG
- **Updated** temporarily restrict `ember-cli-sass` from going above version 5.4.0

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ciena-frost/ember-frost-core/162)

<!-- Reviewable:end -->
