### PR TITLE
Adding a pre-transition onClick action to frost-link

### DIFF
--- a/addon/components/frost-link.js
+++ b/addon/components/frost-link.js
@@ -127,7 +127,7 @@ export default LinkComponent.extend(PropTypeMixin, {
 
   // == Functions =============================================================
 
-  _clickAndInvoke(event) {
+  _clickAndInvoke (event) {
     if (this.onClick) {
       this.onClick()
     }
@@ -136,7 +136,7 @@ export default LinkComponent.extend(PropTypeMixin, {
 
   // == Events ================================================================
 
-  init() {
+  init () {
     this._super(...arguments)
 
     // Turn off the default _invoke on event and use _clickAndInvoke instead

--- a/addon/components/frost-link.js
+++ b/addon/components/frost-link.js
@@ -1,5 +1,10 @@
 import Ember from 'ember'
-const {deprecate, LinkComponent, Logger} = Ember
+const {
+  LinkComponent,
+  Logger,
+  deprecate,
+  get
+} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 import layout from '../templates/components/frost-link'
@@ -47,9 +52,8 @@ function addDesignClass (design, classes) {
 }
 
 export default LinkComponent.extend(PropTypeMixin, {
-  // == Dependencies ==========================================================
 
-  // == Properties ============================================================
+  // == Component properties ==================================================
 
   attributeBindings: [
     'disabled'
@@ -62,13 +66,16 @@ export default LinkComponent.extend(PropTypeMixin, {
   layout,
   target: '',
 
+  // == State properties ======================================================
+
   propTypes: {
     design: PropTypes.oneOf(validDesigns),
     hook: PropTypes.string,
     icon: PropTypes.string,
     priority: PropTypes.oneOf(validPriorities),
     size: PropTypes.oneOf(validSizes),
-    text: PropTypes.string
+    text: PropTypes.string,
+    onClick: PropTypes.func
   },
 
   getDefaultProps () {
@@ -81,9 +88,7 @@ export default LinkComponent.extend(PropTypeMixin, {
     }
   },
 
-  // ==========================================================================
-  // Computed Properties
-  // ==========================================================================
+  // == Computed properties ===================================================
 
   @readOnly
   @computed('design', 'disabled', 'priority', 'size')
@@ -118,17 +123,26 @@ export default LinkComponent.extend(PropTypeMixin, {
     }
 
     return classes.join(' ')
+  },
+
+  // == Functions =============================================================
+
+  _clickAndInvoke(event) {
+    if (this.onClick) {
+      this.onClick()
+    }
+    this._invoke(event)
+  },
+
+  // == Events ================================================================
+
+  init() {
+    this._super(...arguments)
+
+    // Turn off the default _invoke on event and use _clickAndInvoke instead
+    let eventName = get(this, 'eventName')
+    this.off(eventName)
+    this.on(eventName, this, this._clickAndInvoke)
   }
 
-  // ==========================================================================
-  // Functions
-  // ==========================================================================
-
-  // ==========================================================================
-  // Events
-  // ==========================================================================
-
-  // ==========================================================================
-  // Actions
-  // ==========================================================================
 })

--- a/docs/frost-link.md
+++ b/docs/frost-link.md
@@ -19,6 +19,7 @@
 |  |  | `true` | link in focus |
 | `icon` | `string` | `<icon-name>` | the name of a frost-icon |
 | `hook` | `string` | `<unique-name>` | name used for testing with ember-hook |
+| `onClick` |`string` | `<action-name>` | triggers associated action when the link is clicked prior to transition |
 
 
 ## Examples

--- a/tests/dummy/app/pods/link/controller.js
+++ b/tests/dummy/app/pods/link/controller.js
@@ -6,6 +6,17 @@ export default Controller.extend({
   fontSize: 20,
 
   actions: {
+    // BEGIN-SNIPPET pre-transition-action
+    preTransition() {
+      this.notifications.addNotification({
+        message: `Prior to transition...`,
+        type: 'success',
+        autoClear: true,
+        clearDuration: 2000
+      })
+    },
+    // END-SNIPPET
+
     increase (fontSize) {
       this.set('fontSize', fontSize + 1)
     },

--- a/tests/dummy/app/pods/link/controller.js
+++ b/tests/dummy/app/pods/link/controller.js
@@ -7,9 +7,9 @@ export default Controller.extend({
 
   actions: {
     // BEGIN-SNIPPET pre-transition-action
-    preTransition() {
+    preTransition () {
       this.notifications.addNotification({
-        message: `Prior to transition...`,
+        message: 'Prior to transition...',
         type: 'success',
         autoClear: true,
         clearDuration: 2000

--- a/tests/dummy/app/pods/link/template.hbs
+++ b/tests/dummy/app/pods/link/template.hbs
@@ -360,5 +360,29 @@
 
   </div>
 
+  <div class="section-title">Advanced</div>
+  <hr>
+  <div class="section">
+
+    <div class="example">
+        <div class="title">Pre-transition onClick action</div>
+        <div class="demo">
+          {{! BEGIN-SNIPPET pre-transition-action }}
+          {{#frost-link 'link.min'
+            priority='secondary'
+            size='small'
+            onClick=(action 'preTransition')
+          }}
+            Watch for a notification
+          {{/frost-link}}
+          {{! END-SNIPPET }}
+        </div>
+        <div class="snippet">
+          {{code-snippet name='pre-transition-action.hbs'}}
+          {{code-snippet name='pre-transition-action.js'}}
+        </div>
+      </div>
+    </div>
+
   {{outlet}}
 </div>

--- a/tests/integration/components/frost-scroll-test.js
+++ b/tests/integration/components/frost-scroll-test.js
@@ -34,7 +34,7 @@ describeComponent(
       expect(this.$()).to.have.length(1)
     })
 
-    describe.skip('actions', function () {
+    describe('actions', function () {
       beforeEach(function () {
         sandbox = sinon.sandbox.create()
 

--- a/tests/integration/components/frost-scroll-test.js
+++ b/tests/integration/components/frost-scroll-test.js
@@ -34,7 +34,7 @@ describeComponent(
       expect(this.$()).to.have.length(1)
     })
 
-    describe('actions', function () {
+    describe.skip('actions', function () {
       beforeEach(function () {
         sandbox = sinon.sandbox.create()
 


### PR DESCRIPTION
# feature

Useful when you want a link, but need to perform some action before transitioning (like closing a modal)
# Changelog
- Added an `onClick` event to the `frost-link` component that is sent prior to transition
