### PR TITLE
Fix typos

### DIFF
--- a/.bithoundrc
+++ b/.bithoundrc
@@ -2,4 +2,7 @@
   "critics": {
     "lint": {"engine": "none"}
   }
+  "dependencies": {
+    "mute": ["ember-cli"]
+  }
 }

--- a/docs/frost-select.md
+++ b/docs/frost-select.md
@@ -61,7 +61,7 @@ multipleSelected = [1, 2]
   data=data
   selected=singleSelected
   onChange=(action 'yourCallbackAction')
-}}}
+}}
 ```
 
 ### Multi select
@@ -70,7 +70,7 @@ multipleSelected = [1, 2]
   data=data
   onChange=(action 'yourCallbackAction')
   selected=multipleSelected
-}}}
+}}
 ```
 
 ### Simple single select w/ external filtering
@@ -79,7 +79,7 @@ multipleSelected = [1, 2]
   data=data
   onChange=(action 'yourCallbackAction')
   onInput=(action 'yourInputFilterCallbackAction')
-}}}
+}}
 ```
 
 ### Selecting by value


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** typo in `frost-select` readme (#351) 

