### PR TITLE
Fix index exports (+test)

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -18,7 +18,7 @@ export {default as SelectItem} from './components/frost-select-li'
 export {default as SelectOutlet} from './components/frost-select-outlet'
 export {default as Select} from './components/frost-select'
 export {default as Text} from './components/frost-text'
-export {default as TextArea} from './components/frost-text-area'
+export {default as Textarea} from './components/frost-textarea'
 export {default as Toggle} from './components/frost-toggle'
 
 export {default as HookableInput} from './components/hookable-input'

--- a/tests/unit/index-test.js
+++ b/tests/unit/index-test.js
@@ -1,0 +1,55 @@
+/**
+ * Unit test for the re-export index module
+ * May seem silly, but we had a bug where there was a typo in one of the modules being re-exported
+ * Making it so that no one could import anything directly from 'ember-frost-core'
+ */
+import {expect} from 'chai'
+import {describe, it} from 'mocha'
+import * as index from 'ember-frost-core'
+
+describe('Unit / index exports', function () {
+  const componentNames = [
+    'Button',
+    'Checkbox',
+    'Component',
+    'Icon',
+    'Link',
+    'Loading',
+    'MultiSelect',
+    'Password',
+    'RadioButton',
+    'RadioGroup',
+    'Scroll',
+    'SelectDropdown',
+    'SelectItem',
+    'SelectOutlet',
+    'Select',
+    'Text',
+    'Textarea',
+    'Toggle',
+    'HookableInput',
+    'HookableTextarea'
+  ]
+
+  componentNames.forEach((name) => {
+    it(`should export ${name}`, function () {
+      expect(index[name]).not.to.equal(undefined)
+    })
+  })
+
+  const mixinNames = [
+    'CssMixin',
+    'EventsProxyMixin',
+    'EventsMixin'
+  ]
+
+  mixinNames.forEach((name) => {
+    it(`should export ${name}`, function () {
+      expect(index[name]).not.to.equal(undefined)
+    })
+  })
+
+  it('should export utils', function () {
+    expect(index.utils).not.to.equal(undefined)
+  })
+})


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** a bug where the `addon/index.js` had a typo w.r.t. a module name and thus threw an error whenever anyone tried to import anything directly from `ember-frost-core`. 