### PR TITLE
Update dropdown to update at 60 fps and prepare for Ember 2.9

### DIFF
--- a/addon/components/frost-select-dropdown.js
+++ b/addon/components/frost-select-dropdown.js
@@ -1,5 +1,5 @@
 import Ember from 'ember'
-const {$, Component, get, run} = Ember
+const {$, Component, get} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import {task, timeout} from 'ember-concurrency'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'

--- a/addon/components/frost-select.js
+++ b/addon/components/frost-select.js
@@ -397,7 +397,7 @@ export default Component.extend(PropTypeMixin, {
   },
 
   didInsertElement () {
-    this.set('element', this.$())
+    this.set('$element', this.$())
   },
 
   // ==========================================================================

--- a/addon/templates/components/frost-select.hbs
+++ b/addon/templates/components/frost-select.hbs
@@ -22,7 +22,7 @@
   {{to-elsewhere
     named=renderTarget
     send=(component 'frost-select-dropdown'
-      element=element
+      $element=$element
       items=displayItems
       onItemOver=(action 'onItemOver')
       onSelect=(action 'onSelect')


### PR DESCRIPTION
# PATCH
# CHANGELOG
- **Updated** `frost-select` dropdown to update at 60 fps and stop using `element` property as it causes conflicts in Ember 2.9 beta 3.
