### PR TITLE
Use blueprints instead of dependencies

### DIFF
--- a/blueprints/ember-frost-core/index.js
+++ b/blueprints/ember-frost-core/index.js
@@ -28,6 +28,7 @@ module.exports = {
             {name: 'ember-hook', target: '^1.4.0'},
             {name: 'ember-prop-types', target: '^3.0.0'},
             {name: 'ember-sinon', target: '^0.5.1'},
+            {name: 'ember-spread', target: '^1.0.0'},
             {name: 'ember-test-utils', target: '^1.1.2'},
             {name: 'ember-truth-helpers', target: '^1.2.0'}
           ]

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
     "ember-cli": "~2.8.0",
-    "ember-cli-chai": "^0.2.0",
+    "ember-cli-chai": "^0.3.1",
     "ember-cli-code-coverage": "0.3.5",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
@@ -57,8 +57,10 @@
     "ember-export-application-global": "^1.0.5",
     "ember-hook": "^1.4.0",
     "ember-load-initializers": "^0.6.0",
+    "ember-prop-types": "^3.0.0",
     "ember-resolver": "^2.0.3",
     "ember-sinon": "^0.6.0",
+    "ember-spread": "^1.0.0",
     "ember-test-utils": "^1.3.1",
     "ember-truth-helpers": "^1.2.0",
     "eslint": "^3.0.0",
@@ -97,8 +99,6 @@
     "ember-cli-sass": "^5.6.0",
     "ember-cli-string-utils": "^1.0.0",
     "ember-cli-valid-component-name": "^1.0.0",
-    "ember-prop-types": "^3.0.0",
-    "ember-spread": "^0.0.7",
     "npm-install-security-check": "^1.0.0"
   }
 }


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** dependencies to be included via blueprints instead of installed as direct npm dependencies of this addon.
