### PR TITLE
Fix a problem where frost-select would clear prompt on redraw

### DIFF
--- a/addon/components/frost-select.js
+++ b/addon/components/frost-select.js
@@ -223,7 +223,7 @@ export default Component.extend(PropTypeMixin, {
     this._super(...arguments)
     const stateAttrs = this.get('stateAttributes')
 
-    const reduxAttrs = _.chain(stateAttrs)
+    let reduxAttrs = _.chain(stateAttrs)
     .map((attrName) => {
       const split = _.filter(attrName.split(ATTR_MAP_DELIM))
       let attrValue
@@ -240,15 +240,18 @@ export default Component.extend(PropTypeMixin, {
     .fromPairs()
     .value()
 
-    this.get('reduxStore').dispatch(resetDropDown(reduxAttrs))
-
     const dataChanged = isAttrDifferent(newAttrs, oldAttrs, 'data')
     const selectedChanged = isAttrDifferent(newAttrs, oldAttrs, 'selected')
     const selectedValueChanged = isAttrDifferent(newAttrs, oldAttrs, 'selectedValue')
 
+    if (!(selectedChanged || selectedValueChanged)) {
+      reduxAttrs = _.omit(reduxAttrs, ['selectedItem', 'selectedItems'])
+    }
+    this.get('reduxStore').dispatch(resetDropDown(reduxAttrs))
+
     // If frost-select instance is being reused by consumer but context is cleared make
     // make sure to actually clear input (noticed when used in conjunction with dialog
-    // compoonents that don't destroy DOM when closed and re-opened)
+    // components that don't destroy DOM when closed and re-opened)
     if (selectedValueChanged && ('selectedValue' in newAttrs) && (newAttrs.selectedValue.value === undefined)) {
       this.selectOptionByValue(null)
       return

--- a/tests/integration/components/frost-multi-select-test.js
+++ b/tests/integration/components/frost-multi-select-test.js
@@ -179,7 +179,7 @@ describeComponent(
 
 describeComponent(
   'frost-multi-select',
-  'Intergration: FrostMultiSelectComponent',
+  'Integration: FrostMultiSelectComponent',
   {
     integration: true
   },
@@ -199,6 +199,20 @@ describeComponent(
 
         expect(input.val()).to.eql('3 items selected')
         expect(props.onChange.called).to.be.true
+        done()
+      })
+    })
+
+    it('keeps prompt on rerender', function (done) {
+      this.set('selectedValue', ['Tony Starks'])
+      // A bug would cause the prompt to clear on a rerender
+      // We trigger one here by changing a dummy attribute
+      this.set('greeting', 'Bonjour')
+
+      wait(() => {
+        let input = this.$('.frost-select .trigger')
+
+        expect(input.val()).to.eql('Ghostface')
         done()
       })
     })

--- a/tests/integration/components/frost-select-test.js
+++ b/tests/integration/components/frost-select-test.js
@@ -339,22 +339,6 @@ describeComponent(
         let input = this.$('.frost-select input')
         expect(input.val()).to.be.eql('Ghostface')
       })
-
-      it('keeps prompt on attrib change', function () {
-        run(() => {
-          this.set('selVal', 'Tony Starks')
-        })
-        // TODO: This test is supposed to catch a bug where a redraw
-        // clears the prompt displayed in the input
-        // But it doesn't demonstrate the problem
-        // Probably some ordering or run loop issue
-        run(() => {
-          this.set('greeting', 'Bonjour')
-        })
-
-        let input = this.$('.frost-select input')
-        expect(input.val()).to.be.eql('Ghostface')
-      })
     })
   }
 )

--- a/tests/integration/components/frost-select-test.js
+++ b/tests/integration/components/frost-select-test.js
@@ -339,6 +339,22 @@ describeComponent(
         let input = this.$('.frost-select input')
         expect(input.val()).to.be.eql('Ghostface')
       })
+
+      it('keeps prompt on attrib change', function () {
+        run(() => {
+          this.set('selVal', 'Tony Starks')
+        })
+        // TODO: This test is supposed to catch a bug where a redraw
+        // clears the prompt displayed in the input
+        // But it doesn't demonstrate the problem
+        // Probably some ordering or run loop issue
+        run(() => {
+          this.set('greeting', 'Bonjour')
+        })
+
+        let input = this.$('.frost-select input')
+        expect(input.val()).to.be.eql('Ghostface')
+      })
     })
   }
 )


### PR DESCRIPTION
# PATCH

Fix a problem where frost-select would clear prompt on redraw
