### PR TITLE
Remove most uses of lodash methods

### DIFF
--- a/addon/components/frost-button.js
+++ b/addon/components/frost-button.js
@@ -1,6 +1,5 @@
-import _ from 'lodash'
 import Ember from 'ember'
-const {Component, Logger, ViewUtils} = Ember
+const {Component, Logger, typeOf, ViewUtils} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 import layout from '../templates/components/frost-button'
@@ -218,7 +217,7 @@ export default Component.extend(PropTypeMixin, {
       return true
     }
 
-    if (!this.get('disabled') && _.isFunction(this.attrs.onClick)) {
+    if (!this.get('disabled') && typeOf(this.attrs.onClick) === 'function') {
       this.attrs.onClick(this.get('id'))
     }
   }),

--- a/addon/components/frost-checkbox.js
+++ b/addon/components/frost-checkbox.js
@@ -1,6 +1,5 @@
-import _ from 'lodash'
 import Ember from 'ember'
-const {Component, isEmpty, run} = Ember
+const {Component, isEmpty, run, typeOf} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 import layout from '../templates/components/frost-checkbox'
@@ -101,7 +100,7 @@ export default Component.extend(PropTypeMixin, {
 
     input () {
       let id = this.get('value')
-      if (_.isFunction(this.attrs['onInput'])) {
+      if (typeOf(this.attrs['onInput']) === 'function') {
         this.attrs['onInput']({
           id: isEmpty(id) ? this.get('id') : id,
           value: this.$('input').prop('checked')

--- a/addon/components/frost-icon.js
+++ b/addon/components/frost-icon.js
@@ -1,6 +1,5 @@
-import _ from 'lodash'
 import Ember from 'ember'
-const {Component, deprecate} = Ember
+const {Component, deprecate, get} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 import layout from '../templates/components/frost-icon'
@@ -52,10 +51,12 @@ export default Component.extend(PropTypeMixin, {
   // ==========================================================================
 
   /* Ember.Component method */
-  didReceiveAttrs ({newAttrs}) {
+  didReceiveAttrs (attrs) {
+    const icon = get(attrs, 'newAttrs.icon.value') || ''
+
     deprecate(
       'nested icon paths have been deprecated in favor of flat icon packs',
-      !_.includes(_.get(newAttrs, 'icon.value'), '/'),
+      icon.indexOf('/') === -1,
       {
         id: 'frost-debug.deprecate-nested-icon-paths',
         until: '1.0.0',

--- a/addon/components/frost-link.js
+++ b/addon/components/frost-link.js
@@ -1,4 +1,3 @@
-import _ from 'lodash'
 import Ember from 'ember'
 const {deprecate, LinkComponent, Logger} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
@@ -25,7 +24,7 @@ const validSizes = [
 function addDesignClass (design, classes) {
   deprecate(
     '\'in-line\' design style has been deprecated in favour of \'inline\'',
-    !_.eq(design, 'in-line'),
+    design !== 'in-line',
     {
       id: 'frost-debug.deprecate-design-in-line-style',
       until: '1.0.0',

--- a/addon/components/frost-multi-select.js
+++ b/addon/components/frost-multi-select.js
@@ -1,4 +1,3 @@
-import _ from 'lodash'
 import computed, {readOnly} from 'ember-computed-decorators'
 import FrostSelect from './frost-select'
 import layout from '../templates/components/frost-multi-select'
@@ -58,9 +57,9 @@ export default FrostSelect.extend({
   },
 
   getValues () {
-    const selected = this.get('selectedItems')
+    const selected = this.get('selectedItems') || []
     const state = this.get('reduxStore').getState()
-    return _.map(selected, (item) => {
+    return selected.map((item) => {
       return state.baseItems[item].value
     })
   },

--- a/addon/components/frost-scroll.js
+++ b/addon/components/frost-scroll.js
@@ -1,6 +1,5 @@
-import _ from 'lodash'
 import Ember from 'ember'
-const {Component, on, run} = Ember
+const {Component, on, run, typeOf} = Ember
 
 const scrollYEndContext = {
   name: 'on-scroll-y-end'
@@ -35,7 +34,7 @@ export default Component.extend({
       window.Ps.initialize(this.$()[0])
     })
 
-    if (_.isFunction(this.attrs['on-scroll-y-end'])) {
+    if (typeOf(this.attrs['on-scroll-y-end']) === 'function') {
       this.$().on('ps-y-reach-end', () => {
         run.debounce(scrollYEndContext, this.attrs['on-scroll-y-end'], debouncePeriod, true)
       })

--- a/addon/components/frost-select-li.js
+++ b/addon/components/frost-select-li.js
@@ -1,8 +1,7 @@
 import Ember from 'ember'
-const {Component} = Ember
+const {Component, typeOf} = Ember
 import layout from '../templates/components/frost-select-li'
 import FrostEvents from '../mixins/frost-events'
-import _ from 'lodash'
 
 export default Component.extend(FrostEvents, {
   tagName: 'li',
@@ -14,14 +13,14 @@ export default Component.extend(FrostEvents, {
     event.stopPropagation()
     const data = this.get('data')
     const onSelect = this.get('onSelect')
-    if (_.isFunction(onSelect)) {
+    if (typeOf(onSelect) === 'function') {
       onSelect(data)
     }
   },
   mouseEnter () {
     const data = this.get('data')
     const onItemOver = this.get('onItemOver')
-    if (_.isFunction(onItemOver)) {
+    if (typeOf(onItemOver) === 'function') {
       onItemOver(data)
     }
   }

--- a/addon/components/frost-select.js
+++ b/addon/components/frost-select.js
@@ -1,6 +1,6 @@
 import _ from 'lodash'
 import Ember from 'ember'
-const {A, Component} = Ember
+const {A, Component, get, typeOf} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 import layout from '../templates/components/frost-select'
@@ -37,8 +37,12 @@ const keyCodes = {
 const ATTR_MAP_DELIM = '->'
 // TODO: add jsdoc
 function isAttrDifferent (newAttrs, oldAttrs, attributeName) {
-  let oldValue = _.get(oldAttrs, attributeName + '.value')
-  let newValue = _.get(newAttrs, attributeName + '.value')
+  newAttrs = newAttrs || {}
+  oldAttrs = oldAttrs || {}
+
+  let oldValue = get(oldAttrs, attributeName + '.value')
+  let newValue = get(newAttrs, attributeName + '.value')
+
   return newValue !== undefined && !_.isEqual(oldValue, newValue)
 }
 
@@ -145,8 +149,8 @@ export default Component.extend(PropTypeMixin, {
    */
   invalidFilter (data, displayItems) {
     return (
-      _.isArray(data) &&
-      _.isArray(displayItems) &&
+      Array.isArray(data) &&
+      Array.isArray(displayItems) &&
       data.length > 0 &&
       displayItems.length === 0
     )
@@ -213,6 +217,9 @@ export default Component.extend(PropTypeMixin, {
 
   /* Ember.Component method */
   didReceiveAttrs ({newAttrs, oldAttrs}) {
+    newAttrs = newAttrs || {}
+    oldAttrs = oldAttrs || {}
+
     this._super(...arguments)
     const stateAttrs = this.get('stateAttributes')
 
@@ -247,14 +254,14 @@ export default Component.extend(PropTypeMixin, {
       return
     }
 
-    if (selectedValueChanged || (dataChanged && _.get(newAttrs, 'selectedValue.value'))) {
+    if (selectedValueChanged || (dataChanged && get(newAttrs, 'selectedValue.value'))) {
       this.selectOptionByValue(newAttrs.selectedValue.value)
-    } else if (selectedChanged || (dataChanged && _.get(newAttrs, 'selected.value'))) {
+    } else if (selectedChanged || (dataChanged && get(newAttrs, 'selected.value'))) {
       let selected = this.get('selected')
 
-      if (_.isNumber(selected)) {
+      if (typeOf(selected) === 'number') {
         selected = [selected]
-      } else if (!_.isArray(selected)) {
+      } else if (!Array.isArray(selected)) {
         selected = []
       }
     }
@@ -398,7 +405,7 @@ export default Component.extend(PropTypeMixin, {
     onChange (event) {
       const target = event.currentTarget || event.target
       const onInput = this.get('onInput')
-      if (_.isFunction(onInput)) {
+      if (typeOf(onInput) === 'function') {
         onInput(target.value)
       } else {
         this.get('reduxStore').dispatch(updateSearchText(target.value))

--- a/addon/components/frost-textarea.js
+++ b/addon/components/frost-textarea.js
@@ -1,6 +1,5 @@
-import _ from 'lodash'
 import Ember from 'ember'
-const {Component} = Ember
+const {Component, typeOf} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 import layout from '../templates/components/frost-textarea'
@@ -61,7 +60,7 @@ export default Component.extend(PropTypeMixin, {
   oninput: Ember.on('input', function (e) {
     const onInput = this.attrs['onInput']
 
-    if (_.isFunction(onInput)) {
+    if (typeOf(onInput) === 'function') {
       onInput({
         id: this.get('id'),
         value: e.target.value

--- a/addon/reducers/frost-multi-select.js
+++ b/addon/reducers/frost-multi-select.js
@@ -160,7 +160,7 @@ function selectItem (state, selectedItem) {
  * @returns {number[]} List of indices of the selected items
  */
 function itemsFromValue (baseItems, value) {
-  if (!_.isArray(value)) {
+  if (!Array.isArray(value)) {
     value = [value]
   }
   return _.chain(value)

--- a/addon/reducers/frost-select.js
+++ b/addon/reducers/frost-select.js
@@ -1,4 +1,5 @@
 import Ember from 'ember'
+const {assign} = Ember
 import {
   SELECT_ITEM,
 	CLICK_ARROW,
@@ -106,7 +107,7 @@ function select (state, itemIndex) {
   // Close list
   const closeState = close(nextState)
 
-  return _.assign(nextState, closeState)
+  return assign(nextState, closeState)
 }
 
 /**
@@ -148,7 +149,7 @@ export function itemClassNames (index, hoveredItem, selectedItem) {
  * @returns {SelectDisplayItem[]} The transformed list of display items
  */
 function updateClassNames (displayItems, hoveredItem, selectedItem) {
-  _.forEach(displayItems, function (item, index, list) {
+  (displayItems || []).forEach(function (item, index, list) {
     const className = itemClassNames(item.index, hoveredItem, selectedItem, list.length)
     Ember.set(item, 'className', className)
   })
@@ -230,7 +231,7 @@ export default function reducer (state, action) {
       if ((action.itemIndex === undefined || action.itemIndex === null) && state.displayItems.length === 1) {
         hoverState = setHover(state, 0)
       }
-      nextState = _.assign({
+      nextState = assign({
         open: true
       }, hoverState)
       break
@@ -289,7 +290,7 @@ export default function reducer (state, action) {
       break
     case RESET_DROPDOWN:
       nextState = _.defaults(_.pickBy(action.state, _.negate(_.isUndefined)), state)
-      if (_.isArray(nextState.selectedItem)) {
+      if (Array.isArray(nextState.selectedItem)) {
         nextState.selectedItem = nextState.selectedItem[0]
       }
       if (nextState.selectedItem < 0) {

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
   "ember-addon": {
     "after": [
       "ember-computed-decorators",
-      "ember-lodash-shim",
+      "ember-lodash",
       "ember-one-way-controls"
     ],
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
   "ember-addon": {
     "after": [
       "ember-computed-decorators",
-      "ember-lodash",
+      "ember-lodash-shim",
       "ember-one-way-controls"
     ],
     "configPath": "tests/dummy/config"

--- a/tests/dummy/app/pods/icons/controller.js
+++ b/tests/dummy/app/pods/icons/controller.js
@@ -1,4 +1,3 @@
-import _ from 'lodash'
 import Ember from 'ember'
 import iconPacks from 'ember-frost-core/icon-packs'
 
@@ -15,10 +14,10 @@ export default Controller.extend({
   ],
   backgroundColor: 'bg-tile-color',
   iconPacks: computed('iconPacks', () => {
-    return _.map(_.keys(iconPacks), (name) => {
+    return Object.keys(iconPacks).map((name) => {
       return {
-        name: _.capitalize(name),
-        icons: _.map(iconPacks[name], (icon) => {
+        name: Ember.String.capitalize(name),
+        icons: iconPacks[name].map((icon) => {
           return {
             name: icon,
             markdown: `\`${icon}\``

--- a/tests/dummy/app/pods/select/controller.js
+++ b/tests/dummy/app/pods/select/controller.js
@@ -1,6 +1,5 @@
 import Ember from 'ember'
 const {computed, Controller} = Ember
-import _ from 'lodash'
 
 export default Controller.extend({
   data: computed('data', 'search', function () {
@@ -11,7 +10,7 @@ export default Controller.extend({
       }
     })
     if (this.get('search')) {
-      let filteredResult = _.filter(result, (item) => {
+      let filteredResult = result.filter((item) => {
         return item.label.toLowerCase().indexOf(this.get('search').toLowerCase()) !== -1
       })
       result = filteredResult

--- a/tests/integration/components/frost-select-test.js
+++ b/tests/integration/components/frost-select-test.js
@@ -1,6 +1,5 @@
-import _ from 'lodash'
 import Ember from 'ember'
-const {$, run} = Ember
+const {$, run, typeOf} = Ember
 import {expect} from 'chai'
 import {$hook, initialize} from 'ember-hook'
 import {describeComponent, it} from 'ember-mocha'
@@ -34,7 +33,7 @@ const keyCodes = {
 }
 
 function keyDown ($selection, keyCode) {
-  if (_.isString(keyCode)) {
+  if (typeOf(keyCode) === 'string') {
     keyCode = keyCodes[keyCode]
   }
   let event = $.Event('keydown')
@@ -44,7 +43,7 @@ function keyDown ($selection, keyCode) {
 }
 
 function keyUp ($selection, keyCode) {
-  if (_.isString(keyCode)) {
+  if (typeOf(keyCode) === 'string') {
     keyCode = keyCodes[keyCode]
   }
   let event = $.Event('keyup')


### PR DESCRIPTION
# PATCH
# CHANGELOG
- **Removed** most uses of `lodash` methods in favor of ES6 and Ember methods.
