### PR TITLE
Adding a demo for disabled buttons

### DIFF
--- a/tests/dummy/app/pods/button/template.hbs
+++ b/tests/dummy/app/pods/button/template.hbs
@@ -52,6 +52,7 @@
           priority='primary'
           size='large'
           text='Text'
+          onClick=(action 'onClickHandler')
         }}
         {{! END-SNIPPET }}
       </div>
@@ -69,6 +70,7 @@
           priority='primary'
           size='medium'
           text='Text'
+          onClick=(action 'onClickHandler')
         }}
         {{! END-SNIPPET }}
       </div>


### PR DESCRIPTION
# fix
# CHANGELOG
- Updated the button demo to demonstrate that disabled buttons don't fire actions
