### PR TITLE
Fix number input border

### DIFF
--- a/addon/styles/_frost-text.scss
+++ b/addon/styles/_frost-text.scss
@@ -69,6 +69,12 @@ $padding: 0 30px 0 8px;
     border: 0;
   }
 
+  // Note: without this Firefox ends up applying the read-only pseudo selector
+  // to number inputs which causes them not to get a border.
+  &[type='number'] {
+    border: 1px solid $frost-color-input-border;
+  }
+
   &:disabled {
     border: $disabled-border;
     background-color: $disabled-bg;


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** border on `frost-text` input with a `type` of `number`.

