### PR TITLE
test suite for frost-toggle

### DIFF
--- a/addon/components/frost-toggle.js
+++ b/addon/components/frost-toggle.js
@@ -67,9 +67,7 @@ export default Component.extend(PropTypeMixin, FrostEventsProxy, {
   // == Events ================================================================
   init () {
     this._super(...arguments)
-    assert(`Same value has been assigned to both ${this.toString()}.trueValue and ${this.toString()}.falseValue`,
-      (typeOf(get(this, 'trueValue') === 'undefined') && typeOf(get(this, 'falseValue') === 'undefined')) ||
-      get(this, 'trueValue') !== get(this, 'falseValue'))
+    this._setupAssertion()
   },
 
   // == Functions ==============================================================
@@ -88,6 +86,12 @@ export default Component.extend(PropTypeMixin, FrostEventsProxy, {
     if (value === 'false') return false
 
     return value
+  },
+
+  _setupAssertion () {
+    assert(`Same value has been assigned to both ${this.toString()}.trueValue and ${this.toString()}.falseValue`,
+      (typeOf(get(this, 'trueValue')) === 'undefined' && typeOf(get(this, 'falseValue')) === 'undefined') ||
+      get(this, 'trueValue') !== get(this, 'falseValue'))
   },
 
   // == Computed Properties =====================================================

--- a/addon/components/frost-toggle.js
+++ b/addon/components/frost-toggle.js
@@ -29,7 +29,6 @@ export default Component.extend(PropTypeMixin, FrostEventsProxy, {
   layout: layout,
 
   propTypes: {
-    autofocus: PropTypes.bool,
     disabled: PropTypes.bool,
     falseLabel: PropTypes.oneOfType([
       PropTypes.bool,
@@ -52,7 +51,6 @@ export default Component.extend(PropTypeMixin, FrostEventsProxy, {
 
   getDefaultProps () {
     return {
-      autofocus: false,
       disabled: false,
       _falseLabel: get(this, 'falseLabel') !== undefined &&
       (typeOf(get(this, 'falseLabel') === 'string') || typeOf(get(this, 'falseLabel') === 'number'))

--- a/addon/components/frost-toggle.js
+++ b/addon/components/frost-toggle.js
@@ -4,6 +4,7 @@ const {
   Component,
   get,
   isPresent,
+  typeOf,
   ViewUtils: {
     isSimpleClick
   }
@@ -26,23 +27,23 @@ export default Component.extend(PropTypeMixin, FrostEventsProxy, {
   ],
   classNames: ['frost-toggle'],
   layout: layout,
-  size: 'medium',
 
   propTypes: {
     autofocus: PropTypes.bool,
     disabled: PropTypes.bool,
-    hook: PropTypes.string,
-    value: PropTypes.oneOfType([
-      PropTypes.bool,
-      PropTypes.string,
-      PropTypes.number
-    ]),
     falseLabel: PropTypes.oneOfType([
       PropTypes.bool,
       PropTypes.string,
       PropTypes.number
     ]),
+    hook: PropTypes.string,
+    size: PropTypes.string,
     trueLabel: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.string,
+      PropTypes.number
+    ]),
+    value: PropTypes.oneOfType([
       PropTypes.bool,
       PropTypes.string,
       PropTypes.number
@@ -53,10 +54,13 @@ export default Component.extend(PropTypeMixin, FrostEventsProxy, {
     return {
       autofocus: false,
       disabled: false,
-      _trueLabel: typeof this.get('trueLabel') === 'string' || typeof this.get('trueLabel') === 'number'
-                ? this.get('trueLabel') : true,
-      _falseLabel: typeof this.get('falseLabel') === 'string' || typeof this.get('falseLabel') === 'number'
-                ? this.get('falseLabel') : false
+      _falseLabel: get(this, 'falseLabel') !== undefined &&
+      (typeOf(get(this, 'falseLabel') === 'string') || typeOf(get(this, 'falseLabel') === 'number'))
+                ? get(this, 'falseLabel') : false,
+      size: 'medium',
+      _trueLabel: get(this, 'trueLabel') !== undefined &&
+      (typeOf(get(this, 'trueLabel') === 'string') || typeOf(get(this, 'trueLabel') === 'number'))
+                ? get(this, 'trueLabel') : true
     }
   },
 
@@ -64,8 +68,8 @@ export default Component.extend(PropTypeMixin, FrostEventsProxy, {
   init () {
     this._super(...arguments)
     assert(`Same value has been assigned to both ${this.toString()}.trueValue and ${this.toString()}.falseValue`,
-      (typeof this.attrs['trueValue'] === 'undefined' && typeof this.attrs['falseValue'] === 'undefined') ||
-      this.attrs['trueValue'] !== this.attrs['falseValue'])
+      (typeOf(get(this, 'trueValue') === 'undefined') && typeOf(get(this, 'falseValue') === 'undefined')) ||
+      get(this, 'trueValue') !== get(this, 'falseValue'))
   },
 
   // == Functions ==============================================================
@@ -99,7 +103,7 @@ export default Component.extend(PropTypeMixin, FrostEventsProxy, {
 
   @computed('value')
   _isToggled (value) {
-    return this._preferBoolean(value) === this.get('_trueValue')
+    return this._preferBoolean(value) === get(this, '_trueValue')
   },
 
   // == Actions ================================================================

--- a/docs/frost-toggle.md
+++ b/docs/frost-toggle.md
@@ -7,14 +7,19 @@
 ### toggle
 | Attribute | Type | Value | Description |
 | --------- | ---- | ----- | ----------- |
-| `autofocus` | `boolean` | `false` | **default** - toggle component |
-| |  | `true` | sets focus on toggle component |
 | `disabled` | `boolean` | `false` | **default** - toggle component |
 | | | `true` | disable toggle component |
+| `falseLabel` | `boolean` or `string` or `number` | `<value>` | the label for the false value of the toggle component |
+| `falseValue` | `boolean` or `string` or `number` | `<value>` | the false value of the toggle component |
+| `trueLabel` | `boolean` or `string` or `number` | `<value>` | the label for the true value of the toggle component |
+| `trueValue` | `boolean` or `string` or `number` | `<value>` | true value of the toggle component |
 | `hook` | `string` | `<unique-name>` | name used for testing with ember-hook |
+| `onClick` | `string` | `<action-name>` | triggers associated action when the toggle is clicked |
 | `value` | `boolean` or `string` or `number` | `<value>` | value of the toggle component |
-| `falseLabel` | `boolean` or `string` or `number` | `<value>` | **default** to `false` - the label for the false value of the toggle component |
-| `trueLabel` | `boolean` or `string` or `number` | `<value>` | **default** to `true` - the label for the true value of the toggle component |
+
+### Event Handlers
+A comprehensive list of [HTML event handlers](frost-events.md) are available to choose from based on your needs.
+
 
 ## Testing with ember-hook
 If a hook is set on radio-group, a concatenated hook will be created as follows:

--- a/tests/dummy/app/pods/toggle/template.hbs
+++ b/tests/dummy/app/pods/toggle/template.hbs
@@ -7,6 +7,7 @@
             <div class='demo'>
               {{! BEGIN-SNIPPET toggle-action }}
               {{frost-toggle
+                hook='myToggle'
                 value=value1
                 onClick=(action 'toggleHandler1')
               }}

--- a/tests/integration/components/frost-toggle-test.js
+++ b/tests/integration/components/frost-toggle-test.js
@@ -1,0 +1,223 @@
+import {expect} from 'chai'
+import {
+  describeComponent,
+  it
+} from 'ember-mocha'
+import {
+  beforeEach,
+  describe
+} from 'mocha'
+import hbs from 'htmlbars-inline-precompile'
+import {
+  $hook,
+  initialize
+} from 'ember-hook'
+import sinon from 'sinon'
+
+describeComponent(
+  'frost-toggle',
+  'Integration: FrostToggleComponent',
+  {
+    integration: true
+  },
+  function () {
+    beforeEach(function () {
+      initialize()
+    })
+
+    it('renders default values', function () {
+      this.render(hbs`
+        {{frost-toggle}}
+      `)
+
+      expect(
+        this.$('.frost-toggle').find('input').prop('type'),
+        'type set to "checkbox"'
+      ).to.eql('checkbox')
+
+      expect(
+        this.$('.frost-toggle-input'),
+        'class frost-toggle-input is set'
+      ).to.have.length(1)
+
+      expect(
+        this.$('.frost-toggle').find('label').hasClass('frost-toggle-button'),
+        'label has class "frost-toggle-button"'
+      ).to.be.true
+
+      expect(
+        this.$('.frost-toggle').find('label').prop('for'),
+        '"label for" property has the correct value'
+      ).to.eql(
+        this.$('.frost-toggle').find('input').prop('id')
+      )
+    })
+
+    it('sets disabled property', function () {
+      this.render(hbs`
+        {{frost-toggle
+          disabled=true
+        }}
+     `)
+
+      expect(
+        this.$('.frost-toggle').find('input').prop('disabled'),
+        'disabled is set'
+      ).to.be.true
+    })
+
+    it('sets hook property', function () {
+      this.render(hbs`
+        {{frost-toggle
+          hook='my-test'
+        }}
+     `)
+
+      expect(
+        $hook('my-test-toggle-input').hasClass('frost-toggle-input '),
+        'input hook is set'
+      ).to.be.true
+
+      expect(
+        $hook('my-test-toggle-label').hasClass('frost-toggle-button'),
+        'label hook is set'
+      ).to.be.true
+
+      expect(
+        $hook('my-test-toggle-text-on').hasClass('frost-toggle-text on'),
+        'toggle text on hook is set'
+      ).to.be.true
+
+      expect(
+        $hook('my-test-toggle-text-off').hasClass('frost-toggle-text off'),
+        'toggle text off hook is set'
+      ).to.be.true
+    })
+
+    it('sets value property', function () {
+      const value = 'test value'
+
+      this.set('value', value)
+
+      this.render(hbs`
+        {{frost-toggle
+          value=value
+        }}
+     `)
+
+      expect(
+        this.$('.frost-toggle').find('input').val(),
+        'value is set'
+      ).to.eql('on')
+    })
+
+    describe('label is set', function () {
+      it('uses trueLabel property', function () {
+        this.render(hbs`
+          {{frost-toggle
+            trueLabel='Label On'
+            value='on'
+          }}
+       `)
+
+        expect(
+          this.$('.on').text().trim(),
+          'trueLabel is set'
+        ).to.eql('Label On')
+      })
+
+      it('uses default on label of "On"', function () {
+        this.render(hbs`
+          {{frost-toggle
+            value='on'
+          }}
+       `)
+
+        expect(
+          this.$('.on').text().trim(),
+          'default on label is set'
+        ).to.eql('On')
+      })
+
+      it('uses falseLabel property', function () {
+        this.render(hbs`
+          {{frost-toggle
+            falseLabel='Label Off'
+            value='on'
+          }}
+       `)
+
+        expect(
+          this.$('.off').text().trim(),
+          'falseLabel is set'
+        ).to.eql('Label Off')
+      })
+
+      it('uses default off label of "Off"', function () {
+        this.render(hbs`
+          {{frost-toggle}}
+       `)
+
+        expect(
+          this.$('.off').text().trim(),
+          'default off label is set'
+        ).to.eql('Off')
+      })
+    })
+
+    it('uses trueValue property', function () {
+      this.set('testValue', 'enabled')
+
+      this.render(hbs`
+          {{frost-toggle
+            trueValue='enabled'
+            value=testValue
+          }}
+       `)
+
+      expect(
+        this.$('input').prop('checked'),
+        'toggle is in "On" state'
+      ).to.be.true
+    })
+
+    it('uses falseValue property', function () {
+      this.set('testValue', 'disabled')
+
+      this.render(hbs`
+          {{frost-toggle
+            falseValue='disabled'
+            value=testValue
+          }}
+       `)
+
+      expect(
+        this.$('input').prop('checked'),
+        'toggle is in "Off" state'
+      ).to.be.false
+    })
+
+    it('fires onClick closure action', function () {
+      const externalActionSpy = sinon.spy()
+
+      this.on('externalAction', externalActionSpy)
+
+      this.set('testValue', 'disabled')
+
+      this.render(hbs`
+          {{frost-toggle
+            falseValue='disabled'
+            value=testValue
+            onClick=(action 'externalAction')
+          }}
+       `)
+
+      this.$('label').click()
+
+      expect(
+        externalActionSpy.called,
+        'onClick closure action called'
+      ).to.be.true
+    })
+  }
+)

--- a/tests/integration/components/frost-toggle-test.js
+++ b/tests/integration/components/frost-toggle-test.js
@@ -53,6 +53,20 @@ describeComponent(
       )
     })
 
+    it('throws assertion error', function () {
+      expect(
+        () => {
+          this.render(hbs`
+            {{frost-toggle
+              trueValue='testValue'
+              falseValue='testValue'
+            }}
+          `)
+        },
+        'assertion thrown when trueValue and falseValue are same value'
+      ).to.throw(/Same value has been assigned/)
+    })
+
     it('sets disabled property', function () {
       this.render(hbs`
         {{frost-toggle

--- a/tests/unit/components/frost-toggle-test.js
+++ b/tests/unit/components/frost-toggle-test.js
@@ -1,0 +1,194 @@
+import {expect} from 'chai'
+import Ember from 'ember'
+const {run} = Ember
+import FrostEventsProxy from 'ember-frost-core/mixins/frost-events-proxy'
+import {describeComponent} from 'ember-mocha'
+import PropTypeMixin from 'ember-prop-types'
+import {
+  beforeEach,
+  describe,
+  it
+} from 'mocha'
+
+describeComponent(
+  'frost-toggle',
+  'Unit: FrostToggleComponent',
+  {
+    unit: true
+  },
+  function () {
+    let component
+
+    beforeEach(function () {
+      component = this.subject()
+    })
+
+    it('includes className frost-toggle', function () {
+      expect(component.classNames).to.include('frost-toggle')
+    })
+
+    it('sets default property values correctly', function () {
+      expect(
+        component.get('autofocus'),
+        'autofocus: false'
+      ).to.be.false
+
+      expect(
+        component.get('disabled'),
+        'disabled: false'
+      ).to.be.false
+
+      expect(
+        component.get('_trueLabel'),
+        '_trueLabel: true'
+      ).to.be.true
+
+      expect(
+        component.get('_falseLabel'),
+        '_falseLabel: false'
+      ).to.be.false
+
+      expect(
+        component.get('hook'),
+        'hook: "undefined"'
+      ).to.be.undefined
+
+      expect(
+        component.get('size'),
+        'size: "undefined"'
+      ).to.eql('medium')
+    })
+
+    it('sets dependent keys correctly', function () {
+      const _trueValueDependentKeys = [
+        'trueValue',
+        '_trueLabel'
+      ]
+
+      const _falseValueDependentKeys = [
+        'falseValue',
+        '_falseLabel'
+      ]
+
+      const _isToggledDependentKeys = [
+        'value'
+      ]
+
+      expect(
+        component._trueValue._dependentKeys,
+        'Dependent keys are correct for _trueValue()'
+      ).to.eql(_trueValueDependentKeys)
+
+      expect(
+        component._falseValue._dependentKeys,
+        'Dependent keys are correct for _falseValue()'
+      ).to.eql(_falseValueDependentKeys)
+
+      expect(
+        component._isToggled._dependentKeys,
+        'Dependent keys are correct for _isToggled()'
+      ).to.eql(_isToggledDependentKeys)
+    })
+
+    it('has the expected Mixins', function () {
+      expect(
+        PropTypeMixin.detect(component),
+        'PropTypeMixin Mixin is present'
+      ).to.be.true
+
+      expect(
+        FrostEventsProxy.detect(component),
+        'FrostEventsProxy Mixin is present'
+      ).to.be.true
+    })
+
+    describe('_preferBoolean()', function () {
+      it('returns boolean true when passed string "true"', function () {
+        expect(
+          component._preferBoolean('true'),
+          'returned boolean true'
+        ).to.be.true
+      })
+
+      it('returns boolean false when passed string "false"', function () {
+        expect(
+          component._preferBoolean('false'),
+          'returned boolean false'
+        ).to.be.false
+      })
+
+      it('returns value passed when not string "false" or "true"', function () {
+        expect(
+          component._preferBoolean('test'),
+          'passed value is returned'
+        ).to.eql('test')
+      })
+    })
+
+    describe('_trueValue computed property', function () {
+      it('returns "trueValue" when set', function () {
+        run(() => component.set('trueValue', 'testValue'))
+
+        expect(
+          component.get('_trueValue'),
+          '_trueValue successfully set to trueValue'
+        ).to.eql('testValue')
+      })
+
+      it('returns "_trueLabel" when set', function () {
+        run(() => component.set('_trueLabel', 'testLabel'))
+
+        expect(
+          component.get('_trueLabel'),
+          '_trueValue successfully set to _trueLabel'
+        ).to.eql('testLabel')
+      })
+    })
+
+    describe('_falseValue computed property', function () {
+      it('returns "falseValue" when set', function () {
+        run(() => component.set('falseValue', 'testValue'))
+
+        expect(
+          component.get('_falseValue'),
+          '_falseValue successfully set to falseValue'
+        ).to.eql('testValue')
+      })
+
+      it('returns "_falseLabel" when set', function () {
+        run(() => component.set('_falseLabel', 'testLabel'))
+
+        expect(
+          component.get('_falseValue'),
+          '_falseValue successfully set to _falseLabel'
+        ).to.eql('testLabel')
+      })
+    })
+
+    describe('_isToggled computed property', function () {
+      it('returns true when value is toggled on', function () {
+        run(() => {
+          component.set('_trueValue', 'testValueOn')
+          component.set('value', 'testValueOn')
+        })
+
+        expect(
+          component.get('_isToggled'),
+          '_isToggled returns true'
+        ).to.be.true
+      })
+
+      it('returns false when value is toggled off', function () {
+        run(() => {
+          component.set('_trueValue', 'testValueOn')
+          component.set('value', 'testValueOff')
+        })
+
+        expect(
+          component.get('_isToggled'),
+          '_isToggled returns false'
+        ).to.be.false
+      })
+    })
+  }
+)

--- a/tests/unit/components/frost-toggle-test.js
+++ b/tests/unit/components/frost-toggle-test.js
@@ -31,11 +31,6 @@ describeComponent(
 
     it('sets default property values correctly', function () {
       expect(
-        component.get('autofocus'),
-        'autofocus: false'
-      ).to.be.false
-
-      expect(
         component.get('disabled'),
         'disabled: false'
       ).to.be.false

--- a/tests/unit/components/frost-toggle-test.js
+++ b/tests/unit/components/frost-toggle-test.js
@@ -20,7 +20,9 @@ describeComponent(
     let component
 
     beforeEach(function () {
-      component = this.subject()
+      component = this.subject({
+        _setupAssertion: function () {}
+      })
     })
 
     it('includes className frost-toggle', function () {


### PR DESCRIPTION
* **Added** unit/integration tests for frost-toggle
* **Updated** README for frost-toggle added
* **Updated** frost-toggle.js to destructure Ember.get() and use Ember.typeOf()

Closes: https://github.com/ciena-frost/ember-frost-core/issues/194

