### PR TITLE
Stop invoking child include() methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,8 +81,6 @@ module.exports = {
       this.app = app = app.app
     }
 
-    this.eachAddonInvoke('included', [app])
-
     this._super.included(app)
 
     if (app) {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "ember-elsewhere": "~0.4.1",
     "ember-export-application-global": "^1.0.5",
     "ember-hook": "^1.3.5",
-    "ember-load-initializers": "^0.5.1",
+    "ember-load-initializers": "^0.6.0",
     "ember-resolver": "^2.0.3",
     "ember-sinon": "~0.5.0",
     "ember-test-utils": "^1.1.2",


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

### Background

https://github.com/ciena-frost/ember-frost-core/pull/168 added this change, but according to https://github.com/null-null-null/ember-get-config/issues/10 it's no longer necessary as of `ember-get-config@0.1.8`. As it turns out, `ember-prop-types@3.0` (which we're currently using) is using `ember-get-config@0.1.11` (at the time of this PR) and so we should be safe to remove this. Plus, as of `ember-get-config@0.1.8` there's a depreciation notice when it's called again.  

# CHANGELOG

 * **Undo** the change from [#168](https://github.com/ciena-frost/ember-frost-core/pull/168) as it has been [rendered unnecessary](https://github.com/null-null-null/ember-get-config/issues/10) 
