### PR TITLE
Add prop-types to blueprints

### DIFF
--- a/blueprints/ember-frost-core/index.js
+++ b/blueprints/ember-frost-core/index.js
@@ -26,6 +26,7 @@ module.exports = {
             {name: 'ember-computed-decorators', target: '~0.2.0'},
             {name: 'ember-elsewhere', target: '~0.4.1'},
             {name: 'ember-hook', target: '^1.3.5'},
+            {name: 'ember-prop-types', target: '^3.0.0'},
             {name: 'ember-sinon', target: '^0.5.1'},
             {name: 'ember-test-utils', target: '^1.1.2'},
             {name: 'ember-truth-helpers', target: '^1.2.0'}


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Added** missing `ember-prop-types: ^3.0.0` to blueprints when installing `ember-frost-core`

