### PR TITLE
Fixed text field clear and link icon

### DIFF
--- a/addon/styles/_frost-text.scss
+++ b/addon/styles/_frost-text.scss
@@ -16,13 +16,13 @@ $padding: 0 30 0 8px;
   min-width: 175px;
 
   &.is-clear-visible {
-    &.frost-text-clear {
+    .frost-text-clear {
       opacity: 1;
     }
   }
 
   &.is-clear-enabled {
-    &.frost-text-clear {
+    .frost-text-clear {
       cursor: pointer;
       pointer-events: auto;
     }

--- a/addon/templates/components/frost-link.hbs
+++ b/addon/templates/components/frost-link.hbs
@@ -15,7 +15,7 @@
     {{#if (eq priority 'primary')}}
       <div class='content text'>
         {{yield}}
-          <div class='svg'>{{frost-icon icon='new-tab'}}</div>
+          <div class='svg'>{{frost-icon icon='open-tabs'}}</div>
       </div>
     {{else if (eq priority 'secondary')}}
       <div class='content'>
@@ -31,7 +31,7 @@
   {{#if (eq priority 'primary')}}
     <div class='content text'>
       {{linkTitle}}
-        <div class='svg'>{{frost-icon icon='new-tab'}}</div>
+        <div class='svg'>{{frost-icon icon='open-tabs'}}</div>
     </div>
   {{else if (eq priority 'secondary')}}
     <div class='content'>

--- a/tests/integration/components/frost-link-test.js
+++ b/tests/integration/components/frost-link-test.js
@@ -214,7 +214,7 @@ describeComponent(
       `)
 
       expect(
-        this.$('.frost-icon-frost-new-tab'),
+        this.$('.frost-icon-frost-open-tabs'),
         'icon property is set'
       ).to.have.length(1)
     })


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** text input field clear. It now appears as expected
* **Fixed** primary link to use the new icon 'open-tabs'

