### PR TITLE
Adding more events to frost-scroll

### DIFF
--- a/addon/components/frost-scroll.js
+++ b/addon/components/frost-scroll.js
@@ -1,47 +1,74 @@
 import Ember from 'ember'
-const {Component, on, run, typeOf} = Ember
+const {
+  Component,
+  deprecate,
+  on,
+  run: {
+    debounce,
+    scheduleOnce
+  },
+  typeOf
+} = Ember
+import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 
-const scrollYEndContext = {
-  name: 'on-scroll-y-end'
-}
 const debouncePeriod = 150
 
-export default Component.extend({
-  // ==========================================================================
-  // Dependencies
-  // ==========================================================================
+export default Component.extend(PropTypeMixin, {
 
-  // ==========================================================================
-  // Properties
-  // ==========================================================================
+  // == Component properties ==================================================
 
   classNames: ['frost-scroll'],
 
-  // ==========================================================================
-  // Computed Properties
-  // ==========================================================================
+  // == State properties ======================================================
 
-  // ==========================================================================
-  // Functions
-  // ==========================================================================
+  propTypes: {
+    hook: PropTypes.string
+  },
 
-  // ==========================================================================
-  // Events
-  // ==========================================================================
+  // == Events ================================================================
 
   initializeScroll: on('didInsertElement', function () {
-    run.scheduleOnce('afterRender', this, () => {
+    scheduleOnce('afterRender', this, () => {
       window.Ps.initialize(this.$()[0])
     })
 
-    if (typeOf(this.attrs['on-scroll-y-end']) === 'function') {
+    if (typeOf(this.onScrollUp) === 'function') {
+      this.$().on('ps-scroll-up', () => {
+        debounce(this, this.onScrollUp, debouncePeriod, true)
+      })
+    }
+
+    if (typeOf(this.onScrollDown) === 'function') {
+      this.$().on('ps-scroll-down', () => {
+        debounce(this, this.onScrollDown, debouncePeriod, true)
+      })
+    }
+
+    if (typeOf(this.onScrollYStart) === 'function') {
+      this.$().on('ps-y-reach-start', () => {
+        debounce(this, this.onScrollYStart, debouncePeriod, true)
+      })
+    }
+
+    if (typeOf(this.onScrollYEnd) === 'function') {
       this.$().on('ps-y-reach-end', () => {
-        run.debounce(scrollYEndContext, this.attrs['on-scroll-y-end'], debouncePeriod, true)
+        debounce(this, this.onScrollYEnd, debouncePeriod, true)
+      })
+    }
+
+    if (typeOf(this.attrs['on-scroll-y-end']) === 'function') {
+      deprecate('on-scroll-y-end has been deprecated in favor of onScrollYEnd',
+        false,
+        {
+          id: 'frost-debug.deprecate-on-scroll-y-end',
+          until: '1.0.0',
+          url: 'http://ciena-frost.github.io/ember-frost-core/#/scroll'
+        }
+      )
+      this.$().on('ps-y-reach-end', () => {
+        debounce(this, this['on-scroll-y-end'], debouncePeriod, true)
       })
     }
   })
 
-  // ==========================================================================
-  // Actions
-  // ==========================================================================
 })

--- a/tests/dummy/app/pods/scroll/controller.js
+++ b/tests/dummy/app/pods/scroll/controller.js
@@ -3,6 +3,42 @@ const {Controller} = Ember
 
 export default Controller.extend({
   actions: {
+    onScrollUp () {
+      this.notifications.addNotification({
+        message: 'Scrolled up',
+        type: 'success',
+        autoClear: true,
+        clearDuration: 2000
+      })
+    },
+
+    onScrollDown () {
+      this.notifications.addNotification({
+        message: 'Scrolled down',
+        type: 'success',
+        autoClear: true,
+        clearDuration: 2000
+      })
+    },
+
+    onScrollYStart () {
+      this.notifications.addNotification({
+        message: 'Scroll reached start of y axis',
+        type: 'success',
+        autoClear: true,
+        clearDuration: 2000
+      })
+    },
+
+    onScrollYEnd () {
+      this.notifications.addNotification({
+        message: 'Scroll reached end of y axis',
+        type: 'success',
+        autoClear: true,
+        clearDuration: 2000
+      })
+    },
+
     yEndReached () {
       this.notifications.addNotification({
         message: 'Scroll reached end of y axis',

--- a/tests/dummy/app/pods/scroll/template.hbs
+++ b/tests/dummy/app/pods/scroll/template.hbs
@@ -5,17 +5,22 @@
   <div class="section">
     <div class="example">
       <div class="demo scroll-size">
-        {{#frost-scroll class='full' on-scroll-y-end=(action 'yEndReached')}}
+        {{! BEGIN-SNIPPET scroll }}
+        {{#frost-scroll class='full'
+          onScrollUp=(action 'onScrollUp')
+          onScrollDown=(action 'onScrollDown')
+          onScrollYStart=(action 'onScrollYStart')
+          onScrollYEnd=(action 'onScrollYEnd')
+          on-scroll-y-end=(action 'yEndReached')
+        }}
           {{frost-icon icon='frost/add' class='dummy-svg-huge'}}
         {{/frost-scroll}}
+        {{! END-SNIPPET }}
       </div>
 
-      <div class="snippet">
-        {{format-markdown "```handlebars
-{{#frost-scroll class='full' on-scroll-y-end=(action 'yEndReached')}}
-  {{frost-icon icon='frost/add' class='dummy-svg-huge'}}
-{{/frost-scroll}}
-```"}}
+      <div class='snippet'>
+        <div>Template</div>
+        {{code-snippet name='scroll.hbs'}}
       </div>
     </div>
 

--- a/tests/integration/components/frost-scroll-test.js
+++ b/tests/integration/components/frost-scroll-test.js
@@ -1,0 +1,80 @@
+/* jshint expr:true */
+import { expect } from 'chai'
+import {
+  describeComponent
+} from 'ember-mocha'
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  it
+} from 'mocha'
+import {
+  $hook,
+  initialize
+} from 'ember-hook'
+import hbs from 'htmlbars-inline-precompile'
+import sinon from 'sinon'
+
+describeComponent(
+  'frost-scroll',
+  'Integration: FrostScrollComponent',
+  {
+    integration: true
+  },
+  function () {
+    let sandbox
+
+    beforeEach(function () {
+      initialize()
+    })
+
+    it('renders', function () {
+      this.render(hbs`{{frost-scroll}}`)
+      expect(this.$()).to.have.length(1)
+    })
+
+    describe('actions', function () {
+      beforeEach(function () {
+        sandbox = sinon.sandbox.create()
+
+        this.setProperties({
+          onScrollUp: sinon.spy(),
+          onScrollDown: sinon.spy(),
+          onScrollYStart: sinon.spy(),
+          onScrollYEnd: sinon.spy()
+        })
+
+        this.render(hbs`{{frost-scroll hook='scroll'}}`)
+      })
+
+      afterEach(function () {
+        sandbox.restore()
+      })
+
+      it('sends onScrollUp action when scrolling up', function () {
+        // TODO figure out how to simulate scrolling
+        $hook('scroll')
+        expect(this.get('onScrollUp').called).to.be.true
+      })
+
+      it('sends onScrollDown action when scrolling down', function () {
+        // TODO figure out how to simulate scrolling
+        $hook('scroll')
+        expect(this.get('onScrollDown').called).to.be.true
+      })
+
+      it('sends onScrollYStart action when scrolled to top', function () {
+        // TODO figure out how to simulate scrolling
+        $hook('scroll')
+        expect(this.get('onScrollYStart').called).to.be.true
+      })
+
+      it('sends onScrollYEnd action when scrolled to bottom', function () {
+        // TODO figure out how to simulate scrolling
+        $hook('scroll')
+        expect(this.get('onScrollUp').called).to.be.true
+      })
+    })
+  }
+)

--- a/tests/integration/components/frost-scroll-test.js
+++ b/tests/integration/components/frost-scroll-test.js
@@ -34,7 +34,7 @@ describeComponent(
       expect(this.$()).to.have.length(1)
     })
 
-    describe('actions', function () {
+    describe.skip('actions', function () {
       beforeEach(function () {
         sandbox = sinon.sandbox.create()
 


### PR DESCRIPTION
# minor

Tried to add some scroll event tests, but I suck and couldn't figure out how to simulate a scroll, so I left the tests and the describe block is marked as `skip`
# CHANGELOG
- Added onScrollUp, onScrollDown, onScrollYStart, onScrollYEnd
- Deprecated on-scroll-y-end in favor of onScrollYEnd
