### PR TITLE
added ability to clear select by setting selectedValue to empty string

### DIFF
--- a/addon/components/frost-select.js
+++ b/addon/components/frost-select.js
@@ -252,7 +252,11 @@ export default Component.extend(PropTypeMixin, {
     // If frost-select instance is being reused by consumer but context is cleared make
     // make sure to actually clear input (noticed when used in conjunction with dialog
     // components that don't destroy DOM when closed and re-opened)
-    if (selectedValueChanged && ('selectedValue' in newAttrs) && (newAttrs.selectedValue.value === undefined)) {
+    if (
+      selectedValueChanged &&
+      ('selectedValue' in newAttrs) &&
+      (newAttrs.selectedValue.value === undefined || newAttrs.selectedValue.value === '')
+    ) {
       this.selectOptionByValue(null)
       return
     }

--- a/addon/components/frost-select.js
+++ b/addon/components/frost-select.js
@@ -43,7 +43,7 @@ function isAttrDifferent (newAttrs, oldAttrs, attributeName) {
   let oldValue = get(oldAttrs, attributeName + '.value')
   let newValue = get(newAttrs, attributeName + '.value')
 
-  return newValue !== undefined && !_.isEqual(oldValue, newValue)
+  return !_.isEqual(oldValue, newValue)
 }
 
 /** Hook for handling outside element click

--- a/addon/reducers/frost-select.js
+++ b/addon/reducers/frost-select.js
@@ -290,7 +290,9 @@ export default function reducer (state, action) {
       if (selectedIndex >= 0) {
         nextState = select(state, selectedIndex)
       } else {
-        nextState = {}
+        nextState = {
+          prompt: ''
+        }
       }
       break
     case RESET_DROPDOWN:

--- a/docs/frost-select.md
+++ b/docs/frost-select.md
@@ -8,7 +8,7 @@
 | --------------- | ---- | ----- | ----------- |
 | `data`          | `array` | `[{"label: "foo", "value": "bar"}]` |  An array of "label"/"value" key/value pairs representing the rows in the select drop-down. |
 | `selected`      | `number` or `array` | `1` or `[1, 2]` | The indices of the pre-selected values corresponding to values in the passed-in data. Passing negative values (e.g. `-1` or `[-1]`) to a single select will clear the current select state.|
-| `selectedValue` | `any`, `array` if using multi-select, `null` to clear | `'bar'` or `['bar', 'buzz']` | A value to choose in the drop down programmatically, or an array of values if using multi-select. Takes precedence over `selected` attribute. Passing `null` will clear the selected state. |
+| `selectedValue` | `any`, `array` if using multi-select, `null` or `''` (empty string) to clear | `'bar'` or `['bar', 'buzz']` | A value to choose in the drop down programmatically, or an array of values if using multi-select. Takes precedence over `selected` attribute. Passing `null` will clear the selected state. |
 | `disabled`      | `boolean` | `false` | **default** - normal select component |
 |      |  | `true` | disabled select component |
 | `error`        | `boolean` |`false` | **default** - normal select component |

--- a/docs/frost-select.md
+++ b/docs/frost-select.md
@@ -8,7 +8,7 @@
 | --------------- | ---- | ----- | ----------- |
 | `data`          | `array` | `[{"label: "foo", "value": "bar"}]` |  An array of "label"/"value" key/value pairs representing the rows in the select drop-down. |
 | `selected`      | `number` or `array` | `1` or `[1, 2]` | The indices of the pre-selected values corresponding to values in the passed-in data. Passing negative values (e.g. `-1` or `[-1]`) to a single select will clear the current select state.|
-| `selectedValue` | `any`, `array` if using multi-select, `null` or `''` (empty string) to clear | `'bar'` or `['bar', 'buzz']` | A value to choose in the drop down programmatically, or an array of values if using multi-select. Takes precedence over `selected` attribute. Passing `null` will clear the selected state. |
+| `selectedValue` | `any`, `array` if using multi-select, `null` or `''` (empty string) to clear | `'bar'` or `['bar', 'buzz']` | A value to choose in the drop down programmatically, or an array of values if using multi-select. Takes precedence over `selected` attribute. Passing `null` or `''` (empty string) will clear the selected state. |
 | `disabled`      | `boolean` | `false` | **default** - normal select component |
 |      |  | `true` | disabled select component |
 | `error`        | `boolean` |`false` | **default** - normal select component |

--- a/tests/dummy/app/pods/select/controller.js
+++ b/tests/dummy/app/pods/select/controller.js
@@ -21,8 +21,9 @@ export default Controller.extend({
   selectedIndex: 1,
   selectedIndices: [1, 2],
   preSelectedValue: 'Arthur Curry',
+  preSelectedValueForClearing: 'Arthur Curry',
   selectedValues: ['Arthur Curry', 'Ray Palmer'],
-
+  clearSelectedValue: false,
   actions: {
     onBlurHandler () {
       this.notifications.addNotification({
@@ -41,6 +42,7 @@ export default Controller.extend({
         clearDuration: 2000
       })
     },
+
     onInputHandler (filterValue) {
       this.notifications.addNotification({
         message: 'Handling input: ' + filterValue,
@@ -49,6 +51,14 @@ export default Controller.extend({
         clearDuration: 2000
       })
       this.set('search', filterValue)
+    },
+
+    onClearSelect (event) {
+      this.set('preSelectedValueForClearing', '')
+    },
+
+    onChangeClearable (value) {
+      this.set('preSelectedValueForClearing', value[0])
     }
   }
 })

--- a/tests/dummy/app/pods/select/template.hbs
+++ b/tests/dummy/app/pods/select/template.hbs
@@ -23,6 +23,35 @@
       </div>
     </div>
 
+    <div class="example">
+      <div class="title">clearing</div>
+      <i>works by setting the property being passed as 'selectedValue' to an empty string<br/></i>
+      <div class="demo">
+        {{log preSelectedValueForClearing}}
+        {{frost-select
+          data=data
+          hook='mySelect'
+          selectedValue=preSelectedValueForClearing
+          onChange=(action 'onChangeClearable')
+        }}
+        {{frost-button text='Clear'
+          onClick=(action 'onClearSelect')
+          priority='secondary'
+          size='small'
+          text='Clear'
+        }}
+      </div>
+      <div class="snippet">
+        {{format-markdown "```handlebars
+{{frost-select
+  data=data
+  hook='mySelect'
+  selectedValue=preSelectedValueForClearing
+}}
+```"}}
+      </div>
+    </div>
+
   </div>
 
   <div class="section-title">Options</div>

--- a/tests/integration/components/frost-select-test.js
+++ b/tests/integration/components/frost-select-test.js
@@ -140,7 +140,7 @@ describeComponent(
         this.$('.frost-select input').focus()
       })
       expect(this.$('.frost-select').hasClass('open')).to.be.true
-    })*/
+    }) */
 
     it('highlights list items on mouse over', function () {
       run(() => {
@@ -403,6 +403,14 @@ describeComponent(
         })
 
         expect($input.val()).to.be.eql('Ghostface')
+      })
+
+      it('clears when selectedValue is set to empty string', function () {
+        this.set('selVal', '')
+        this.render(selectedTestTemplate)
+        return run.later(() => {
+          expect($input.val()).to.be.eql('')
+        })
       })
     })
   }


### PR DESCRIPTION
# PATCH
# CHANGELOG
- select value and prompt is now clearable by setting the 'selectedValue' property to an empty string in the consuming context
