### PR TITLE
relocated cloneEvent method, updated places where it is called and ad…

### DIFF
--- a/addon/components/frost-radio-button.js
+++ b/addon/components/frost-radio-button.js
@@ -12,8 +12,7 @@ const {
 import computed from 'ember-computed-decorators'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 import layout from '../templates/components/frost-radio-button'
-import Events from '../utils/events'
-const {cloneEvent} = Events
+import {cloneEvent} from '../utils/utils'
 
 export default Component.extend(PropTypeMixin, {
   // == Properties  ============================================================

--- a/addon/components/frost-toggle.js
+++ b/addon/components/frost-toggle.js
@@ -13,8 +13,7 @@ import computed from 'ember-computed-decorators'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 import layout from '../templates/components/frost-toggle'
 import FrostEventsProxy from '../mixins/frost-events-proxy'
-import Events from '../utils/events'
-const {cloneEvent} = Events
+import {cloneEvent} from '../utils/utils'
 
 export default Component.extend(PropTypeMixin, FrostEventsProxy, {
   // == Properties ============================================================

--- a/addon/utils/events.js
+++ b/addon/utils/events.js
@@ -1,8 +1,5 @@
 import Ember from 'ember'
-const {
-  $,
-  deprecate
-} = Ember
+const {deprecate} = Ember
 
 export default {
   addProperty: function (event, frostEvent) {
@@ -46,13 +43,6 @@ export default {
         }
       })
     })
-  },
-
-  cloneEvent: function (event, target) {
-    let newEvent = $.Event(null, event)
-    let newTarget = $.clone(target)
-    newEvent.target = newTarget
-    return newEvent
   },
 
   map: {

--- a/addon/utils/utils.js
+++ b/addon/utils/utils.js
@@ -1,0 +1,11 @@
+import Ember from 'ember'
+const {$} = Ember
+
+export function cloneEvent (event, target) {
+  let newEvent = $.Event(null, event)
+  let newTarget = $.clone(target)
+
+  newEvent.target = newTarget
+
+  return newEvent
+}

--- a/tests/unit/components/frost-toggle-test.js
+++ b/tests/unit/components/frost-toggle-test.js
@@ -2,6 +2,7 @@ import {expect} from 'chai'
 import Ember from 'ember'
 const {run} = Ember
 import FrostEventsProxy from 'ember-frost-core/mixins/frost-events-proxy'
+import * as utils from 'ember-frost-core/utils/utils'
 import {describeComponent} from 'ember-mocha'
 import PropTypeMixin from 'ember-prop-types'
 import {
@@ -9,6 +10,7 @@ import {
   describe,
   it
 } from 'mocha'
+import sinon from 'sinon'
 
 describeComponent(
   'frost-toggle',
@@ -185,6 +187,60 @@ describeComponent(
           component.get('_isToggled'),
           '_isToggled returns false'
         ).to.be.false
+      })
+    })
+
+    describe('_changeTarget()', function () {
+      it('sets toggled state to "false"', function () {
+        const cloneEventStub = sinon.stub(utils, 'cloneEvent').returns({
+          target: { value: null }
+        })
+
+        run(() => {
+          component.set('_trueValue', 'testValueOn')
+          component.set('value', 'testValueOn')
+          component.set('_falseValue', 'testValueOff')
+        })
+
+        expect(
+          component._changeTarget({}, {}),
+          'target object is set to "false" toggled state'
+        ).to.eql({
+          target: {
+            state: false,
+            value: 'testValueOff'
+          }
+        })
+
+        expect(
+          cloneEventStub.called,
+          'cloneEvent() method is called'
+        ).to.be.true
+
+        utils.cloneEvent.restore()
+      })
+
+      it('sets toggled state to "true"', function () {
+        sinon.stub(utils, 'cloneEvent').returns({
+          target: { value: null }
+        })
+
+        run(() => {
+          component.set('_trueValue', 'testValueOn')
+          component.set('value', 'testValueOff')
+          component.set('_falseValue', 'testValueOff')
+        })
+
+        expect(
+          component._changeTarget({}, {}),
+          'target object is set to "true" toggled state'
+        ).to.eql({
+          target: {
+            state: true,
+            value: 'testValueOn'
+          }
+        })
+        utils.cloneEvent.restore()
       })
     })
   }


### PR DESCRIPTION
* **Added** unit tests for frost-toggle's _changeTarget()
* **Updated** location of cloneEvent()
* **Updated** frost-toggle.js and frost-radio-button.js to use new path for cloneEvent()

Closes: https://github.com/ciena-frost/ember-frost-core/issues/278