### PR TITLE
Fixed select tabIndex after being disabled

### DIFF
--- a/addon/components/frost-select.js
+++ b/addon/components/frost-select.js
@@ -171,6 +171,13 @@ export default Component.extend(PropTypeMixin, {
 
   @readOnly
   @computed('disabled', 'tabIndex')
+  /**
+   * Get appropriate tab index
+   * disabled state changes.
+   * @param {Boolean} disabled - whether or not input is disabled
+   * @param {Number} tabIndex - tab index
+   * @returns {Number} tab index
+   */
   computedTabIndex (disabled, tabIndex) {
     return disabled ? -1 : tabIndex
   },

--- a/addon/components/frost-select.js
+++ b/addon/components/frost-select.js
@@ -43,7 +43,7 @@ export default Component.extend(PropTypeMixin, {
   // == Properties ============================================================
 
   attributeBindings: [
-    'tabIndex'
+    'computedTabIndex:tabIndex'
   ],
 
   classNameBindings: [
@@ -170,6 +170,12 @@ export default Component.extend(PropTypeMixin, {
   },
 
   @readOnly
+  @computed('disabled', 'tabIndex')
+  computedTabIndex (disabled, tabIndex) {
+    return disabled ? -1 : tabIndex
+  },
+
+  @readOnly
   @computed('selectedItems')
   text (selectedItems) {
     switch (selectedItems.length) {
@@ -218,11 +224,6 @@ export default Component.extend(PropTypeMixin, {
       !compareSelectedValues(newSelectedValue, this.get('internalSelectedValue'))
     ) {
       props.internalSelectedValue = newSelectedValue
-    }
-
-    // Make sure user can't tab into disabled select
-    if (this.get('disabled')) {
-      props.tabIndex = -1
     }
 
     if (Object.keys(props).length !== 0) {

--- a/tests/integration/components/frost-select-test.js
+++ b/tests/integration/components/frost-select-test.js
@@ -413,42 +413,47 @@ describeComponent(...integration('frost-select'), function () {
         expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
       })
 
-      describe('when input is disabled and then re-enabled', function () {
+      describe('when input is disabled', function () {
         beforeEach(function () {
           this.set('disabled', true)
-          this.set('disabled', false)
         })
 
-        it('renders as expected', function () {
-          expectSelectWithState('select', {
-            focused: false,
-            tabIndex: 3
+        describe('when input is re-enabled', function () {
+          beforeEach(function () {
+            this.set('disabled', false)
           })
 
-          expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-          expect(onChange.callCount, 'OnChange is not called').to.equal(0)
-          expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
-        })
-      })
+          it('renders as expected', function () {
+            expectSelectWithState('select', {
+              focused: false,
+              tabIndex: 3
+            })
 
-      describe('when input is enabled and tabIndex is set at the same time', function () {
-        beforeEach(function () {
-          this.set('disabled', true)
-          this.setProperties({
-            disabled: false,
-            tabIndex: 42
+            expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
+            expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+            expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
           })
         })
 
-        it('renders as expected', function () {
-          expectSelectWithState('select', {
-            focused: false,
-            tabIndex: 42
+        describe('when input is re-enabled and tabIndex is set simultaneously', function () {
+          beforeEach(function () {
+            this.set('disabled', true)
+            this.setProperties({
+              disabled: false,
+              tabIndex: 42
+            })
           })
 
-          expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-          expect(onChange.callCount, 'OnChange is not called').to.equal(0)
-          expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
+          it('renders as expected', function () {
+            expectSelectWithState('select', {
+              focused: false,
+              tabIndex: 42
+            })
+
+            expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
+            expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+            expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
+          })
         })
       })
     })

--- a/tests/integration/components/frost-select-test.js
+++ b/tests/integration/components/frost-select-test.js
@@ -412,6 +412,45 @@ describeComponent(...integration('frost-select'), function () {
         expect(onChange.callCount, 'OnChange is not called').to.equal(0)
         expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
       })
+
+      describe('when input is disabled and then re-enabled', function () {
+        beforeEach(function () {
+          this.set('disabled', true)
+          this.set('disabled', false)
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState('select', {
+            focused: false,
+            tabIndex: 3
+          })
+
+          expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
+          expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+          expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
+        })
+      })
+
+      describe('when input is enabled and tabIndex is set at the same time', function () {
+        beforeEach(function () {
+          this.set('disabled', true)
+          this.setProperties({
+            disabled: false,
+            tabIndex: 42
+          })
+        })
+
+        it('renders as expected', function () {
+          expectSelectWithState('select', {
+            focused: false,
+            tabIndex: 42
+          })
+
+          expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
+          expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+          expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
+        })
+      })
     })
 
     describe('when input has error', function () {


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [X] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* Fixed the tabIndex on frost-select that are disabled and then enabled

