### PR TITLE
Updated ember-hook selector for frost-select-dropdown input

### DIFF
--- a/addon/templates/components/frost-select-dropdown.hbs
+++ b/addon/templates/components/frost-select-dropdown.hbs
@@ -10,6 +10,7 @@
   style={{listStyle}}
 >
   {{frost-text
+    hook=(concat receivedHook '-list-input')
     onInput=onFilterInput
     value=filter
   }}

--- a/tests/integration/components/frost-select-test.js
+++ b/tests/integration/components/frost-select-test.js
@@ -974,4 +974,16 @@ describeComponent(...integration('frost-select'), function () {
       })
     })
   })
+
+  describe('ember-hook selectors', function () {
+    describe('when dropdown is open', function () {
+      beforeEach(function () {
+        $hook('select').click().focus()
+      })
+
+      it('can find dropdown input', function () {
+        expect($hook('select-list-input')).to.have.length(1)
+      })
+    })
+  })
 })

--- a/tests/integration/components/frost-select-test.js
+++ b/tests/integration/components/frost-select-test.js
@@ -978,7 +978,7 @@ describeComponent(...integration('frost-select'), function () {
   describe('ember-hook selectors', function () {
     describe('when dropdown is open', function () {
       beforeEach(function () {
-        $hook('select').click().focus()
+        $hook('select').click()
       })
 
       it('can find dropdown input', function () {


### PR DESCRIPTION
#PATCH#
Super simple, just wanted this hook for my tests. 

I'm hoping no one is depending on the default `-input` hook since it has only been that way for a day (and that would be a pretty strange thing to depend on anyway).

# Changelog

* Updated ember-hook selector for frost-select-dropdown input