### PR TITLE
Change frost-select list item color to $frost-color-grey-3

### DIFF
--- a/addon/styles/_frost-select.scss
+++ b/addon/styles/_frost-select.scss
@@ -71,7 +71,7 @@ $frost-input-select-option-row-height: 35px;
 
   li {
     border-bottom: solid 1px $frost-color-lgrey-3;
-    color: $frost-color-grey-5;
+    color: $frost-color-grey-3;
     cursor: pointer;
     display: inline-block;
     height: $frost-input-select-option-row-height;


### PR DESCRIPTION
# PATCH

This UX improvement was requested by Katherine Parmeson : https://agile-jira.ciena.com/browse/BPCC-7
# Changelog
- The unselected text in the `frost-select` drop down menu is now a darker color.
