### PR TITLE
Fix Major Memory Leak by Uninitializing Perfect Scroll When Cleaning Up

### DIFF
--- a/addon/components/frost-scroll.js
+++ b/addon/components/frost-scroll.js
@@ -89,5 +89,6 @@ export default Component.extend(PropTypeMixin, {
     this.$().off('ps-y-reach-end', this._legacyScrollYEndHandler)
     this.$().off('ps-y-reach-end', this._scrollYEndHandler)
     this.$().off('ps-y-reach-start', this._scrollYStartHandler)
+    window.Ps.destroy(this.$()[0])
   })
 })


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixes** a major memory leak in `frost-scroll`

