### PR TITLE
Frost Select / Radio - Addressing several issues

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@ dist/**/*
 node_modules/**/*
 tmp/**/*
 blueprints/frost-component/files/**/*
+tests/integration/components/frost-scroll-test.js

--- a/addon/components/frost-radio-button-input.js
+++ b/addon/components/frost-radio-button-input.js
@@ -1,13 +1,14 @@
 import Ember from 'ember'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
-import FrostEvents from '../mixins/frost-events'
 
 const {
   Component,
-  computed
+  computed: {
+    alias
+  }
 } = Ember
 
-export default Component.extend(FrostEvents, PropTypeMixin, {
+export default Component.extend(PropTypeMixin, {
   // == Properties =============================================================
   attributeBindings: [
     'checked',
@@ -15,15 +16,15 @@ export default Component.extend(FrostEvents, PropTypeMixin, {
     'value',
     'type'
   ],
-  classNames: ['frost-radio-button-input'],
-  excludeEvents: ['onChange'],
+  classNames: [
+    'frost-radio-button-input'
+  ],
   tagName: 'input',
 
   propTypes: {
     checked: PropTypes.bool,
     disabled: PropTypes.bool,
     hook: PropTypes.string,
-    value: PropTypes.bool,
     type: PropTypes.string
   },
 
@@ -35,17 +36,15 @@ export default Component.extend(FrostEvents, PropTypeMixin, {
   },
 
   // == Computed properties ====================================================
-  checked: computed('groupValue', 'value', function () {
-    return this.get('groupValue') === this.get('value')
-  }),
+
+  checked: alias('parentView.checked'),
 
   // == Functions ==============================================================
-  init () {
+  didInsertElement () {
     this._super(...arguments)
 
-    let assert = `${this.toString()} must be initialized in the yield block of 'frost-radio-button'`
+    let assert = `${this.toString()} must exist inside 'frost-radio-button'`
     let cond = /frost-radio-button/.test(this.parentView.toString())
     Ember.assert(assert, cond)
   }
-
 })

--- a/addon/components/frost-select.js
+++ b/addon/components/frost-select.js
@@ -75,7 +75,12 @@ export default Component.extend(FrostEventsProxy, PropTypeMixin, {
 
   attributeBindings: ['tabIndex'],
   classNames: ['frost-select'],
-  classNameBindings: ['shouldOpen:focus', 'shouldOpen:open', 'disabled', 'hasError:error'],
+  classNameBindings: [
+    'shouldOpen:focus',
+    'shouldOpen:open',
+    'disabled',
+    'hasError:error'
+  ],
   stateProperties: [
     'open',
     'prompt',
@@ -133,9 +138,6 @@ export default Component.extend(FrostEventsProxy, PropTypeMixin, {
   // ==========================================================================
   // Computed Properties
   // ==========================================================================
-
-  @readOnly
-  @computed('maxListHeight')
   /**
    * Get inline style for container
    * Note: This must be a computed property rather than in a SASS file because the
@@ -143,18 +145,20 @@ export default Component.extend(FrostEventsProxy, PropTypeMixin, {
    * @param {Number} maxListHeight - maximum height at which list should render
    * @returns {String} container style
    */
+  @readOnly
+  @computed('maxListHeight')
   containerStyle (maxListHeight) {
     return Ember.String.htmlSafe(`max-height: ${maxListHeight}px`)
   },
 
-  @readOnly
-  @computed('data', 'displayItems')
   /**
    * Flag for if the user has typed something that doesn't match any options
    * @param {Array<Item>} data - all the possible items
    * @param {Object[]} displayItems - the current items being displayed
    * @returns {Boolean} true if in error state
    */
+  @readOnly
+  @computed('data', 'displayItems')
   invalidFilter (data, displayItems) {
     return (
       Array.isArray(data) &&
@@ -163,9 +167,6 @@ export default Component.extend(FrostEventsProxy, PropTypeMixin, {
       displayItems.length === 0
     )
   },
-
-  @readOnly
-  @computed('error', 'invalidFilter')
   /**
    * Computed flag for if consumer flagged us as having an error, or if the user has typed
    * something bad.
@@ -173,12 +174,11 @@ export default Component.extend(FrostEventsProxy, PropTypeMixin, {
    * @param {Boolean} invalidFilter - true if the user has typed something that doesn't match an option
    * @returns {Boolean} true if either error condition occured
    */
+  @readOnly
+  @computed('error', 'invalidFilter')
   hasError (error, invalidFilter) {
     return error || invalidFilter
   },
-
-  @readOnly
-  @computed('invalidFilter', 'shouldDisableDropDown', 'open')
   /**
    * Determine if drop-down should open
    * @param {Boolean} invalidFilter - did the user goof?
@@ -186,29 +186,31 @@ export default Component.extend(FrostEventsProxy, PropTypeMixin, {
    * @param {Boolean} open - TODO: what is this?
    * @returns {Boolean} true if we should open
    */
+  @readOnly
+  @computed('invalidFilter', 'shouldDisableDropDown', 'open')
   shouldOpen (invalidFilter, shouldDisableDropDown, open) {
     return !invalidFilter && !shouldDisableDropDown && open
   },
 
-  @readOnly
-  @computed('invalidFilter', 'disabled')
   /**
    * Determine if we should disable opening the drop-down
    * @param {Boolean} invalidFilter - did the user goof?
    * @param {Boolean} disabled - are we in a disabled state?
    * @returns {Boolean} true if opening should be disabled
    */
+  @readOnly
+  @computed('invalidFilter', 'disabled')
   shouldDisableDropDown (invalidFilter, disabled) {
     return invalidFilter || disabled
   },
 
-  @readOnly
-  @computed('width')
   /**
    * Compute the style attribute based on width
    * @param {Number} width - the width property
    * @returns {String} the computed style attribute
    */
+  @readOnly
+  @computed('width')
   style (width) {
     return `width: ${width}px`
   },
@@ -224,10 +226,7 @@ export default Component.extend(FrostEventsProxy, PropTypeMixin, {
   },
 
   /* Ember.Component method */
-  didReceiveAttrs ({newAttrs, oldAttrs}) {
-    newAttrs = newAttrs || {}
-    oldAttrs = oldAttrs || {}
-
+  didReceiveAttrs ({newAttrs = {}, oldAttrs = {}}) {
     this._super(...arguments)
     const stateAttrs = get(this, 'stateAttributes')
 
@@ -392,6 +391,17 @@ export default Component.extend(FrostEventsProxy, PropTypeMixin, {
   // ==========================================================================
   // Events
   // ==========================================================================
+  click () {
+    const reduxStore = get(this, 'reduxStore')
+    const {
+      lastAction
+    } = reduxStore.getState()
+    if (lastAction !== 'OPEN_DROPDOWN' && lastAction !== 'CLICK_ARROW') {
+      reduxStore.dispatch(openDropDown)
+    } else {
+      reduxStore.getState().lastAction = null
+    }
+  },
   focusIn (event) {
     get(this, 'reduxStore').dispatch(openDropDown)
 
@@ -424,6 +434,10 @@ export default Component.extend(FrostEventsProxy, PropTypeMixin, {
       } else {
         get(this, 'reduxStore').dispatch(updateSearchText(target.value))
       }
+    },
+    onClickArrow (event) {
+      event.preventDefault()
+      get(this, 'reduxStore').dispatch(clickArrow)
     },
     // TODO: add jsdoc
     onItemOver (data) {

--- a/addon/components/frost-select.js
+++ b/addon/components/frost-select.js
@@ -336,7 +336,6 @@ export default Component.extend(FrostEventsProxy, PropTypeMixin, {
   /** Handler for click outside of an element
    */
   onOutsideClick () {
-    set(this, 'open', false)
     get(this, 'reduxStore').dispatch(closeDropDown)
   },
 

--- a/addon/components/frost-select.js
+++ b/addon/components/frost-select.js
@@ -399,7 +399,7 @@ export default Component.extend(FrostEventsProxy, PropTypeMixin, {
 
       const el = this.$('input')
       if (!el.is(':focus')) {
-        this.$('input').focus()
+        el.focus()
       }
     })
   },

--- a/addon/components/frost-select.js
+++ b/addon/components/frost-select.js
@@ -384,11 +384,17 @@ export default Component.extend(PropTypeMixin, {
   // ==========================================================================
   // Events
   // ==========================================================================
-
+  focusIn (event) {
+    this.get('reduxStore').dispatch(openDropDown)
+    // If an onFocus event handler is defined, call it
+    if (this.attrs.onFocus) {
+      this.attrs.onFocus(event)
+    }
+    return false
+  },
   // ==========================================================================
   // Actions
   // ==========================================================================
-
   actions: {
     // TODO: add jsdoc
     onBlur (event) {
@@ -418,17 +424,6 @@ export default Component.extend(PropTypeMixin, {
       const reduxStore = this.get('reduxStore')
       reduxStore.dispatch(clickArrow)
     },
-
-    // TODO: add jsdoc
-    onFocus () {
-      this.get('reduxStore').dispatch(openDropDown)
-      // If an onFocus event handler is defined, call it
-      if (this.attrs.onFocus) {
-        this.attrs.onFocus()
-      }
-      return false
-    },
-
     // TODO: add jsdoc
     onItemOver (data) {
       this.get('reduxStore').dispatch(mouseHoverItem(data.index))

--- a/addon/components/frost-select.js
+++ b/addon/components/frost-select.js
@@ -2,6 +2,9 @@ import _ from 'lodash'
 import Ember from 'ember'
 const {
   A: EmberArray,
+  String: {
+    htmlSafe
+  },
   Component,
   get,
   set,
@@ -149,7 +152,7 @@ export default Component.extend(FrostEventsProxy, PropTypeMixin, {
   @readOnly
   @computed('maxListHeight')
   containerStyle (maxListHeight) {
-    return Ember.String.htmlSafe(`max-height: ${maxListHeight}px`)
+    return htmlSafe(`max-height: ${maxListHeight}px`)
   },
 
   /**
@@ -213,7 +216,7 @@ export default Component.extend(FrostEventsProxy, PropTypeMixin, {
   @readOnly
   @computed('width')
   style (width) {
-    return `width: ${width}px`
+    return htmlSafe(`width: ${width}px`)
   },
 
   // ==========================================================================
@@ -295,7 +298,6 @@ export default Component.extend(FrostEventsProxy, PropTypeMixin, {
       // escape key or tab key, close the dropdown
       case keyCodes.esc:
         event.preventDefault()
-
         reduxStore.dispatch(closeDropDown)
         break
       // enter + spacebar, choose selected
@@ -376,7 +378,6 @@ export default Component.extend(FrostEventsProxy, PropTypeMixin, {
           this.notifyOfChange()
           break
       }
-
       if (!wasOpen && newProps.open) {
         this.bindDropdownEvents()
       } else if (wasOpen && !newProps.open) {

--- a/addon/reducers/frost-multi-select.js
+++ b/addon/reducers/frost-multi-select.js
@@ -12,6 +12,9 @@ import selectReducer, {
   itemClassNames
 } from './frost-select'
 import Ember from 'ember'
+const {
+  isEmpty
+} = Ember
 import _ from 'lodash'
 
 /**
@@ -186,7 +189,12 @@ export default function reducer (state, action) {
       nextState = selectItem(state, action.itemIndex)
       break
     case SELECT_HOVER:
-      nextState = selectItem(state, state.hoveredItem)
+      var {
+        hoveredItem
+      } = state
+      nextState = !isEmpty(hoveredItem)
+        ? selectItem(state, hoveredItem)
+        : state
       break
     case SELECT_VALUE:
       nextState = {

--- a/addon/reducers/frost-select.js
+++ b/addon/reducers/frost-select.js
@@ -1,5 +1,8 @@
 import Ember from 'ember'
-
+const {
+  isEmpty,
+  set
+} = Ember
 const assign = Ember.assign || Object.assign || Ember.merge
 
 import {
@@ -150,12 +153,12 @@ export function itemClassNames (index, hoveredItem, selectedItem) {
  * @param {any} selectedItem The item that is currently selected
  * @returns {SelectDisplayItem[]} The transformed list of display items
  */
-function updateClassNames (displayItems, hoveredItem, selectedItem) {
-  (displayItems || []).forEach(function (item, index, list) {
-    const className = itemClassNames(item.index, hoveredItem, selectedItem, list.length)
-    Ember.set(item, 'className', className)
+function updateClassNames (displayed = [], hovered, selected) {
+  displayed.forEach((item, index, list) => {
+    const className = itemClassNames(item.index, hovered, selected, list.length)
+    set(item, 'className', className)
   })
-  return displayItems
+  return displayed
 }
 
 /**
@@ -219,7 +222,11 @@ export default function reducer (state, action) {
       nextState = select(state, action.itemIndex)
       break
     case SELECT_HOVER:
-      nextState = select(state, state.hoveredItem)
+      var {
+        hoveredItem
+      } = state
+      nextState = !isEmpty(hoveredItem)
+        ? select(state, hoveredItem) : state
       break
     case CLICK_ARROW:
       // Toggle

--- a/addon/reducers/frost-select.js
+++ b/addon/reducers/frost-select.js
@@ -219,6 +219,7 @@ export default function reducer (state, action) {
       nextState = select(state, action.itemIndex)
       break
     case SELECT_HOVER:
+      console.log(state)
       nextState = select(state, state.hoveredItem)
       break
     case CLICK_ARROW:

--- a/addon/reducers/frost-select.js
+++ b/addon/reducers/frost-select.js
@@ -147,10 +147,11 @@ export function itemClassNames (index, hoveredItem, selectedItem) {
 }
 
 /**
- * Updates the items in the display items list to have the correct CSS classnames
- * @param {any} displayItems List of display items to update (NOTE: The items in this list are mutated by this function)
- * @param {any} hoveredItem The item currently being hovered
- * @param {any} selectedItem The item that is currently selected
+ * Updates the items in the display items list to have the correct CSS classes
+ * @param {any} displayed List of display items to update
+ *  (NOTE: The items in this list are mutated by this function)
+ * @param {any} hovered The item currently being hovered
+ * @param {any} selected The item that is currently selected
  * @returns {SelectDisplayItem[]} The transformed list of display items
  */
 function updateClassNames (displayed = [], hovered, selected) {
@@ -222,11 +223,8 @@ export default function reducer (state, action) {
       nextState = select(state, action.itemIndex)
       break
     case SELECT_HOVER:
-      var {
-        hoveredItem
-      } = state
-      nextState = !isEmpty(hoveredItem)
-        ? select(state, hoveredItem) : state
+      nextState = !isEmpty(state.hoveredItem)
+        ? select(state, state.hoveredItem) : state
       break
     case CLICK_ARROW:
       // Toggle

--- a/addon/reducers/frost-select.js
+++ b/addon/reducers/frost-select.js
@@ -219,7 +219,6 @@ export default function reducer (state, action) {
       nextState = select(state, action.itemIndex)
       break
     case SELECT_HOVER:
-      console.log(state)
       nextState = select(state, state.hoveredItem)
       break
     case CLICK_ARROW:

--- a/addon/styles/_frost-radio-button.scss
+++ b/addon/styles/_frost-radio-button.scss
@@ -1,54 +1,52 @@
 .frost-radio-group {
-  cursor: pointer;
-}
+  .frost-radio-button {
+    outline: 0;
+    margin: 2px;
 
-.frost-radio-button {
-  padding: 2px;
-  outline: 0;
+    label {
+      cursor: pointer;
 
-  label {
-    cursor: pointer;
+      svg {
+        width: 20px;
+        height: 20px;
+        vertical-align: text-top;
 
-    svg {
-      width: 20px;
-      height: 20px;
-      vertical-align: text-top;
+        .inner {
+          transition: fill 0.2s ease;
+          fill: transparent;
+        }
 
-      .inner {
-        transition: fill 0.2s ease;
-        fill: transparent;
+        .ring {
+          transition: fill 0.2s ease;
+          fill: $frost-color-grey-5;
+        }
+      }
+    }
+
+    .frost-radio-button-input {
+      display: none;
+    }
+
+    &.checked:not(.disabled) label svg .inner {
+      fill: $frost-color-blue-1;
+    }
+
+    &:hover, &:focus {
+      &:not(.disabled):not(.checked) {
+        label svg .inner {
+          fill: $frost-color-blue-4;
+        }
+      }
+    }
+    &.disabled {
+      label {
+        color: $frost-color-grey-5;
+        cursor: default;
       }
 
-      .ring {
-        transition: fill 0.2s ease;
+      &.checked label svg .inner {
         fill: $frost-color-grey-5;
       }
-    }
-  }
-
-  .frost-radio-button-input {
-    display: none;
-  }
-
-  &.checked:not(.disabled) label svg .inner {
-    fill: $frost-color-blue-1;
-  }
-
-  &:hover, &:focus {
-    &:not(.disabled):not(.checked) {
-      label svg .inner {
-        fill: $frost-color-blue-4;
-      }
-    }
-  }
-  &.disabled {
-    label {
-      color: $frost-color-grey-5;
-      cursor: default;
-    }
-
-    &.checked label svg .inner {
-      fill: $frost-color-grey-5;
     }
   }
 }

--- a/addon/styles/_frost-select.scss
+++ b/addon/styles/_frost-select.scss
@@ -2,12 +2,12 @@
 $frost-input-text-height: 35px;
 $frost-input-select-option-row-height: 35px;
 
-@mixin triangle-up($color, $size) {
+@mixin triangle-up($color, $size, $width) {
   border-bottom: $size solid $color;
   border-left: $size solid transparent;
   border-right: $size solid transparent;
   height: 0;
-  width: 25px;
+  width: $width;
   content: '';
 }
 
@@ -21,7 +21,15 @@ $frost-input-select-option-row-height: 35px;
   position: relative;
   width: 200px;
   background: $frost-select-container-background;
-
+  li {
+    border-bottom: solid 1px #F5F6F7;
+    color: #7b7f7f;
+    font-weight: 200;
+    height: 35px;
+    line-height: 35px;
+    padding: 0 10px;
+    width: 100%;
+  }
   .drop-down-container {
     background: $frost-select-container-background;
     border: 1px solid $frost-color-lgrey-3;
@@ -32,19 +40,20 @@ $frost-input-select-option-row-height: 35px;
     opacity: 0;
     position: absolute;
     top: calc(100% + 10px);
-    transition: height .4s ease, opacity .2s ease;
+    transition: opacity .2s ease;
     width: calc(100% + 2px);
     pointer-events: none;
 
     .list-container {
       position:relative;
       &:before {
-        @include triangle-up($frost-select-container-background, 10px);
+        @include triangle-up($frost-select-container-background, 10px, 15px);
         transform: translateX(-50%);
         position: absolute;
         left: 50%;
         top: -10px;
         z-index: -1;
+        -webkit-filter: drop-shadow(0 -2px 2px rgba(0,0,0,.15));
       }
     }
   }
@@ -123,6 +132,8 @@ $frost-input-select-option-row-height: 35px;
     pointer-events: auto;
     ul {
       height: auto;
+      box-shadow: 0 2px 6px 2px rgba(0,0,0,.2);
+      border-radius: 4px;
     }
   }
 }

--- a/addon/styles/_frost-select.scss
+++ b/addon/styles/_frost-select.scss
@@ -43,18 +43,14 @@ $frost-input-select-option-row-height: 35px;
     transition: opacity .2s ease;
     width: calc(100% + 2px);
     pointer-events: none;
-
-    .list-container {
-      position:relative;
-      &:before {
-        @include triangle-up($frost-select-container-background, 10px, 15px);
-        transform: translateX(-50%);
-        position: absolute;
-        left: 50%;
-        top: -10px;
-        z-index: -1;
-        -webkit-filter: drop-shadow(0 -2px 2px rgba(0,0,0,.15));
-      }
+    &:before {
+      @include triangle-up($frost-select-container-background, 10px, 15px);
+      transform: translateX(-50%);
+      position: absolute;
+      left: 50%;
+      top: -10px;
+      z-index: -1;
+      -webkit-filter: drop-shadow(0 -2px 2px rgba(0,0,0,.15));
     }
   }
 
@@ -117,7 +113,7 @@ $frost-input-select-option-row-height: 35px;
     right: 10px;
     top: 7px;
     width: 20px;
-
+    pointer-events: none;
     polygon {
       fill: $frost-select-indicator;
     }

--- a/addon/styles/_frost-select.scss
+++ b/addon/styles/_frost-select.scss
@@ -113,7 +113,6 @@ $frost-input-select-option-row-height: 35px;
     right: 10px;
     top: 7px;
     width: 20px;
-    pointer-events: none;
     polygon {
       fill: $frost-select-indicator;
     }

--- a/addon/styles/_frost-select.scss
+++ b/addon/styles/_frost-select.scss
@@ -8,6 +8,7 @@ $frost-input-select-option-row-height: 35px;
   border-right: $size solid transparent;
   height: 0;
   width: 25px;
+  content: '';
 }
 
 .frost-select {
@@ -20,18 +21,6 @@ $frost-input-select-option-row-height: 35px;
   position: relative;
   width: 200px;
   background: $frost-select-container-background;
-
-  .up-arrow {
-    @include triangle-up($frost-select-container-background, 12px);
-    display: inline-block;
-    left: calc(50% - 15px);
-    overflow: visible;
-    pointer-events: none;
-    position: absolute;
-    right: 8px;
-    top: -10px;
-    z-index: 3;
-  }
 
   .drop-down-container {
     background: $frost-select-container-background;
@@ -46,6 +35,18 @@ $frost-input-select-option-row-height: 35px;
     transition: height .4s ease, opacity .2s ease;
     width: calc(100% + 2px);
     pointer-events: none;
+
+    .list-container {
+      position:relative;
+      &:before {
+        @include triangle-up($frost-select-container-background, 10px);
+        transform: translateX(-50%);
+        position: absolute;
+        left: 50%;
+        top: -10px;
+        z-index: -1;
+      }
+    }
   }
 
   input.trigger {

--- a/addon/templates/components/frost-combobox.hbs
+++ b/addon/templates/components/frost-combobox.hbs
@@ -9,19 +9,21 @@
         <polygon points='7.5,11.4 1.1,5 2.5,3.6 7.5,8.6 12.5,3.6 13.9,5 '/>
     </svg>
 </div>
+{{#if displayItems}}
 <div class='drop-down-container'>
-    <div class='list-container'>
-        <ul ref='container' style={{containerStyle}}>
-            {{#each displayItems as |item|}}
-                <li
-                  class={{item.className}}
-                  data-value={{item.value}}
-                  data-index={{item.index}}
-                  onClick={{action "onSelect"}}
-                  onMouseOver={{action "onItemOver"}}
-                >{{item.label}}</li>
-            {{/each}}
-        </ul>
-    </div>
+  <div class='list-container'>
+    <ul ref='container' style={{containerStyle}}>
+      {{#each displayItems as |item|}}
+        <li
+          class={{item.className}}
+          data-value={{item.value}}
+          data-index={{item.index}}
+          onClick={{action "onSelect"}}
+          onMouseOver={{action "onItemOver"}}
+        >{{item.label}}</li>
+      {{/each}}
+    </ul>
+  </div>
 </div>
+{{/if}}
 {{yield}}

--- a/addon/templates/components/frost-combobox.hbs
+++ b/addon/templates/components/frost-combobox.hbs
@@ -1,4 +1,9 @@
-<input class="trigger" type="text" value={{prompt}} onFocus={{action "onFocus"}} onBlur={{action "onBlur"}} onInput={{action "onChange"}}>
+<input
+  class="trigger"
+  type="text"
+  value={{prompt}}
+  onInput={{action "onChange"}}
+>
 <div class="down-arrow">
     <svg viewBox='0 0 15 15'>
         <polygon points='7.5,11.4 1.1,5 2.5,3.6 7.5,8.6 12.5,3.6 13.9,5 '/>
@@ -6,11 +11,15 @@
 </div>
 <div class='drop-down-container'>
     <div class='list-container'>
-        <div class='up-arrow'></div>
         <ul ref='container' style={{containerStyle}}>
             {{#each displayItems as |item|}}
-                <li class={{item.className}} data-value={{item.value}} data-index={{item.index}} onClick={{action "onSelect"}} onMouseOver={{action "onItemOver"}}>{{item.label}}
-                </li>
+                <li
+                  class={{item.className}}
+                  data-value={{item.value}}
+                  data-index={{item.index}}
+                  onClick={{action "onSelect"}}
+                  onMouseOver={{action "onItemOver"}}
+                >{{item.label}}</li>
             {{/each}}
         </ul>
     </div>

--- a/addon/templates/components/frost-combobox.hbs
+++ b/addon/templates/components/frost-combobox.hbs
@@ -1,8 +1,10 @@
 <input
   class="trigger"
+  onInput={{action "onChange"}}
+  onFocus={{action 'onFocusIn'}}
+  onBlur={{action 'onFocusOut'}}
   type="text"
   value={{prompt}}
-  onInput={{action "onChange"}}
 >
 <div class="down-arrow">
     <svg viewBox='0 0 15 15'>

--- a/addon/templates/components/frost-multi-select.hbs
+++ b/addon/templates/components/frost-multi-select.hbs
@@ -8,38 +8,39 @@
   value={{prompt}}
 >
 
-<div class="down-arrow">
+<div class="down-arrow" onClick={{action 'onClickArrow'}}>
   <svg viewBox='0 0 15 15'>
     <polygon points='7.5,11.4 1.1,5 2.5,3.6 7.5,8.6 12.5,3.6 13.9,5'/>
   </svg>
 </div>
-<div class="drop-down-container">
-  <div class="multi-status">
-    <span class="number-selected">{{selectedItems.length}} selected</span>
-    <span class="clear" tabIndex={-1} onClick={{action 'clearSelection'}}>Clear all</span>
-  </div>
-  <div class="list-container">
-    <ul ref="container" style={{containerStyle}} data-test={{hook (concat hook '-list')}}>
-      {{#each displayItems as |item index|}}
-        {{#frost-select-li
-          class=item.className
-          data=item
-          hook=(concat hook '-item-' index)
-          onSelect=(action 'onSelect')
-          onItemOver=(action 'onItemOver')
-        }}
-          {{frost-checkbox
-            checked=item.selected
-            hook=(concat hook '-checkbox-item-' index)
-            onInput=(action 'onCheck')
-            size='medium'
-            value=item.index
+{{#if displayItems}}
+  <div class="drop-down-container">
+    <div class="multi-status">
+      <span class="number-selected">{{selectedItems.length}} selected</span>
+      <span class="clear" tabIndex={-1} onClick={{action 'clearSelection'}}>Clear all</span>
+    </div>
+    <div class="list-container">
+      <ul ref="container" style={{containerStyle}} data-test={{hook (concat hook '-list')}}>
+        {{#each displayItems as |item index|}}
+          {{#frost-select-li
+            class=item.className
+            data=item
+            hook=(concat hook '-item-' index)
+            onSelect=(action 'onSelect')
+            onItemOver=(action 'onItemOver')
           }}
-          {{item.label}}
-        {{/frost-select-li}}
-      {{/each}}
-    </ul>
+            {{frost-checkbox
+              checked=item.selected
+              hook=(concat hook '-checkbox-item-' index)
+              onInput=(action 'onCheck')
+              size='medium'
+              value=item.index
+            }}
+            {{item.label}}
+          {{/frost-select-li}}
+        {{/each}}
+      </ul>
+    </div>
   </div>
-
-</div>
+{{/if}}
 {{yield}}

--- a/addon/templates/components/frost-multi-select.hbs
+++ b/addon/templates/components/frost-multi-select.hbs
@@ -3,7 +3,6 @@
   disabled={{disableInput}}
   data-test={{hook (concat hook '-input')}}
   onBlur={{action 'onBlur'}}
-  onFocus={{action 'onFocus'}}
   onInput={{action 'onChange'}}
   placeholder={{placeholder}}
   type="text"

--- a/addon/templates/components/frost-multi-select.hbs
+++ b/addon/templates/components/frost-multi-select.hbs
@@ -2,14 +2,13 @@
   class="trigger"
   disabled={{disableInput}}
   data-test={{hook (concat hook '-input')}}
-  onBlur={{action 'onBlur'}}
   onInput={{action 'onChange'}}
   placeholder={{placeholder}}
   type="text"
   value={{prompt}}
 >
 
-<div class="down-arrow" onClick={{action 'onClickArrow'}}>
+<div class="down-arrow">
   <svg viewBox='0 0 15 15'>
     <polygon points='7.5,11.4 1.1,5 2.5,3.6 7.5,8.6 12.5,3.6 13.9,5'/>
   </svg>
@@ -20,7 +19,6 @@
     <span class="clear" tabIndex={-1} onClick={{action 'clearSelection'}}>Clear all</span>
   </div>
   <div class="list-container">
-    <div class="up-arrow"></div>
     <ul ref="container" style={{containerStyle}} data-test={{hook (concat hook '-list')}}>
       {{#each displayItems as |item index|}}
         {{#frost-select-li

--- a/addon/templates/components/frost-multi-select.hbs
+++ b/addon/templates/components/frost-multi-select.hbs
@@ -3,6 +3,8 @@
   disabled={{disableInput}}
   data-test={{hook (concat hook '-input')}}
   onInput={{action 'onChange'}}
+  onFocus={{action 'onFocusIn'}}
+  onBlur={{action 'onFocusOut'}}
   placeholder={{placeholder}}
   type="text"
   value={{prompt}}

--- a/addon/templates/components/frost-select.hbs
+++ b/addon/templates/components/frost-select.hbs
@@ -4,7 +4,6 @@
   class="trigger"
   disabled={{disabled}}
   data-test={{hook (concat hook '-input')}}
-  onFocus={{action 'onFocus'}}
   onBlur={{action 'onBlur'}}
   onInput={{action 'onChange'}}
   placeholder={{placeholder}}
@@ -20,7 +19,6 @@
 
 <div class="drop-down-container">
   <div class="list-container">
-    <div class="up-arrow"></div>
     <ul ref="container" style={{containerStyle}} data-test={{hook (concat hook '-list')}}>
       {{#each displayItems as |item index|}}
         {{#frost-select-li

--- a/addon/templates/components/frost-select.hbs
+++ b/addon/templates/components/frost-select.hbs
@@ -1,9 +1,11 @@
 <input
-  autocomplete=false
+  autocomplete='false'
   autofocus={{autofocus}}
   class="trigger"
   disabled={{disabled}}
   data-test={{hook (concat hook '-input')}}
+  onFocus={{action 'onFocusIn'}}
+  onBlur={{action 'onFocusOut'}}
   onInput={{action 'onChange'}}
   placeholder={{placeholder}}
   type="text"

--- a/addon/templates/components/frost-select.hbs
+++ b/addon/templates/components/frost-select.hbs
@@ -10,27 +10,28 @@
   value={{prompt}}
 >
 
-<div class="down-arrow">
+<div class="down-arrow" onClick={{action 'onClickArrow'}}>
   <svg viewBox="0 0 15 15">
     <polygon points="7.5,11.4 1.1,5 2.5,3.6 7.5,8.6 12.5,3.6 13.9,5"/>
   </svg>
 </div>
-
-<div class="drop-down-container">
-  <div class="list-container">
-    <ul ref="container" style={{containerStyle}} data-test={{hook (concat hook '-list')}}>
-      {{#each displayItems as |item index|}}
-        {{#frost-select-li
-          class=item.className
-          hook=(concat hook '-item-' index)
-          data=item
-          onSelect=(action 'onSelect')
-          onItemOver=(action 'onItemOver')
-        }}
-          {{item.label}}
-        {{/frost-select-li}}
-      {{/each}}
-    </ul>
+{{#if displayItems}}
+  <div class="drop-down-container">
+    <div class="list-container">
+      <ul ref="container" style={{containerStyle}} data-test={{hook (concat hook '-list')}}>
+        {{#each displayItems as |item index|}}
+          {{#frost-select-li
+            class=item.className
+            hook=(concat hook '-item-' index)
+            data=item
+            onSelect=(action 'onSelect')
+            onItemOver=(action 'onItemOver')
+          }}
+            {{item.label}}
+          {{/frost-select-li}}
+        {{/each}}
+      </ul>
+    </div>
   </div>
-</div>
+{{/if}}
 {{yield}}

--- a/addon/templates/components/frost-select.hbs
+++ b/addon/templates/components/frost-select.hbs
@@ -4,14 +4,13 @@
   class="trigger"
   disabled={{disabled}}
   data-test={{hook (concat hook '-input')}}
-  onBlur={{action 'onBlur'}}
   onInput={{action 'onChange'}}
   placeholder={{placeholder}}
   type="text"
   value={{prompt}}
 >
 
-<div class="down-arrow" onClick={{action 'onClickArrow'}}>
+<div class="down-arrow">
   <svg viewBox="0 0 15 15">
     <polygon points="7.5,11.4 1.1,5 2.5,3.6 7.5,8.6 12.5,3.6 13.9,5"/>
   </svg>

--- a/tests/dummy/app/pods/select/controller.js
+++ b/tests/dummy/app/pods/select/controller.js
@@ -24,9 +24,9 @@ export default Controller.extend({
   selectedValues: ['Arthur Curry', 'Ray Palmer'],
 
   actions: {
-    onFocusOutHandler () {
+    onFocusOutHandler (e) {
       this.notifications.addNotification({
-        message: 'onFocusOut event',
+        message: `onFocusOut event ${e}`,
         type: 'success',
         autoClear: true,
         clearDuration: 2000

--- a/tests/dummy/app/pods/select/controller.js
+++ b/tests/dummy/app/pods/select/controller.js
@@ -24,9 +24,17 @@ export default Controller.extend({
   selectedValues: ['Arthur Curry', 'Ray Palmer'],
 
   actions: {
-    onBlurHandler () {
+    onFocusOutHandler () {
       this.notifications.addNotification({
-        message: 'blur event',
+        message: 'onFocusOut event',
+        type: 'success',
+        autoClear: true,
+        clearDuration: 2000
+      })
+    },
+    onFocusInHandler () {
+      this.notifications.addNotification({
+        message: 'onFocusIn event',
         type: 'success',
         autoClear: true,
         clearDuration: 2000

--- a/tests/dummy/app/pods/select/template.hbs
+++ b/tests/dummy/app/pods/select/template.hbs
@@ -139,7 +139,7 @@
         {{frost-select
           data=data
           onFocusIn=(action 'onFocusInHandler')
-          onFocusOut=(action 'onFocusOutHandler')
+          onFocusOut=(action 'onFocusOutHandler' 'hip way to do events')
         }}
       </div>
       <div class="snippet">
@@ -147,7 +147,27 @@
 {{frost-select
   data=data
   onFocusIn=(action 'onFocusInHandler')
-  onFocusOut=(action 'onFocusOutHandler')}}
+  onFocusOut=(action 'onFocusOutHandler' 'hip way to do events')
+}}
+```"}}
+      </div>
+    </div>
+    <div class="example">
+      <div class="title">Deprecated Events</div>
+      <div class="demo">
+        {{frost-select
+          data=data
+          onFocusIn=(action 'onFocusInHandler')
+          onBlur=(action 'onFocusOutHandler' 'deprecated')
+        }}
+      </div>
+      <div class="snippet">
+        {{format-markdown "```handlebars
+{{frost-select
+  data=data
+  onFocusIn=(action 'onFocusInHandler')
+  onBlur=(action 'onFocusOutHandler' 'deprecated')
+}}
 ```"}}
       </div>
     </div>
@@ -338,8 +358,7 @@
         {{frost-multi-select
           data=data
           onFocusIn=(action 'onFocusInHandler')
-          onBlur=(action 'onFocusOutHandler')
-          onFocusOut=(action 'onFocusOutHandler')
+          onFocusOut=(action 'onFocusOutHandler' 'hip way to do it')
         }}
       </div>
       <div class="snippet">
@@ -347,8 +366,24 @@
 {{frost-multi-select
   data=data
   onFocusIn=(action 'onFocusInHandler')
-  onBlur=(action 'onFocusOutHandler')
-  onFocusOut=(action 'onFocusOutHandler')
+  onFocusOut=(action 'onFocusOutHandler' 'hip way to do it')
+}}
+```"}}
+      </div>
+    </div>
+    <div class="example">
+      <div class="title">Deprecated Events</div>
+      <div class="demo">
+        {{frost-multi-select
+          data=data
+          onBlur=(action 'onFocusOutHandler' 'deprecated way to do it')
+        }}
+      </div>
+      <div class="snippet">
+        {{format-markdown "```handlebars
+{{frost-multi-select
+  data=data
+  onBlur=(action 'onFocusOutHandler' 'deprecated way to do it')
 }}
 ```"}}
       </div>

--- a/tests/dummy/app/pods/select/template.hbs
+++ b/tests/dummy/app/pods/select/template.hbs
@@ -134,19 +134,20 @@
   <div class="section">
 
     <div class="example">
-      <div class="title">onBlur</div>
+      <div class="title">Focus States</div>
       <div class="demo">
         {{frost-select
           data=data
-          onBlur=(action 'onBlurHandler')
+          onFocusIn=(action 'onFocusInHandler')
+          onFocusOut=(action 'onFocusOutHandler')
         }}
       </div>
       <div class="snippet">
         {{format-markdown "```handlebars
 {{frost-select
   data=data
-  onBlur=(action 'onBlurHandler')
-}}
+  onFocusIn=(action 'onFocusInHandler')
+  onFocusOut=(action 'onFocusOutHandler')}}
 ```"}}
       </div>
     </div>
@@ -332,18 +333,22 @@
   <div class="section">
 
     <div class="example">
-      <div class="title">onBlur</div>
+      <div class="title">Focus States</div>
       <div class="demo">
         {{frost-multi-select
           data=data
-          onBlur=(action 'onBlurHandler')
+          onFocusIn=(action 'onFocusInHandler')
+          onBlur=(action 'onFocusOutHandler')
+          onFocusOut=(action 'onFocusOutHandler')
         }}
       </div>
       <div class="snippet">
         {{format-markdown "```handlebars
 {{frost-multi-select
   data=data
-  onBlur=(action 'onBlurHandler')
+  onFocusIn=(action 'onFocusInHandler')
+  onBlur=(action 'onFocusOutHandler')
+  onFocusOut=(action 'onFocusOutHandler')
 }}
 ```"}}
       </div>

--- a/tests/integration/components/frost-select-test.js
+++ b/tests/integration/components/frost-select-test.js
@@ -281,10 +281,12 @@ describeComponent(
 
     it('handles click outside of select', function () {
       run(() => {
-        this.$('.frost-select .down-arrow').click()
+        this.$('.frost-select down-arrow').click()
         this.$().click()
       })
-      expect(dropDown.hasClass('open')).to.be.false
+      let select = this.$('.frost-select')
+
+      expect(select.hasClass('open')).to.be.false
     })
 
     it('handles losing focus by pressing tab', function () {

--- a/tests/unit/components/frost-combobox-test.js
+++ b/tests/unit/components/frost-combobox-test.js
@@ -1,6 +1,8 @@
 import {expect} from 'chai'
+import Ember from 'ember'
+const {run} = Ember
 import {describeComponent} from 'ember-mocha'
-import {beforeEach, it} from 'mocha'
+import {beforeEach, describe, it} from 'mocha'
 
 describeComponent(
   'frost-combobox',
@@ -17,6 +19,20 @@ describeComponent(
 
     it('includes className frost-select', function () {
       expect(component.classNames).to.include('frost-select')
+    })
+
+    describe('when onBlur property is omitted', function () {
+      beforeEach(function () {
+        run(() => {
+          component.set('onBlur', undefined)
+        })
+      })
+
+      it('does not throw an error when onBlur action is triggered', function () {
+        expect(function () {
+          component.get('actions.onFocusOut').call(component)
+        }).not.to.throw(Error)
+      })
     })
   }
 )

--- a/tests/unit/components/frost-combobox-test.js
+++ b/tests/unit/components/frost-combobox-test.js
@@ -1,8 +1,6 @@
 import {expect} from 'chai'
-import Ember from 'ember'
-const {run} = Ember
 import {describeComponent} from 'ember-mocha'
-import {beforeEach, describe, it} from 'mocha'
+import {beforeEach, it} from 'mocha'
 
 describeComponent(
   'frost-combobox',

--- a/tests/unit/components/frost-combobox-test.js
+++ b/tests/unit/components/frost-combobox-test.js
@@ -20,19 +20,5 @@ describeComponent(
     it('includes className frost-select', function () {
       expect(component.classNames).to.include('frost-select')
     })
-
-    describe('when onBlur property is omitted', function () {
-      beforeEach(function () {
-        run(() => {
-          component.set('onBlur', undefined)
-        })
-      })
-
-      it('does not throw an error when onBlur action is triggered', function () {
-        expect(function () {
-          component.get('actions.onBlur').call(component)
-        }).not.to.throw(Error)
-      })
-    })
   }
 )

--- a/tests/unit/components/frost-multi-select-test.js
+++ b/tests/unit/components/frost-multi-select-test.js
@@ -20,19 +20,5 @@ describeComponent(
     it('includes className frost-select', function () {
       expect(component.classNames).to.include('frost-select')
     })
-
-    describe('when onBlur property is omitted', function () {
-      beforeEach(function () {
-        run(() => {
-          component.set('onBlur', undefined)
-        })
-      })
-
-      it('does not error when onBlur action is triggered', function () {
-        expect(function () {
-          component.get('actions.onBlur').call(component)
-        }).not.to.throw(Error)
-      })
-    })
   }
 )

--- a/tests/unit/components/frost-multi-select-test.js
+++ b/tests/unit/components/frost-multi-select-test.js
@@ -1,10 +1,12 @@
 import {expect} from 'chai'
+import Ember from 'ember'
+const {run} = Ember
 import {describeComponent} from 'ember-mocha'
-import {beforeEach, it} from 'mocha'
+import {beforeEach, describe, it} from 'mocha'
 
 describeComponent(
-  'frost-multi-select',
-  'FrostMultiSelectComponent',
+  'frost-combobox',
+  'FrostComboboxComponent',
   {
     unit: true
   },
@@ -17,6 +19,20 @@ describeComponent(
 
     it('includes className frost-select', function () {
       expect(component.classNames).to.include('frost-select')
+    })
+
+    describe('when onBlur property is omitted', function () {
+      beforeEach(function () {
+        run(() => {
+          component.set('onBlur', undefined)
+        })
+      })
+
+      it('does not throw an error when onBlur action is triggered', function () {
+        expect(function () {
+          component.get('actions.onFocusOut').call(component)
+        }).not.to.throw(Error)
+      })
     })
   }
 )

--- a/tests/unit/components/frost-multi-select-test.js
+++ b/tests/unit/components/frost-multi-select-test.js
@@ -1,8 +1,6 @@
 import {expect} from 'chai'
-import Ember from 'ember'
-const {run} = Ember
 import {describeComponent} from 'ember-mocha'
-import {beforeEach, describe, it} from 'mocha'
+import {beforeEach, it} from 'mocha'
 
 describeComponent(
   'frost-multi-select',

--- a/tests/unit/components/frost-select-test.js
+++ b/tests/unit/components/frost-select-test.js
@@ -27,20 +27,6 @@ describeComponent(
       expect(component.classNames).to.include('frost-select')
     })
 
-    describe('when onBlur property is omitted', function () {
-      beforeEach(function () {
-        run(() => {
-          component.set('onBlur', undefined)
-        })
-      })
-
-      it('should not throw an error when onBlur action is triggered', function () {
-        expect(function () {
-          component.get('actions.onBlur').call(component)
-        }).not.to.throw(Error)
-      })
-    })
-
     describe('.didReceiveAttrs()', function () {
       ;[0, 1].forEach((selectedIndex) => {
         describe(`when selected index is ${selectedIndex} and no previous selected index`, function () {


### PR DESCRIPTION
# patch
# Changelog
- [x] There is a dead zone in the select between the text and the arrow. #183 
- [x] Please update CSS in Frost select #179
- [x] Frost Select throws error on enter without match #159
- [x] Using EventsProxy for events
- Frost Radio Group
  - Ember release 2.8 was erroring when destroying `parentView`
- Up arrow drawn in scss, one less element rendered
- Fix focus states by using attribute binding to `shouldOpen`
- If there are no display items, do not render `<div class='drop-down-container'>`
