### PR TITLE
Align width of text, password, and select inputs

### DIFF
--- a/addon/styles/_frost-password.scss
+++ b/addon/styles/_frost-password.scss
@@ -4,7 +4,7 @@ $error-margin: 1px; // Note: margin + border width equals border width of focus 
 .frost-password {
   display: block;
   position: relative;
-  width: 175px;
+  min-width: 175px;
 
   &.revealable {
     .frost-text-clear {

--- a/addon/styles/_frost-select.scss
+++ b/addon/styles/_frost-select.scss
@@ -24,10 +24,9 @@ $frost-input-select-option-row-height: 35px;
   cursor: pointer;
   display: inline-block;
   height: $frost-input-text-height;
-  min-width: 125px;
+  min-width: 175px;
   outline: none;
   position: relative;
-  width: 200px;
   background: $frost-select-container-background;
 
   &:focus {

--- a/addon/styles/_frost-select.scss
+++ b/addon/styles/_frost-select.scss
@@ -22,7 +22,6 @@ $frost-input-select-option-row-height: 35px;
 .frost-select {
   border: solid 1px $frost-color-input-border;
   cursor: pointer;
-  display: inline-block;
   height: $frost-input-text-height;
   min-width: 175px;
   outline: none;

--- a/addon/styles/_frost-text.scss
+++ b/addon/styles/_frost-text.scss
@@ -16,7 +16,7 @@ $padding: 0 30px 0 8px;
 .frost-text {
   display: block;
   position: relative;
-  width: 175px;
+  min-width: 175px;
 
   &.error .frost-text-input {
     border: $error-border;

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -48,7 +48,7 @@ hr {
 .dummy-body.text-input.field {
   .example .snippet {
     min-width: 305px;
-    margin: 15px 0 10px 0;
+    margin: 15px 20px 10px 0;
   }
 }
 
@@ -150,6 +150,8 @@ hr {
     .demo {
       display: block;
       vertical-align: top;
+      margin-right: 20px;
+
       > .frost-icon {
         width: 40px;
         height: 40px;


### PR DESCRIPTION
# PATCH
# CHANGELOG
- **Fixed** width of following inputs to match: `frost-password`, `frost-select`, and `frost-text`.
