### PR TITLE
Making hook required for components

### DIFF
--- a/addon/components/frost-component.js
+++ b/addon/components/frost-component.js
@@ -19,7 +19,7 @@ export default Component.extend(PropTypesMixin, HookMixin, SpreadMixin, CssMixin
 
   propTypes: {
     // options
-    hook: PropTypes.string,
+    hook: PropTypes.string.isRequired,
     hookPrefix: PropTypes.string,
     hookQualifiers: PropTypes.object,
 


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* Marking `hook` as a required property for frost components (warning log)

