### PR TITLE
Remove unnecessary mutable cell check

### DIFF
--- a/addon/components/frost-button.js
+++ b/addon/components/frost-button.js
@@ -2,7 +2,7 @@
  * Component definition for the frost-button component
  */
 import Ember from 'ember'
-const {Component, Logger, ViewUtils, get, isEmpty, typeOf} = Ember
+const {Component, Logger, ViewUtils, get, isEmpty} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 import SpreadMixin from 'ember-spread'
@@ -221,18 +221,6 @@ export default Component.extend(SpreadMixin, PropTypeMixin, {
   },
   /* eslint-enable complexity */
 
-  _getOnClickHandler () {
-    if (typeOf(this.attrs.onClick) === 'function') {
-      return this.attrs.onClick
-    }
-    // For the case when handler is passed from component property and converted
-    // into mutable cell
-    if (typeOf(this.attrs.onClick) === 'object' &&
-      typeOf(this.attrs.onClick.value) === 'function') {
-      return this.attrs.onClick.value
-    }
-  },
-
   // == DOM Events ============================================================
 
   // FIXME: jsdoc
@@ -241,9 +229,9 @@ export default Component.extend(SpreadMixin, PropTypeMixin, {
       return true
     }
 
-    const onClickHandler = this._getOnClickHandler()
-    if (onClickHandler && !get(this, 'disabled')) {
-      onClickHandler(get(this, 'id'))
+    const onClick = this.get('onClick')
+    if (onClick && !get(this, 'disabled')) {
+      onClick(get(this, 'id'))
     }
   }),
 

--- a/addon/components/frost-button.js
+++ b/addon/components/frost-button.js
@@ -2,7 +2,7 @@
  * Component definition for the frost-button component
  */
 import Ember from 'ember'
-const {Component, Logger, ViewUtils, get, isEmpty} = Ember
+const {Component, Logger, ViewUtils, get, isEmpty, typeOf} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 import SpreadMixin from 'ember-spread'
@@ -230,7 +230,7 @@ export default Component.extend(SpreadMixin, PropTypeMixin, {
     }
 
     const onClick = this.get('onClick')
-    if (onClick && !get(this, 'disabled')) {
+    if (typeOf(onClick) === 'function' && !get(this, 'disabled')) {
       onClick(get(this, 'id'))
     }
   }),

--- a/addon/components/frost-button.js
+++ b/addon/components/frost-button.js
@@ -2,7 +2,7 @@
  * Component definition for the frost-button component
  */
 import Ember from 'ember'
-const {Component, Logger, ViewUtils, get, isEmpty, typeOf} = Ember
+const {Component, Logger, ViewUtils, isEmpty, typeOf} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 import SpreadMixin from 'ember-spread'
@@ -230,8 +230,8 @@ export default Component.extend(SpreadMixin, PropTypeMixin, {
     }
 
     const onClick = this.get('onClick')
-    if (typeOf(onClick) === 'function' && !get(this, 'disabled')) {
-      onClick(get(this, 'id'))
+    if (typeOf(onClick) === 'function' && !this.get('disabled')) {
+      onClick(this.get('id'))
     }
   }),
 

--- a/tests/unit/components/frost-button-test.js
+++ b/tests/unit/components/frost-button-test.js
@@ -468,53 +468,5 @@ describeComponent(
         ).to.include('tertiary')
       })
     })
-
-    describe('._getOnClickHandler()', function () {
-      beforeEach(function () {
-        component.attrs = {}
-      })
-
-      afterEach(function () {
-        component.attrs = null
-      })
-
-      it('returns handler when onClick attribute is a function', function () {
-        component.attrs.onClick = function () {}
-
-        expect(
-          component._getOnClickHandler(),
-          'onClick() is returned'
-        ).to.be.a('function')
-      })
-
-      it('returns handler when onClick attribute is an mutable cell object', function () {
-        component.attrs.onClick = {
-          value: function () {}
-        }
-
-        expect(
-          component._getOnClickHandler(),
-          'onClick() is returned'
-        ).to.be.a('function')
-      })
-
-      it('doesn\'t return handler when onClick is empty', function () {
-        component.attrs.onClick = undefined
-
-        expect(
-          component._getOnClickHandler(),
-          'onClick() is not returned'
-        ).to.be.an('undefined')
-      })
-
-      it('doesn\'t return handler when onClick is empty object', function () {
-        component.attrs.onClick = {}
-
-        expect(
-          component._getOnClickHandler(),
-          'onClick() is not returned'
-        ).to.be.an('undefined')
-      })
-    })
   }
 )


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
- **removed** `_getOnClickHandler()` and unnecessary mutable cell check.
