### PR TITLE
****FOR DISCUSSION**** Data driven button 

### DIFF
--- a/addon/components/frost-button.js
+++ b/addon/components/frost-button.js
@@ -212,20 +212,35 @@ export default Component.extend(PropTypeMixin, {
 
   // == Events ================================================================
 
+  init () {
+    this._super(...arguments)
+
+    if (this.hash) {
+      Object.keys(this.hash).forEach((key) => {
+        const value = this.get(`hash.${key}`)
+        if (Ember.typeOf(value) === 'function') {
+          Ember.defineProperty(this, key, undefined, value)
+        } else {
+          Ember.defineProperty(this, key, Ember.computed.alias(`hash.${key}`))
+        }
+      })
+    }
+  },
+
   onclick: Ember.on('click', function (event) {
     if (!ViewUtils.isSimpleClick(event)) {
       return true
     }
 
-    if (!this.get('disabled') && typeOf(this.attrs.onClick) === 'function') {
-      this.attrs.onClick(this.get('id'))
+    if (!this.get('disabled') && typeOf(this.onClick) === 'function') {
+      this.onClick(this.get('id'))
     }
   }),
 
   _onFocus: Ember.on('focusIn', function (e) {
     // If an onFocus handler is defined, call it
-    if (this.attrs.onFocus) {
-      this.attrs.onFocus()
+    if (this.onFocus) {
+      this.onFocus()
     }
   })
 

--- a/tests/dummy/app/pods/button/controller.js
+++ b/tests/dummy/app/pods/button/controller.js
@@ -1,8 +1,26 @@
 import Ember from 'ember'
 const {Controller} = Ember
 
+function createActionClosure (func) {
+  let context = this
+  return function closure () {
+    func.apply(context, arguments)
+  }
+}
+
 export default Controller.extend({
   vertical: false,
+
+  // BEGIN-SNIPPET button-hash
+  createAttrsHash: Ember.on('init', function () {
+    this.set('attrsHash', {
+      priority: 'primary',
+      size: 'medium',
+      text: 'Data driven',
+      onClick: createActionClosure.call(this, this.actions.onClickHandler)
+    })
+  }),
+  // END-SNIPPET
 
   actions: {
     onClickHandler () {

--- a/tests/dummy/app/pods/button/template.hbs
+++ b/tests/dummy/app/pods/button/template.hbs
@@ -422,4 +422,23 @@
     </div>
   </div>
 
+  <div class='section-title'>Data driven</div>
+  <hr>
+  <div class='section'>
+    <div class='example'>
+      <div class='title'>hash</div>
+      <div class='demo'>
+        {{! BEGIN-SNIPPET button-hash }}
+        {{frost-button
+          hash=attrsHash
+        }}
+        {{! END-SNIPPET }}
+      </div>
+      <div class='snippet'>
+        {{code-snippet name='button-hash.js'}}
+        {{code-snippet name='button-hash.hbs'}}
+      </div>
+    </div>
+  </div>
+
 </div>

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -75,7 +75,6 @@ hr {
 
 .dummy-body.button {
   .example .snippet {
-    width: 320px;
     margin: 15px 0 10px 0;
   }
 }


### PR DESCRIPTION
# minor

The intention would be to package this into a mixin that is compatible with prop-types so that we could effectively data drive any component simply by adding the mixin

This is the approach I'm exploring to expose all properties in situations like the modal cancel/confirm, but it will apply in a much wider variety of situations
