### PR TITLE
Add filter match underlining to frost-select

### DIFF
--- a/addon/components/frost-select-dropdown.js
+++ b/addon/components/frost-select-dropdown.js
@@ -37,7 +37,6 @@ export default Component.extend(PropTypeMixin, {
     focusedIndex: PropTypes.number,
     left: PropTypes.number,
     maxHeight: PropTypes.number,
-    onCheck: PropTypes.func,
     top: PropTypes.number,
     width: PropTypes.number
   },

--- a/addon/components/frost-select-li.js
+++ b/addon/components/frost-select-li.js
@@ -1,8 +1,11 @@
 import Ember from 'ember'
 const {Component} = Ember
+import computed, {readOnly} from 'ember-computed-decorators'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 
 import layout from '../templates/components/frost-select-li'
+
+const regexEscapeChars = '-[]/{}()*+?.^$|'.split('')
 
 export default Component.extend(PropTypeMixin, {
   // == Properties ============================================================
@@ -12,9 +15,30 @@ export default Component.extend(PropTypeMixin, {
 
   propTypes: {
     data: PropTypes.object.isRequired,
+    filter: PropTypes.string,
     hook: PropTypes.string.isRequired,
+    multiselect: PropTypes.bool,
     onItemOver: PropTypes.func.isRequired,
     onSelect: PropTypes.func.isRequired
+  },
+
+  // == Computed Properties ===================================================
+
+  @readOnly
+  @computed('data', 'filter')
+  label (data, filter) {
+    if (filter) {
+      // Make sure special chars are escaped in filter so we can use it as a
+      // regular expression pattern
+      filter = filter.replace(`[${regexEscapeChars.join('\\')}]`, 'g')
+
+      const pattern = new RegExp(filter, 'gi')
+      const label = data.label.replace(pattern, '<u>$&</u>')
+
+      return Ember.String.htmlSafe(label)
+    }
+
+    return data && data.label || ''
   },
 
   // == Events ================================================================

--- a/addon/styles/_frost-select.scss
+++ b/addon/styles/_frost-select.scss
@@ -103,6 +103,8 @@ $frost-select-placeholder-color: $frost-color-grey-6;
   overflow-y: auto;
 
   ul {
+    display: flex;
+    flex-wrap: wrap;
     margin: 0;
     overflow-x: hidden;
     overflow-y: auto;
@@ -136,6 +138,7 @@ $frost-select-placeholder-color: $frost-color-grey-6;
   color: $frost-color-grey-3;
   cursor: pointer;
   display: inline-block;
+  flex: 1 0 auto;
   height: $frost-input-select-option-row-height;
   line-height: $frost-input-select-option-row-height;
   overflow: hidden;

--- a/addon/templates/components/frost-select-dropdown.hbs
+++ b/addon/templates/components/frost-select-dropdown.hbs
@@ -36,24 +36,15 @@
       </div>
     {{/if}}
     {{#each renderItems as |item index|}}
-      {{#frost-select-li
+      {{frost-select-li
         class=item.className
         data=item
+        filter=filter
         hook=(concat receivedHook '-item-' index)
+        multiselect=multiselect
         onItemOver=(action 'focusOnItem')
         onSelect=(action 'selectItem')
       }}
-        {{#if multiselect}}
-          {{frost-checkbox
-            checked=item.selected
-            hook=(concat receivedHook '-checkbox-item-' index)
-            onInput=onCheck
-            size='medium'
-            value=item.index
-          }}
-        {{/if}}
-        {{item.label}}
-      {{/frost-select-li}}
     {{/each}}
   </ul>
 </div>

--- a/addon/templates/components/frost-select-li.hbs
+++ b/addon/templates/components/frost-select-li.hbs
@@ -1,1 +1,8 @@
-{{yield}}
+{{#if multiselect}}
+  {{frost-checkbox
+    checked=data.selected
+    hook=(concat hook '-checkbox')
+    size='medium'
+  }}
+{{/if}}
+{{label}}

--- a/test-support/helpers/ember-frost-core.js
+++ b/test-support/helpers/ember-frost-core.js
@@ -78,6 +78,16 @@ export function click (element) {
 }
 
 /**
+ * Filter frost-select
+ * @param {String} filter - filter to apply to select
+ */
+export function filterSelect (filter) {
+  $('.frost-select-dropdown .frost-text-input')
+    .val(filter)
+    .trigger('input')
+}
+
+/**
  * Verify button exists with expected state
  * @param {jQuery|String} button - name of Ember hook or jQuery instance
  * @param {FrostButtonState} state - expected button state


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Added** underlining of matching text in items when filtering `frost-select`.

