### PR TITLE
Update button tests

### DIFF
--- a/tests/integration/components/frost-button-test.js
+++ b/tests/integration/components/frost-button-test.js
@@ -1,347 +1,342 @@
 import {expect} from 'chai'
 import {$hook} from 'ember-hook'
-import {describeComponent, it} from 'ember-mocha'
+import {setupComponentTest} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
-import {describe} from 'mocha'
+import {describe, it} from 'mocha'
 import sinon from 'sinon'
 
-describeComponent(
-  'frost-button',
-  'Integration: FrostButtonComponent',
-  {
-    integration: true
-  },
-  function () {
-    it('renders a text button as expected', function () {
-      this.render(hbs`
-        {{frost-button text='Text'}}
-      `)
+describe('Integration: FrostButtonComponent', function () {
+  setupComponentTest('frost-button', {integration: true})
 
-      expect(
-        this.$('.text'),
-        'Text button has the correct class'
-      ).to.have.length(1)
+  it('renders a text button as expected', function () {
+    this.render(hbs`
+      {{frost-button text='Text'}}
+    `)
 
-      expect(
-        this.$('.frost-button').text().trim(),
-        'Text is set correctly'
-      ).to.eql('Text')
-    })
+    expect(
+      this.$('.text'),
+      'Text button has the correct class'
+    ).to.have.length(1)
 
-    it('renders an icon button as expected', function () {
-      this.render(hbs`
-        {{frost-button icon='icon'}}
-      `)
+    expect(
+      this.$('.frost-button').text().trim(),
+      'Text is set correctly'
+    ).to.eql('Text')
+  })
 
-      expect(
-        this.$('.icon'),
-        'Icon button has the correct class'
-      ).to.have.length(1)
-    })
+  it('renders an icon button as expected', function () {
+    this.render(hbs`
+      {{frost-button icon='icon'}}
+    `)
 
-    it('renders a text and icon button as expected', function () {
-      this.render(hbs`
-        {{frost-button
-          icon='round-add'
-          text='Test'
-        }}
-      `)
+    expect(
+      this.$('.icon'),
+      'Icon button has the correct class'
+    ).to.have.length(1)
+  })
 
-      expect(
-        this.$('.frost-icon-frost-round-add'),
-        'includes expected icon'
-      ).to.have.length(1)
+  it('renders a text and icon button as expected', function () {
+    this.render(hbs`
+      {{frost-button
+        icon='round-add'
+        text='Test'
+      }}
+    `)
 
-      expect(
-        this.$('.icon-text'),
-        'Icon and Text button has the correct class'
-      ).to.have.length(1)
+    expect(
+      this.$('.frost-icon-frost-round-add'),
+      'includes expected icon'
+    ).to.have.length(1)
 
-      expect(
-        this.$('.frost-button').text().trim(),
-        'Button text is set'
-      ).to.eql('Test')
-    })
+    expect(
+      this.$('.icon-text'),
+      'Icon and Text button has the correct class'
+    ).to.have.length(1)
 
-    it('sets the hook property', function () {
-      this.render(hbs`
-        {{frost-button
-          hook='my-button'
-          icon='round-add'
-          text='Test'
-        }}
-      `)
+    expect(
+      this.$('.frost-button').text().trim(),
+      'Button text is set'
+    ).to.eql('Test')
+  })
 
-      expect(
-        $hook('my-button').text().trim(),
-        'Hook is set correctly'
-      ).to.equal('Test')
-    })
+  it('sets the hook property', function () {
+    this.render(hbs`
+      {{frost-button
+        hook='my-button'
+        icon='round-add'
+        text='Test'
+      }}
+    `)
 
-    describe('Priority property', function () {
-      it('has primary class set', function () {
-        this.render(hbs`
-          {{frost-button
-            priority='primary'
-            size='medium'
-            text='Text'
-          }}
-        `)
+    expect(
+      $hook('my-button').text().trim(),
+      'Hook is set correctly'
+    ).to.equal('Test')
+  })
 
-        expect(
-          this.$('.frost-button').hasClass('primary'),
-          'primary class is set'
-        ).to.equal(true)
-      })
-
-      it('has secondary class set', function () {
-        this.render(hbs`
-          {{frost-button
-            priority='secondary'
-            size='medium'
-            text='Text'
-          }}
-        `)
-
-        expect(
-          this.$('.frost-button').hasClass('secondary'),
-          'secondary class is set'
-        ).to.equal(true)
-      })
-
-      it('has tertiary class set', function () {
-        this.render(hbs`
-          {{frost-button
-            priority='tertiary'
-            size='medium'
-            text='Text'
-          }}
-        `)
-
-        expect(
-          this.$('.frost-button').hasClass('tertiary'),
-          'tertiary class is set'
-        ).to.equal(true)
-      })
-    })
-
-    describe('Size property', function () {
-      it('has small class set', function () {
-        this.render(hbs`
-          {{frost-button
-            priority='primary'
-            size='small'
-            text='Text'
-          }}
-        `)
-
-        expect(
-          this.$('.frost-button').hasClass('small'),
-          'small class is set'
-        ).to.equal(true)
-      })
-
-      it('has medium class set', function () {
-        this.render(hbs`
-          {{frost-button
-            priority='secondary'
-            size='medium'
-            text='Text'
-          }}
-        `)
-
-        expect(
-          this.$('.frost-button').hasClass('medium'),
-          'medium class is set'
-        ).to.equal(true)
-      })
-
-      it('has large class set', function () {
-        this.render(hbs`
-          {{frost-button
-            priority='secondary'
-            size='large'
-            text='Text'
-          }}
-        `)
-
-        expect(
-          this.$('.frost-button').hasClass('large'),
-          'large class is set'
-        ).to.equal(true)
-      })
-    })
-
-    describe('Design property', function () {
-      it('has info-bar class set', function () {
-        this.render(hbs`
-          {{frost-button
-            design='info-bar'
-            icon='icon'
-            text='Text'
-          }}
-        `)
-
-        expect(
-          this.$('.frost-button').hasClass('info-bar'),
-          'info-bar class is set'
-        ).to.equal(true)
-      })
-
-      it('has app-bar class set', function () {
-        this.render(hbs`
-          {{frost-button
-            design='app-bar'
-            icon='icon'
-            text='Text'
-          }}
-        `)
-
-        expect(
-          this.$('.frost-button').hasClass('app-bar'),
-          'app-bar class is set'
-        ).to.equal(true)
-      })
-
-      it('has tab class set', function () {
-        this.render(hbs`
-          {{frost-button
-            design='tab'
-            icon='icon'
-            text='Text'
-          }}
-        `)
-
-        expect(
-          this.$('.frost-button').hasClass('tab'),
-          'tab class is set'
-        ).to.equal(true)
-      })
-    })
-
-    it('sets autofocus property', function () {
-      this.render(hbs`
-        {{frost-button
-          priority='secondary'
-          size='small'
-          text='Testing'
-          autofocus=true
-        }}
-      `)
-
-      expect(
-        this.$('.frost-button').prop('autofocus'),
-        'autofocus class is set'
-      ).to.equal(true)
-    })
-
-    it('sets disabled property', function () {
-      this.render(hbs`
-        {{frost-button
-          priority='secondary'
-          size='small'
-          text='Testing'
-          disabled=true
-        }}
-      `)
-
-      expect(
-        this.$('.frost-button').prop('disabled'),
-        'disabled class is set'
-      ).to.equal(true)
-    })
-
-    it('sets title property', function () {
-      this.render(hbs`
-        {{frost-button
-          priority='secondary'
-          size='small'
-          text='Testing'
-          title="This is a button"
-        }}
-      `)
-
-      expect(
-        this.$('.frost-button').prop('title'),
-        'title class is set'
-      ).to.eql('This is a button')
-    })
-
-    it('sets vertical property', function () {
-      this.render(hbs`
-        {{frost-button
-          icon='add'
-          priority='primary'
-          size='medium'
-          text='Testing'
-          vertical=true
-        }}
-      `)
-
-      expect(
-        this.$('.frost-button').hasClass('vertical'),
-        'vertical class is set'
-      ).to.equal(true)
-    })
-
-    it('fires onClick closure action', function () {
-      const externalActionSpy = sinon.spy()
-
-      this.on('externalAction', externalActionSpy)
-
+  describe('Priority property', function () {
+    it('has primary class set', function () {
       this.render(hbs`
         {{frost-button
           priority='primary'
           size='medium'
           text='Text'
-          onClick=(action 'externalAction')
         }}
       `)
 
-      this.$('button').click()
-
       expect(
-        externalActionSpy.called,
-        'onClick closure action called'
+        this.$('.frost-button').hasClass('primary'),
+        'primary class is set'
       ).to.equal(true)
     })
 
-    it('fires onFocus closure action', function () {
-      const externalActionSpy = sinon.spy()
+    it('has secondary class set', function () {
+      this.render(hbs`
+        {{frost-button
+          priority='secondary'
+          size='medium'
+          text='Text'
+        }}
+      `)
 
-      this.on('externalAction', externalActionSpy)
+      expect(
+        this.$('.frost-button').hasClass('secondary'),
+        'secondary class is set'
+      ).to.equal(true)
+    })
 
+    it('has tertiary class set', function () {
+      this.render(hbs`
+        {{frost-button
+          priority='tertiary'
+          size='medium'
+          text='Text'
+        }}
+      `)
+
+      expect(
+        this.$('.frost-button').hasClass('tertiary'),
+        'tertiary class is set'
+      ).to.equal(true)
+    })
+  })
+
+  describe('Size property', function () {
+    it('has small class set', function () {
       this.render(hbs`
         {{frost-button
           priority='primary'
-          size='medium'
+          size='small'
           text='Text'
-          onFocus=(action 'externalAction')
         }}
       `)
 
-      this.$('button').trigger('focusin')
-
       expect(
-        externalActionSpy.called,
-        'onFocus closure action called'
+        this.$('.frost-button').hasClass('small'),
+        'small class is set'
       ).to.equal(true)
     })
 
-    it('renders a text button as expected using spread', function () {
+    it('has medium class set', function () {
       this.render(hbs`
-        {{frost-button options=(hash text='Text')}}
+        {{frost-button
+          priority='secondary'
+          size='medium'
+          text='Text'
+        }}
       `)
 
       expect(
-        this.$('.text'),
-        'Text button has the correct class'
-      ).to.have.length(1)
+        this.$('.frost-button').hasClass('medium'),
+        'medium class is set'
+      ).to.equal(true)
+    })
+
+    it('has large class set', function () {
+      this.render(hbs`
+        {{frost-button
+          priority='secondary'
+          size='large'
+          text='Text'
+        }}
+      `)
 
       expect(
-        this.$('.frost-button').text().trim(),
-        'Text is set correctly'
-      ).to.eql('Text')
+        this.$('.frost-button').hasClass('large'),
+        'large class is set'
+      ).to.equal(true)
     })
-  }
-)
+  })
+
+  describe('Design property', function () {
+    it('has info-bar class set', function () {
+      this.render(hbs`
+        {{frost-button
+          design='info-bar'
+          icon='icon'
+          text='Text'
+        }}
+      `)
+
+      expect(
+        this.$('.frost-button').hasClass('info-bar'),
+        'info-bar class is set'
+      ).to.equal(true)
+    })
+
+    it('has app-bar class set', function () {
+      this.render(hbs`
+        {{frost-button
+          design='app-bar'
+          icon='icon'
+          text='Text'
+        }}
+      `)
+
+      expect(
+        this.$('.frost-button').hasClass('app-bar'),
+        'app-bar class is set'
+      ).to.equal(true)
+    })
+
+    it('has tab class set', function () {
+      this.render(hbs`
+        {{frost-button
+          design='tab'
+          icon='icon'
+          text='Text'
+        }}
+      `)
+
+      expect(
+        this.$('.frost-button').hasClass('tab'),
+        'tab class is set'
+      ).to.equal(true)
+    })
+  })
+
+  it('sets autofocus property', function () {
+    this.render(hbs`
+      {{frost-button
+        priority='secondary'
+        size='small'
+        text='Testing'
+        autofocus=true
+      }}
+    `)
+
+    expect(
+      this.$('.frost-button').prop('autofocus'),
+      'autofocus class is set'
+    ).to.equal(true)
+  })
+
+  it('sets disabled property', function () {
+    this.render(hbs`
+      {{frost-button
+        priority='secondary'
+        size='small'
+        text='Testing'
+        disabled=true
+      }}
+    `)
+
+    expect(
+      this.$('.frost-button').prop('disabled'),
+      'disabled class is set'
+    ).to.equal(true)
+  })
+
+  it('sets title property', function () {
+    this.render(hbs`
+      {{frost-button
+        priority='secondary'
+        size='small'
+        text='Testing'
+        title="This is a button"
+      }}
+    `)
+
+    expect(
+      this.$('.frost-button').prop('title'),
+      'title class is set'
+    ).to.eql('This is a button')
+  })
+
+  it('sets vertical property', function () {
+    this.render(hbs`
+      {{frost-button
+        icon='add'
+        priority='primary'
+        size='medium'
+        text='Testing'
+        vertical=true
+      }}
+    `)
+
+    expect(
+      this.$('.frost-button').hasClass('vertical'),
+      'vertical class is set'
+    ).to.equal(true)
+  })
+
+  it('fires onClick closure action', function () {
+    const externalActionSpy = sinon.spy()
+
+    this.on('externalAction', externalActionSpy)
+
+    this.render(hbs`
+      {{frost-button
+        priority='primary'
+        size='medium'
+        text='Text'
+        onClick=(action 'externalAction')
+      }}
+    `)
+
+    this.$('button').click()
+
+    expect(
+      externalActionSpy.called,
+      'onClick closure action called'
+    ).to.equal(true)
+  })
+
+  it('fires onFocus closure action', function () {
+    const externalActionSpy = sinon.spy()
+
+    this.on('externalAction', externalActionSpy)
+
+    this.render(hbs`
+      {{frost-button
+        priority='primary'
+        size='medium'
+        text='Text'
+        onFocus=(action 'externalAction')
+      }}
+    `)
+
+    this.$('button').trigger('focusin')
+
+    expect(
+      externalActionSpy.called,
+      'onFocus closure action called'
+    ).to.equal(true)
+  })
+
+  it('renders a text button as expected using spread', function () {
+    this.render(hbs`
+      {{frost-button options=(hash text='Text')}}
+    `)
+
+    expect(
+      this.$('.text'),
+      'Text button has the correct class'
+    ).to.have.length(1)
+
+    expect(
+      this.$('.frost-button').text().trim(),
+      'Text is set correctly'
+    ).to.eql('Text')
+  })
+})

--- a/tests/integration/components/frost-button-test.js
+++ b/tests/integration/components/frost-button-test.js
@@ -1,12 +1,14 @@
 import {expect} from 'chai'
 import {$hook} from 'ember-hook'
-import {setupComponentTest} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
 import {describe, it} from 'mocha'
 import sinon from 'sinon'
 
-describe('Integration: FrostButtonComponent', function () {
-  setupComponentTest('frost-button', {integration: true})
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
+
+const test = integration('frost-button')
+describe(test.label, function () {
+  test.setup()
 
   it('renders a text button as expected', function () {
     this.render(hbs`

--- a/tests/integration/components/frost-button-test.js
+++ b/tests/integration/components/frost-button-test.js
@@ -1,7 +1,7 @@
 import {expect} from 'chai'
 import {$hook} from 'ember-hook'
 import hbs from 'htmlbars-inline-precompile'
-import {describe, it} from 'mocha'
+import {beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
 
 import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
@@ -10,335 +10,349 @@ const test = integration('frost-button')
 describe(test.label, function () {
   test.setup()
 
-  it('renders a text button as expected', function () {
-    this.render(hbs`
-      {{frost-button text='Text'}}
-    `)
+  describe('when setting text property', function () {
+    beforeEach(function () {
+      this.render(hbs`
+        {{frost-button text='Text'}}
+      `)
+    })
 
-    expect(
-      this.$('.text'),
-      'Text button has the correct class'
-    ).to.have.length(1)
+    it('should have the "text" class', function () {
+      expect(this.$('.text')).to.have.length(1)
+    })
 
-    expect(
-      this.$('.frost-button').text().trim(),
-      'Text is set correctly'
-    ).to.eql('Text')
+    it('should have the text set correctly', function () {
+      expect(this.$('.frost-button').text().trim()).to.equal('Text')
+    })
   })
 
-  it('renders an icon button as expected', function () {
-    this.render(hbs`
-      {{frost-button icon='icon'}}
-    `)
+  describe('when setting icon property', function () {
+    beforeEach(function () {
+      this.render(hbs`
+        {{frost-button icon='icon'}}
+      `)
+    })
 
-    expect(
-      this.$('.icon'),
-      'Icon button has the correct class'
-    ).to.have.length(1)
+    it('should have the "icon" class', function () {
+      expect(this.$('.icon')).to.have.length(1)
+    })
   })
 
-  it('renders a text and icon button as expected', function () {
-    this.render(hbs`
-      {{frost-button
-        icon='round-add'
-        text='Test'
-      }}
-    `)
+  describe('when setting text and icon together', function () {
+    beforeEach(function () {
+      this.render(hbs`
+        {{frost-button
+          icon='round-add'
+          text='Test'
+        }}
+      `)
+    })
 
-    expect(
-      this.$('.frost-icon-frost-round-add'),
-      'includes expected icon'
-    ).to.have.length(1)
+    it('should include the expected icon', function () {
+      expect(this.$('.frost-icon-frost-round-add')).to.have.length(1)
+    })
 
-    expect(
-      this.$('.icon-text'),
-      'Icon and Text button has the correct class'
-    ).to.have.length(1)
+    it('should have the "icon-text" class', function () {
+      expect(this.$('.icon-text')).to.have.length(1)
+    })
 
-    expect(
-      this.$('.frost-button').text().trim(),
-      'Button text is set'
-    ).to.eql('Test')
+    it('should have the proper button text', function () {
+      expect(this.$('.frost-button').text().trim()).to.equal('Test')
+    })
   })
 
-  it('sets the hook property', function () {
-    this.render(hbs`
-      {{frost-button
-        hook='my-button'
-        icon='round-add'
-        text='Test'
-      }}
-    `)
+  describe('when hook property is set', function () {
+    beforeEach(function () {
+      this.render(hbs`
+        {{frost-button
+          hook='my-button'
+          icon='round-add'
+          text='Test'
+        }}
+      `)
+    })
 
-    expect(
-      $hook('my-button').text().trim(),
-      'Hook is set correctly'
-    ).to.equal('Test')
+    it('should set the hook properly', function () {
+      expect($hook('my-button').text().trim()).to.equal('Test')
+    })
   })
 
   describe('Priority property', function () {
-    it('has primary class set', function () {
-      this.render(hbs`
-        {{frost-button
-          priority='primary'
-          size='medium'
-          text='Text'
-        }}
-      `)
+    describe('when it is "primary"', function () {
+      beforeEach(function () {
+        this.render(hbs`
+          {{frost-button
+            priority='primary'
+            size='medium'
+            text='Text'
+          }}
+        `)
+      })
 
-      expect(
-        this.$('.frost-button').hasClass('primary'),
-        'primary class is set'
-      ).to.equal(true)
+      it('should have "primary" class', function () {
+        expect(this.$('.frost-button')).to.have.class('primary')
+      })
     })
 
-    it('has secondary class set', function () {
-      this.render(hbs`
-        {{frost-button
-          priority='secondary'
-          size='medium'
-          text='Text'
-        }}
-      `)
+    describe('when it is "secondary"', function () {
+      beforeEach(function () {
+        this.render(hbs`
+          {{frost-button
+            priority='secondary'
+            size='medium'
+            text='Text'
+          }}
+        `)
+      })
 
-      expect(
-        this.$('.frost-button').hasClass('secondary'),
-        'secondary class is set'
-      ).to.equal(true)
+      it('should have "secondary" class', function () {
+        expect(this.$('.frost-button')).to.have.class('secondary')
+      })
     })
 
-    it('has tertiary class set', function () {
-      this.render(hbs`
-        {{frost-button
-          priority='tertiary'
-          size='medium'
-          text='Text'
-        }}
-      `)
+    describe('when it is "tertiary"', function () {
+      beforeEach(function () {
+        this.render(hbs`
+          {{frost-button
+            priority='tertiary'
+            size='medium'
+            text='Text'
+          }}
+        `)
+      })
 
-      expect(
-        this.$('.frost-button').hasClass('tertiary'),
-        'tertiary class is set'
-      ).to.equal(true)
+      it('should have "tertiary" class', function () {
+        expect(this.$('.frost-button')).to.have.class('tertiary')
+      })
     })
   })
 
   describe('Size property', function () {
-    it('has small class set', function () {
-      this.render(hbs`
-        {{frost-button
-          priority='primary'
-          size='small'
-          text='Text'
-        }}
-      `)
+    describe('when it is "small"', function () {
+      beforeEach(function () {
+        this.render(hbs`
+          {{frost-button
+            priority='primary'
+            size='small'
+            text='Text'
+          }}
+        `)
+      })
 
-      expect(
-        this.$('.frost-button').hasClass('small'),
-        'small class is set'
-      ).to.equal(true)
+      it('should have "small" class', function () {
+        expect(this.$('.frost-button')).to.have.class('small')
+      })
     })
 
-    it('has medium class set', function () {
-      this.render(hbs`
-        {{frost-button
-          priority='secondary'
-          size='medium'
-          text='Text'
-        }}
-      `)
+    describe('when it is "medium"', function () {
+      beforeEach(function () {
+        this.render(hbs`
+          {{frost-button
+            priority='primary'
+            size='medium'
+            text='Text'
+          }}
+        `)
+      })
 
-      expect(
-        this.$('.frost-button').hasClass('medium'),
-        'medium class is set'
-      ).to.equal(true)
+      it('should have "medium" class', function () {
+        expect(this.$('.frost-button')).to.have.class('medium')
+      })
     })
 
-    it('has large class set', function () {
-      this.render(hbs`
-        {{frost-button
-          priority='secondary'
-          size='large'
-          text='Text'
-        }}
-      `)
+    describe('when it is "large"', function () {
+      beforeEach(function () {
+        this.render(hbs`
+          {{frost-button
+            priority='primary'
+            size='large'
+            text='Text'
+          }}
+        `)
+      })
 
-      expect(
-        this.$('.frost-button').hasClass('large'),
-        'large class is set'
-      ).to.equal(true)
+      it('should have "large" class', function () {
+        expect(this.$('.frost-button')).to.have.class('large')
+      })
     })
   })
 
   describe('Design property', function () {
-    it('has info-bar class set', function () {
+    describe('when it is "info-bar"', function () {
+      beforeEach(function () {
+        this.render(hbs`
+          {{frost-button
+            design='info-bar'
+            icon='icon'
+            text='Text'
+          }}
+        `)
+      })
+
+      it('should have "info-bar" class', function () {
+        expect(this.$('.frost-button')).to.have.class('info-bar')
+      })
+    })
+
+    describe('when it is "app-bar"', function () {
+      beforeEach(function () {
+        this.render(hbs`
+          {{frost-button
+            design='app-bar'
+            icon='icon'
+            text='Text'
+          }}
+        `)
+      })
+
+      it('should have "app-bar" class', function () {
+        expect(this.$('.frost-button')).to.have.class('app-bar')
+      })
+    })
+
+    describe('when it is "tab"', function () {
+      beforeEach(function () {
+        this.render(hbs`
+          {{frost-button
+            design='tab'
+            icon='icon'
+            text='Text'
+          }}
+        `)
+      })
+
+      it('should have "tab" class', function () {
+        expect(this.$('.frost-button')).to.have.class('tab')
+      })
+    })
+  })
+
+  describe('when autofocus property is set', function () {
+    beforeEach(function () {
       this.render(hbs`
         {{frost-button
-          design='info-bar'
-          icon='icon'
+          priority='secondary'
+          size='small'
+          text='Testing'
+          autofocus=true
+        }}
+      `)
+    })
+
+    it('should set the "autofocus" property', function () {
+      expect(this.$('.frost-button')).to.have.prop('autofocus')
+    })
+  })
+
+  describe('when disabled property is set', function () {
+    beforeEach(function () {
+      this.render(hbs`
+        {{frost-button
+          priority='secondary'
+          size='small'
+          text='Testing'
+          disabled=true
+        }}
+      `)
+    })
+
+    it('should set the "disabled" property', function () {
+      expect(this.$('.frost-button')).to.have.prop('disabled')
+    })
+  })
+
+  describe('when title property is set', function () {
+    beforeEach(function () {
+      this.render(hbs`
+        {{frost-button
+          priority='secondary'
+          size='small'
+          text='Testing'
+          title="This is a button"
+        }}
+      `)
+    })
+
+    it('should set the "title" property', function () {
+      expect(this.$('.frost-button')).to.have.prop('title', 'This is a button')
+    })
+  })
+
+  describe('when veritcal property is set', function () {
+    beforeEach(function () {
+      this.render(hbs`
+        {{frost-button
+          icon='add'
+          priority='primary'
+          size='medium'
+          text='Testing'
+          vertical=true
+        }}
+      `)
+    })
+
+    it('should have the "vertical" class', function () {
+      expect(this.$('.frost-button')).to.have.class('vertical')
+    })
+  })
+
+  describe('when onClick is given and button is clicked', function () {
+    let handler
+    beforeEach(function () {
+      handler = sinon.spy()
+      this.setProperties({handler})
+      this.render(hbs`
+        {{frost-button
+          priority='primary'
+          size='medium'
           text='Text'
+          onClick=(action handler)
         }}
       `)
 
-      expect(
-        this.$('.frost-button').hasClass('info-bar'),
-        'info-bar class is set'
-      ).to.equal(true)
+      this.$('button').click()
     })
 
-    it('has app-bar class set', function () {
+    it('should call the handler', function () {
+      expect(handler).to.have.callCount(1)
+    })
+  })
+
+  describe('when onFocus is given and button is focused', function () {
+    let handler
+    beforeEach(function () {
+      handler = sinon.spy()
+      this.setProperties({handler})
       this.render(hbs`
         {{frost-button
-          design='app-bar'
-          icon='icon'
+          priority='primary'
+          size='medium'
           text='Text'
+          onFocus=(action handler)
         }}
       `)
 
-      expect(
-        this.$('.frost-button').hasClass('app-bar'),
-        'app-bar class is set'
-      ).to.equal(true)
+      this.$('button').trigger('focusin')
     })
 
-    it('has tab class set', function () {
+    it('should call the handler', function () {
+      expect(handler).to.have.callCount(1)
+    })
+  })
+
+  describe('when using spread to render a text button', function () {
+    beforeEach(function () {
       this.render(hbs`
-        {{frost-button
-          design='tab'
-          icon='icon'
-          text='Text'
-        }}
+        {{frost-button options=(hash text='Text')}}
       `)
-
-      expect(
-        this.$('.frost-button').hasClass('tab'),
-        'tab class is set'
-      ).to.equal(true)
     })
-  })
 
-  it('sets autofocus property', function () {
-    this.render(hbs`
-      {{frost-button
-        priority='secondary'
-        size='small'
-        text='Testing'
-        autofocus=true
-      }}
-    `)
+    it('should have the "text" class', function () {
+      expect(this.$('.text')).to.have.length(1)
+    })
 
-    expect(
-      this.$('.frost-button').prop('autofocus'),
-      'autofocus class is set'
-    ).to.equal(true)
-  })
-
-  it('sets disabled property', function () {
-    this.render(hbs`
-      {{frost-button
-        priority='secondary'
-        size='small'
-        text='Testing'
-        disabled=true
-      }}
-    `)
-
-    expect(
-      this.$('.frost-button').prop('disabled'),
-      'disabled class is set'
-    ).to.equal(true)
-  })
-
-  it('sets title property', function () {
-    this.render(hbs`
-      {{frost-button
-        priority='secondary'
-        size='small'
-        text='Testing'
-        title="This is a button"
-      }}
-    `)
-
-    expect(
-      this.$('.frost-button').prop('title'),
-      'title class is set'
-    ).to.eql('This is a button')
-  })
-
-  it('sets vertical property', function () {
-    this.render(hbs`
-      {{frost-button
-        icon='add'
-        priority='primary'
-        size='medium'
-        text='Testing'
-        vertical=true
-      }}
-    `)
-
-    expect(
-      this.$('.frost-button').hasClass('vertical'),
-      'vertical class is set'
-    ).to.equal(true)
-  })
-
-  it('fires onClick closure action', function () {
-    const externalActionSpy = sinon.spy()
-
-    this.on('externalAction', externalActionSpy)
-
-    this.render(hbs`
-      {{frost-button
-        priority='primary'
-        size='medium'
-        text='Text'
-        onClick=(action 'externalAction')
-      }}
-    `)
-
-    this.$('button').click()
-
-    expect(
-      externalActionSpy.called,
-      'onClick closure action called'
-    ).to.equal(true)
-  })
-
-  it('fires onFocus closure action', function () {
-    const externalActionSpy = sinon.spy()
-
-    this.on('externalAction', externalActionSpy)
-
-    this.render(hbs`
-      {{frost-button
-        priority='primary'
-        size='medium'
-        text='Text'
-        onFocus=(action 'externalAction')
-      }}
-    `)
-
-    this.$('button').trigger('focusin')
-
-    expect(
-      externalActionSpy.called,
-      'onFocus closure action called'
-    ).to.equal(true)
-  })
-
-  it('renders a text button as expected using spread', function () {
-    this.render(hbs`
-      {{frost-button options=(hash text='Text')}}
-    `)
-
-    expect(
-      this.$('.text'),
-      'Text button has the correct class'
-    ).to.have.length(1)
-
-    expect(
-      this.$('.frost-button').text().trim(),
-      'Text is set correctly'
-    ).to.eql('Text')
+    it('should have the proper text value', function () {
+      expect(this.$('.frost-button').text().trim()).to.equal('Text')
+    })
   })
 })

--- a/tests/unit/components/frost-button-test.js
+++ b/tests/unit/components/frost-button-test.js
@@ -2,456 +2,451 @@ import {expect} from 'chai'
 import Ember from 'ember'
 const {Logger, run} = Ember
 import Component from 'ember-frost-core/components/frost-component'
-import {describeComponent} from 'ember-mocha'
+import {setupComponentTest} from 'ember-mocha'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
 
-describeComponent(
-  'frost-button',
-  'Unit: FrostButtonComponent',
-  {
-    unit: true
-  },
-  function () {
-    let component
+describe('Unit: FrostButtonComponent', function () {
+  setupComponentTest('frost-button', {unit: true})
 
-    beforeEach(function () {
-      component = this.subject()
-    })
+  let component
 
-    it('sets default property values correctly', function () {
+  beforeEach(function () {
+    component = this.subject()
+  })
+
+  it('sets default property values correctly', function () {
+    expect(
+      component.get('tagName'),
+      'tagName: "button"'
+    ).to.eql('button')
+
+    expect(
+      component.get('autofocus'),
+      'autofocus: false'
+    ).to.equal(false)
+
+    expect(
+      component.get('design'),
+      'design: ""'
+    ).to.eql('')
+
+    expect(
+      component.get('disabled'),
+      'disabled: false'
+    ).to.equal(false)
+
+    expect(
+      component.get('hook'),
+      'hook: "undefined"'
+    ).to.equal(undefined)
+
+    expect(
+      component.get('icon'),
+      'icon: ""'
+    ).to.eql('')
+
+    expect(
+      component.get('pack'),
+      'pack: "frost"'
+    ).to.eql('frost')
+
+    expect(
+      component.get('priority'),
+      'priority: ""'
+    ).to.eql('')
+
+    expect(
+      component.get('size'),
+      'size: ""'
+    ).to.eql('')
+
+    expect(
+      component.get('text'),
+      'text: ""'
+    ).to.eql('')
+
+    expect(
+      component.get('title'),
+      'title: null'
+    ).to.equal(null)
+
+    expect(
+      component.get('type'),
+      'type: "button"'
+    ).to.eql('button')
+
+    expect(
+      component.get('vertical'),
+      'vertical: false'
+    ).to.equal(false)
+  })
+
+  it('sets dependent keys correctly', function () {
+    const isTextOnlyDependentKeys = [
+      'icon',
+      'text'
+    ]
+
+    const isIconOnlyDependentKeys = [
+      'icon',
+      'text'
+    ]
+
+    const isIconAndTextDependentKeys = [
+      'icon',
+      'text'
+    ]
+
+    const extraClassesDependentKeys = [
+      'design',
+      'icon',
+      'priority',
+      'size',
+      'text',
+      'vertical'
+    ]
+
+    expect(
+      component.isTextOnly._dependentKeys,
+      'Dependent keys are correct for isTextOnly()'
+    ).to.eql(isTextOnlyDependentKeys)
+
+    expect(
+      component.isIconOnly._dependentKeys,
+      'Dependent keys are correct for isIconOnly()'
+    ).to.eql(isIconOnlyDependentKeys)
+
+    expect(
+      component.isIconAndText._dependentKeys,
+      'Dependent keys are correct for isIconAndText()'
+    ).to.eql(isIconAndTextDependentKeys)
+
+    expect(
+      component.extraClasses._dependentKeys,
+      'Dependent keys are correct for extraClasses()'
+    ).to.eql(extraClassesDependentKeys)
+  })
+
+  it('extends the commone frost component', function () {
+    expect(
+      component instanceof Component,
+      'is instance of Frost Component'
+    ).to.equal(true)
+  })
+
+  describe('"isTextOnly" computed property', function () {
+    it('is set to "true" when "text" is set', function () {
+      const text = 'text'
+
+      run(() => component.set('text', text))
+
       expect(
-        component.get('tagName'),
-        'tagName: "button"'
-      ).to.eql('button')
-
-      expect(
-        component.get('autofocus'),
-        'autofocus: false'
-      ).to.equal(false)
-
-      expect(
-        component.get('design'),
-        'design: ""'
-      ).to.eql('')
-
-      expect(
-        component.get('disabled'),
-        'disabled: false'
-      ).to.equal(false)
-
-      expect(
-        component.get('hook'),
-        'hook: "undefined"'
-      ).to.equal(undefined)
-
-      expect(
-        component.get('icon'),
-        'icon: ""'
-      ).to.eql('')
-
-      expect(
-        component.get('pack'),
-        'pack: "frost"'
-      ).to.eql('frost')
-
-      expect(
-        component.get('priority'),
-        'priority: ""'
-      ).to.eql('')
-
-      expect(
-        component.get('size'),
-        'size: ""'
-      ).to.eql('')
-
-      expect(
-        component.get('text'),
-        'text: ""'
-      ).to.eql('')
-
-      expect(
-        component.get('title'),
-        'title: null'
-      ).to.equal(null)
-
-      expect(
-        component.get('type'),
-        'type: "button"'
-      ).to.eql('button')
-
-      expect(
-        component.get('vertical'),
-        'vertical: false'
-      ).to.equal(false)
-    })
-
-    it('sets dependent keys correctly', function () {
-      const isTextOnlyDependentKeys = [
-        'icon',
-        'text'
-      ]
-
-      const isIconOnlyDependentKeys = [
-        'icon',
-        'text'
-      ]
-
-      const isIconAndTextDependentKeys = [
-        'icon',
-        'text'
-      ]
-
-      const extraClassesDependentKeys = [
-        'design',
-        'icon',
-        'priority',
-        'size',
-        'text',
-        'vertical'
-      ]
-
-      expect(
-        component.isTextOnly._dependentKeys,
-        'Dependent keys are correct for isTextOnly()'
-      ).to.eql(isTextOnlyDependentKeys)
-
-      expect(
-        component.isIconOnly._dependentKeys,
-        'Dependent keys are correct for isIconOnly()'
-      ).to.eql(isIconOnlyDependentKeys)
-
-      expect(
-        component.isIconAndText._dependentKeys,
-        'Dependent keys are correct for isIconAndText()'
-      ).to.eql(isIconAndTextDependentKeys)
-
-      expect(
-        component.extraClasses._dependentKeys,
-        'Dependent keys are correct for extraClasses()'
-      ).to.eql(extraClassesDependentKeys)
-    })
-
-    it('extends the commone frost component', function () {
-      expect(
-        component instanceof Component,
-        'is instance of Frost Component'
+        component.get('isTextOnly'),
+        'isTextOnly: true'
       ).to.equal(true)
     })
 
-    describe('"isTextOnly" computed property', function () {
-      it('is set to "true" when "text" is set', function () {
-        const text = 'text'
+    it('is set to "false" when "icon" and "text" are both set', function () {
+      const icon = 'round-add'
+      const text = 'text'
 
-        run(() => component.set('text', text))
-
-        expect(
-          component.get('isTextOnly'),
-          'isTextOnly: true'
-        ).to.equal(true)
+      run(() => {
+        component.set('icon', icon)
+        component.set('text', text)
       })
 
-      it('is set to "false" when "icon" and "text" are both set', function () {
-        const icon = 'round-add'
-        const text = 'text'
+      expect(
+        component.get('isTextOnly'),
+        'isTextOnly: false'
+      ).to.equal(false)
+    })
+  })
 
-        run(() => {
-          component.set('icon', icon)
-          component.set('text', text)
-        })
+  describe('"isIconOnly" computed property', function () {
+    it('is set to "true" when "icon" is set', function () {
+      const icon = 'icon'
 
-        expect(
-          component.get('isTextOnly'),
-          'isTextOnly: false'
-        ).to.equal(false)
-      })
+      run(() => component.set('icon', icon))
+
+      expect(
+        component.get('isIconOnly'),
+        'isIconOnly: true'
+      ).to.equal(true)
     })
 
-    describe('"isIconOnly" computed property', function () {
-      it('is set to "true" when "icon" is set', function () {
-        const icon = 'icon'
+    it('is set to "false" when "icon" and "text" are both set', function () {
+      const icon = 'round-add'
+      const text = 'text'
 
-        run(() => component.set('icon', icon))
-
-        expect(
-          component.get('isIconOnly'),
-          'isIconOnly: true'
-        ).to.equal(true)
+      run(() => {
+        component.set('icon', icon)
+        component.set('text', text)
       })
 
-      it('is set to "false" when "icon" and "text" are both set', function () {
-        const icon = 'round-add'
-        const text = 'text'
+      expect(
+        component.get('isIconOnly'),
+        'isIconOnly: false'
+      ).to.equal(false)
+    })
+  })
 
-        run(() => {
-          component.set('icon', icon)
-          component.set('text', text)
-        })
+  describe('"isIconAndText" computed property', function () {
+    it('is set to "false" when only "icon" is set', function () {
+      const icon = 'icon'
 
-        expect(
-          component.get('isIconOnly'),
-          'isIconOnly: false'
-        ).to.equal(false)
-      })
+      run(() => component.set('icon', icon))
+
+      expect(
+        component.get('isIconAndText'),
+        'isIconAndText: false'
+      ).to.equal(false)
     })
 
-    describe('"isIconAndText" computed property', function () {
-      it('is set to "false" when only "icon" is set', function () {
-        const icon = 'icon'
+    it('is set to "false" when only "text" is set', function () {
+      const text = 'text'
 
-        run(() => component.set('icon', icon))
+      run(() => component.set('text', text))
 
-        expect(
-          component.get('isIconAndText'),
-          'isIconAndText: false'
-        ).to.equal(false)
-      })
-
-      it('is set to "false" when only "text" is set', function () {
-        const text = 'text'
-
-        run(() => component.set('text', text))
-
-        expect(
-          component.get('isIconAndText'),
-          'isIconAndText: false'
-        ).to.equal(false)
-      })
-
-      it('is set to "true" when "icon" and "text" are both set', function () {
-        const icon = 'round-add'
-        const text = 'text'
-
-        run(() => {
-          component.set('icon', icon)
-          component.set('text', text)
-        })
-
-        expect(
-          component.get('isIconAndText'),
-          'isIconAndText: true'
-        ).to.equal(true)
-      })
+      expect(
+        component.get('isIconAndText'),
+        'isIconAndText: false'
+      ).to.equal(false)
     })
 
-    describe('"extraClasses" computed property', function () {
-      describe('design class', function () {
-        const validDesignClasses = [
-          {in: 'app-bar', out: 'app-bar'},
-          {in: 'info-bar', out: 'info-bar'},
-          {in: 'tab', out: 'tab'}
-        ]
+    it('is set to "true" when "icon" and "text" are both set', function () {
+      const icon = 'round-add'
+      const text = 'text'
 
-        validDesignClasses.forEach((test) => {
-          it(`includes "${test.out}" when design="${test.in}" is passed in`, function () {
-            const text = 'text'
+      run(() => {
+        component.set('icon', icon)
+        component.set('text', text)
+      })
 
-            run(() => {
-              component.set('design', test.in)
-              component.set('text', text)
-            })
+      expect(
+        component.get('isIconAndText'),
+        'isIconAndText: true'
+      ).to.equal(true)
+    })
+  })
 
-            expect(
-              component.get('extraClasses'),
-              `extraClasses: "${test.out}"`
-            ).to.eql(test.out)
-          })
-        })
+  describe('"extraClasses" computed property', function () {
+    describe('design class', function () {
+      const validDesignClasses = [
+        {in: 'app-bar', out: 'app-bar'},
+        {in: 'info-bar', out: 'info-bar'},
+        {in: 'tab', out: 'tab'}
+      ]
 
-        describe('"design" property must also have either "text" or "icon" set', function () {
-          const design = 'app-bar'
-
-          it('returns with no class set if either "text" or "icon" are not also set', function () {
-            run(() => component.set('design', design))
-
-            expect(
-              component.get('extraClasses'),
-              'Nothing is returned: must include either "text" or "icon"'
-            ).to.equal(undefined)
-          })
-
-          it('calls Ember.Logger.error if either "text" or "icon" are not also set', function () {
-            const EmberLoggerSpy = sinon.spy(Logger, 'error')
-
-            run(() => component.set('design', design))
-
-            component.get('extraClasses')
-
-            expect(
-              EmberLoggerSpy.called,
-              'Ember.Logger.error is called with error message'
-            ).to.equal(true)
-
-            Logger.error.restore()
-          })
-        })
-
-        describe('display warning on design property', function () {
-          const design = 'app-bar'
-          const priority = 'primary'
-          const size = 'medium'
+      validDesignClasses.forEach((test) => {
+        it(`includes "${test.out}" when design="${test.in}" is passed in`, function () {
           const text = 'text'
-          let EmberLoggerSpy
 
-          beforeEach(function () {
-            EmberLoggerSpy = sinon.spy(Logger, 'warn')
+          run(() => {
+            component.set('design', test.in)
+            component.set('text', text)
           })
 
-          afterEach(function () {
-            Logger.warn.restore()
-          })
-
-          it('is used with "priority" property', function () {
-            run(() => {
-              component.set('design', design)
-              component.set('priority', priority)
-              component.set('text', text)
-            })
-
-            component.get('extraClasses')
-
-            expect(
-              EmberLoggerSpy.called,
-              'Ember.Logger.warn is called with warn message'
-            ).to.equal(true)
-          })
-
-          it('is used with "size" property', function () {
-            run(() => {
-              component.set('design', design)
-              component.set('size', size)
-              component.set('text', text)
-            })
-
-            component.get('extraClasses')
-
-            expect(
-              EmberLoggerSpy.called,
-              'Ember.Logger.warn is called with warn message'
-            ).to.equal(true)
-          })
-
-          it('is used with "priority" and "size" properties', function () {
-            run(() => {
-              component.set('design', design)
-              component.set('priority', priority)
-              component.set('size', size)
-              component.set('text', text)
-            })
-
-            component.get('extraClasses')
-
-            expect(
-              EmberLoggerSpy.called,
-              'Ember.Logger.warn is called with warn message'
-            ).to.equal(true)
-          })
+          expect(
+            component.get('extraClasses'),
+            `extraClasses: "${test.out}"`
+          ).to.eql(test.out)
         })
       })
 
-      it('concatenates the classes when size, priority and vertical are set', function () {
+      describe('"design" property must also have either "text" or "icon" set', function () {
+        const design = 'app-bar'
+
+        it('returns with no class set if either "text" or "icon" are not also set', function () {
+          run(() => component.set('design', design))
+
+          expect(
+            component.get('extraClasses'),
+            'Nothing is returned: must include either "text" or "icon"'
+          ).to.equal(undefined)
+        })
+
+        it('calls Ember.Logger.error if either "text" or "icon" are not also set', function () {
+          const EmberLoggerSpy = sinon.spy(Logger, 'error')
+
+          run(() => component.set('design', design))
+
+          component.get('extraClasses')
+
+          expect(
+            EmberLoggerSpy.called,
+            'Ember.Logger.error is called with error message'
+          ).to.equal(true)
+
+          Logger.error.restore()
+        })
+      })
+
+      describe('display warning on design property', function () {
+        const design = 'app-bar'
         const priority = 'primary'
         const size = 'medium'
-        const vertical = true
+        const text = 'text'
+        let EmberLoggerSpy
 
-        run(() => {
-          component.set('size', size)
-          component.set('priority', priority)
-          component.set('vertical', vertical)
+        beforeEach(function () {
+          EmberLoggerSpy = sinon.spy(Logger, 'warn')
         })
 
-        expect(
-          component.get('extraClasses'),
-          '"extraClasses" is concatenated correctly'
-        ).to.eql('medium primary vertical')
-      })
+        afterEach(function () {
+          Logger.warn.restore()
+        })
 
-      describe('size class', function () {
-        const validSizes = [
-          {in: 'large', out: 'large'},
-          {in: 'medium', out: 'medium'},
-          {in: 'small', out: 'small'}
-        ]
-
-        validSizes.forEach((test) => {
-          it(`includes "${test.out}" when size="${test.in}" is passed in`, function () {
-            run(() => component.set('size', test.in))
-
-            expect(
-              component.get('extraClasses'),
-              `extraClasses: "${test.out}"`
-            ).to.eql(test.out)
+        it('is used with "priority" property', function () {
+          run(() => {
+            component.set('design', design)
+            component.set('priority', priority)
+            component.set('text', text)
           })
-        })
-      })
 
-      it('is set to "vertical" when "vertical=true" is passed in', function () {
-        const vertical = true
+          component.get('extraClasses')
 
-        run(() => component.set('vertical', vertical))
-
-        expect(
-          component.get('extraClasses'),
-          'extraClasses: "vertical"'
-        ).to.eql('vertical')
-      })
-
-      it('calls addPriorityClass to set the priority class', function () {
-        const addPriorityClassSpy = sinon.spy(component, 'addPriorityClass')
-        const priority = 'primary'
-        const testArray = [ priority ]
-
-        run(() => {
-          component.set('priority', priority)
+          expect(
+            EmberLoggerSpy.called,
+            'Ember.Logger.warn is called with warn message'
+          ).to.equal(true)
         })
 
-        const extraClasses = component.get('extraClasses')
+        it('is used with "size" property', function () {
+          run(() => {
+            component.set('design', design)
+            component.set('size', size)
+            component.set('text', text)
+          })
 
-        expect(
-          extraClasses,
-          'extraClasses: "primary"'
-        ).to.eql('primary')
+          component.get('extraClasses')
 
-        expect(
-          addPriorityClassSpy.calledWith(priority, testArray),
-          'addPriorityClass method called'
-        ).to.equal(true)
+          expect(
+            EmberLoggerSpy.called,
+            'Ember.Logger.warn is called with warn message'
+          ).to.equal(true)
+        })
+
+        it('is used with "priority" and "size" properties', function () {
+          run(() => {
+            component.set('design', design)
+            component.set('priority', priority)
+            component.set('size', size)
+            component.set('text', text)
+          })
+
+          component.get('extraClasses')
+
+          expect(
+            EmberLoggerSpy.called,
+            'Ember.Logger.warn is called with warn message'
+          ).to.equal(true)
+        })
       })
     })
 
-    describe('addPriorityClass', function () {
-      it('adds class primary', function () {
-        let testArray = []
+    it('concatenates the classes when size, priority and vertical are set', function () {
+      const priority = 'primary'
+      const size = 'medium'
+      const vertical = true
 
-        component.addPriorityClass('primary', testArray)
-
-        expect(
-          testArray,
-          'addPriorityClass adds class primary'
-        ).to.include('primary')
+      run(() => {
+        component.set('size', size)
+        component.set('priority', priority)
+        component.set('vertical', vertical)
       })
 
-      it('adds class secondary', function () {
-        let testArray = []
+      expect(
+        component.get('extraClasses'),
+        '"extraClasses" is concatenated correctly'
+      ).to.eql('medium primary vertical')
+    })
 
-        component.addPriorityClass('secondary', testArray)
+    describe('size class', function () {
+      const validSizes = [
+        {in: 'large', out: 'large'},
+        {in: 'medium', out: 'medium'},
+        {in: 'small', out: 'small'}
+      ]
 
-        expect(
-          testArray,
-          'addPriorityClass adds class secondary'
-        ).to.include('secondary')
-      })
+      validSizes.forEach((test) => {
+        it(`includes "${test.out}" when size="${test.in}" is passed in`, function () {
+          run(() => component.set('size', test.in))
 
-      it('adds class tertiary', function () {
-        let testArray = []
-
-        component.addPriorityClass('tertiary', testArray)
-
-        expect(
-          testArray,
-          'addPriorityClass adds class tertiary'
-        ).to.include('tertiary')
+          expect(
+            component.get('extraClasses'),
+            `extraClasses: "${test.out}"`
+          ).to.eql(test.out)
+        })
       })
     })
-  }
-)
+
+    it('is set to "vertical" when "vertical=true" is passed in', function () {
+      const vertical = true
+
+      run(() => component.set('vertical', vertical))
+
+      expect(
+        component.get('extraClasses'),
+        'extraClasses: "vertical"'
+      ).to.eql('vertical')
+    })
+
+    it('calls addPriorityClass to set the priority class', function () {
+      const addPriorityClassSpy = sinon.spy(component, 'addPriorityClass')
+      const priority = 'primary'
+      const testArray = [ priority ]
+
+      run(() => {
+        component.set('priority', priority)
+      })
+
+      const extraClasses = component.get('extraClasses')
+
+      expect(
+        extraClasses,
+        'extraClasses: "primary"'
+      ).to.eql('primary')
+
+      expect(
+        addPriorityClassSpy.calledWith(priority, testArray),
+        'addPriorityClass method called'
+      ).to.equal(true)
+    })
+  })
+
+  describe('addPriorityClass', function () {
+    it('adds class primary', function () {
+      let testArray = []
+
+      component.addPriorityClass('primary', testArray)
+
+      expect(
+        testArray,
+        'addPriorityClass adds class primary'
+      ).to.include('primary')
+    })
+
+    it('adds class secondary', function () {
+      let testArray = []
+
+      component.addPriorityClass('secondary', testArray)
+
+      expect(
+        testArray,
+        'addPriorityClass adds class secondary'
+      ).to.include('secondary')
+    })
+
+    it('adds class tertiary', function () {
+      let testArray = []
+
+      component.addPriorityClass('tertiary', testArray)
+
+      expect(
+        testArray,
+        'addPriorityClass adds class tertiary'
+      ).to.include('tertiary')
+    })
+  })
+})

--- a/tests/unit/components/frost-button-test.js
+++ b/tests/unit/components/frost-button-test.js
@@ -1,6 +1,6 @@
 import {expect} from 'chai'
 import Ember from 'ember'
-const {Logger, run} = Ember
+const {Logger} = Ember
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
 
@@ -11,444 +11,358 @@ const test = unit('frost-button')
 describe(test.label, function () {
   test.setup()
 
-  let component
+  let component, sandbox
 
   beforeEach(function () {
+    sandbox = sinon.sandbox.create()
     component = this.subject()
   })
 
-  it('sets default property values correctly', function () {
-    expect(
-      component.get('tagName'),
-      'tagName: "button"'
-    ).to.eql('button')
-
-    expect(
-      component.get('autofocus'),
-      'autofocus: false'
-    ).to.equal(false)
-
-    expect(
-      component.get('design'),
-      'design: ""'
-    ).to.eql('')
-
-    expect(
-      component.get('disabled'),
-      'disabled: false'
-    ).to.equal(false)
-
-    expect(
-      component.get('hook'),
-      'hook: "undefined"'
-    ).to.equal(undefined)
-
-    expect(
-      component.get('icon'),
-      'icon: ""'
-    ).to.eql('')
-
-    expect(
-      component.get('pack'),
-      'pack: "frost"'
-    ).to.eql('frost')
-
-    expect(
-      component.get('priority'),
-      'priority: ""'
-    ).to.eql('')
-
-    expect(
-      component.get('size'),
-      'size: ""'
-    ).to.eql('')
-
-    expect(
-      component.get('text'),
-      'text: ""'
-    ).to.eql('')
-
-    expect(
-      component.get('title'),
-      'title: null'
-    ).to.equal(null)
-
-    expect(
-      component.get('type'),
-      'type: "button"'
-    ).to.eql('button')
-
-    expect(
-      component.get('vertical'),
-      'vertical: false'
-    ).to.equal(false)
+  afterEach(function () {
+    sandbox.restore()
   })
 
-  it('sets dependent keys correctly', function () {
-    const isTextOnlyDependentKeys = [
-      'icon',
-      'text'
-    ]
-
-    const isIconOnlyDependentKeys = [
-      'icon',
-      'text'
-    ]
-
-    const isIconAndTextDependentKeys = [
-      'icon',
-      'text'
-    ]
-
-    const extraClassesDependentKeys = [
-      'design',
-      'icon',
-      'priority',
-      'size',
-      'text',
-      'vertical'
-    ]
-
-    expect(
-      component.isTextOnly._dependentKeys,
-      'Dependent keys are correct for isTextOnly()'
-    ).to.eql(isTextOnlyDependentKeys)
-
-    expect(
-      component.isIconOnly._dependentKeys,
-      'Dependent keys are correct for isIconOnly()'
-    ).to.eql(isIconOnlyDependentKeys)
-
-    expect(
-      component.isIconAndText._dependentKeys,
-      'Dependent keys are correct for isIconAndText()'
-    ).to.eql(isIconAndTextDependentKeys)
-
-    expect(
-      component.extraClasses._dependentKeys,
-      'Dependent keys are correct for extraClasses()'
-    ).to.eql(extraClassesDependentKeys)
+  it('should default tagName to button', function () {
+    expect(component.get('tagName')).to.equal('button')
   })
 
-  it('extends the commone frost component', function () {
-    expect(
-      component instanceof Component,
-      'is instance of Frost Component'
-    ).to.equal(true)
+  it('should default autofocus to false', function () {
+    expect(component.get('autofocus')).to.equal(false)
+  })
+
+  it('should default design to empty string', function () {
+    expect(component.get('design')).to.equal('')
+  })
+
+  it('should default disabled to false', function () {
+    expect(component.get('disabled')).to.equal(false)
+  })
+
+  it('should not default hook', function () {
+    expect(component.get('hook')).to.equal(undefined)
+  })
+
+  it('should default icon to empty string', function () {
+    expect(component.get('icon')).to.equal('')
+  })
+
+  it('should default pack to frost', function () {
+    expect(component.get('pack')).to.equal('frost')
+  })
+
+  it('should default priority to empty string', function () {
+    expect(component.get('priority')).to.equal('')
+  })
+
+  it('should default size to empty string', function () {
+    expect(component.get('size')).to.equal('')
+  })
+
+  it('should default text to empty string', function () {
+    expect(component.get('text')).to.equal('')
+  })
+
+  it('should default title to empty string', function () {
+    expect(component.get('text')).to.equal('')
+  })
+
+  it('should default type to button', function () {
+    expect(component.get('type')).to.equal('button')
+  })
+
+  it('should default vertical to false', function () {
+    expect(component.get('vertical')).to.equal(false)
+  })
+
+  it('should extend the common frost component', function () {
+    expect(component instanceof Component).to.equal(true)
   })
 
   describe('"isTextOnly" computed property', function () {
-    it('is set to "true" when "text" is set', function () {
-      const text = 'text'
-
-      run(() => component.set('text', text))
-
-      expect(
-        component.get('isTextOnly'),
-        'isTextOnly: true'
-      ).to.equal(true)
-    })
-
-    it('is set to "false" when "icon" and "text" are both set', function () {
-      const icon = 'round-add'
-      const text = 'text'
-
-      run(() => {
-        component.set('icon', icon)
-        component.set('text', text)
+    describe('when text alone is set', function () {
+      beforeEach(function () {
+        component.set('text', 'some text')
       })
 
-      expect(
-        component.get('isTextOnly'),
-        'isTextOnly: false'
-      ).to.equal(false)
+      it('should be true', function () {
+        expect(component.get('isTextOnly')).to.equal(true)
+      })
+    })
+
+    describe('when text and icon are set', function () {
+      beforeEach(function () {
+        component.setProperties({
+          icon: 'round-add',
+          text: 'some text'
+        })
+      })
+
+      it('should be false', function () {
+        expect(component.get('isTextOnly')).to.equal(false)
+      })
     })
   })
 
   describe('"isIconOnly" computed property', function () {
-    it('is set to "true" when "icon" is set', function () {
-      const icon = 'icon'
-
-      run(() => component.set('icon', icon))
-
-      expect(
-        component.get('isIconOnly'),
-        'isIconOnly: true'
-      ).to.equal(true)
-    })
-
-    it('is set to "false" when "icon" and "text" are both set', function () {
-      const icon = 'round-add'
-      const text = 'text'
-
-      run(() => {
-        component.set('icon', icon)
-        component.set('text', text)
+    describe('when icon alone is set', function () {
+      beforeEach(function () {
+        component.set('icon', 'round-add')
       })
 
-      expect(
-        component.get('isIconOnly'),
-        'isIconOnly: false'
-      ).to.equal(false)
+      it('should be true', function () {
+        expect(component.get('isIconOnly')).to.equal(true)
+      })
+    })
+
+    describe('when icon and text are set', function () {
+      beforeEach(function () {
+        component.setProperties({
+          icon: 'round-add',
+          text: 'some text'
+        })
+      })
+
+      it('should be false', function () {
+        expect(component.get('isIconOnly')).to.equal(false)
+      })
     })
   })
 
   describe('"isIconAndText" computed property', function () {
-    it('is set to "false" when only "icon" is set', function () {
-      const icon = 'icon'
-
-      run(() => component.set('icon', icon))
-
-      expect(
-        component.get('isIconAndText'),
-        'isIconAndText: false'
-      ).to.equal(false)
-    })
-
-    it('is set to "false" when only "text" is set', function () {
-      const text = 'text'
-
-      run(() => component.set('text', text))
-
-      expect(
-        component.get('isIconAndText'),
-        'isIconAndText: false'
-      ).to.equal(false)
-    })
-
-    it('is set to "true" when "icon" and "text" are both set', function () {
-      const icon = 'round-add'
-      const text = 'text'
-
-      run(() => {
-        component.set('icon', icon)
-        component.set('text', text)
+    describe('when icon alone is set', function () {
+      beforeEach(function () {
+        component.set('icon', 'round-add')
       })
 
-      expect(
-        component.get('isIconAndText'),
-        'isIconAndText: true'
-      ).to.equal(true)
+      it('should be false', function () {
+        expect(component.get('isIconAndText')).to.equal(false)
+      })
+    })
+
+    describe('when text alone is set', function () {
+      beforeEach(function () {
+        component.set('text', 'some text')
+      })
+
+      it('should be false', function () {
+        expect(component.get('isIconAndText')).to.equal(false)
+      })
+    })
+
+    describe('when icon and text are set', function () {
+      beforeEach(function () {
+        component.setProperties({
+          icon: 'round-add',
+          text: 'some text'
+        })
+      })
+
+      it('should be true', function () {
+        expect(component.get('isIconAndText')).to.equal(true)
+      })
     })
   })
 
   describe('"extraClasses" computed property', function () {
-    describe('design class', function () {
-      const validDesignClasses = [
-        {in: 'app-bar', out: 'app-bar'},
-        {in: 'info-bar', out: 'info-bar'},
-        {in: 'tab', out: 'tab'}
-      ]
+    const validDesignClasses = [
+      {in: 'app-bar', out: 'app-bar'},
+      {in: 'info-bar', out: 'info-bar'},
+      {in: 'tab', out: 'tab'}
+    ]
 
-      validDesignClasses.forEach((test) => {
-        it(`includes "${test.out}" when design="${test.in}" is passed in`, function () {
-          const text = 'text'
-
-          run(() => {
-            component.set('design', test.in)
-            component.set('text', text)
-          })
-
-          expect(
-            component.get('extraClasses'),
-            `extraClasses: "${test.out}"`
-          ).to.eql(test.out)
-        })
-      })
-
-      describe('"design" property must also have either "text" or "icon" set', function () {
-        const design = 'app-bar'
-
-        it('returns with no class set if either "text" or "icon" are not also set', function () {
-          run(() => component.set('design', design))
-
-          expect(
-            component.get('extraClasses'),
-            'Nothing is returned: must include either "text" or "icon"'
-          ).to.equal(undefined)
-        })
-
-        it('calls Ember.Logger.error if either "text" or "icon" are not also set', function () {
-          const EmberLoggerSpy = sinon.spy(Logger, 'error')
-
-          run(() => component.set('design', design))
-
-          component.get('extraClasses')
-
-          expect(
-            EmberLoggerSpy.called,
-            'Ember.Logger.error is called with error message'
-          ).to.equal(true)
-
-          Logger.error.restore()
-        })
-      })
-
-      describe('display warning on design property', function () {
-        const design = 'app-bar'
-        const priority = 'primary'
-        const size = 'medium'
-        const text = 'text'
-        let EmberLoggerSpy
-
+    validDesignClasses.forEach((test) => {
+      describe(`When design is set to "${test.in}"`, function () {
         beforeEach(function () {
-          EmberLoggerSpy = sinon.spy(Logger, 'warn')
+          component.setProperties({
+            design: test.in,
+            text: 'some text'
+          })
         })
 
-        afterEach(function () {
-          Logger.warn.restore()
+        it(`should include "${test.out}"`, function () {
+          expect(component.get('extraClasses')).to.include(test.out)
+        })
+      })
+    })
+
+    const validSizes = [
+      {in: 'large', out: 'large'},
+      {in: 'medium', out: 'medium'},
+      {in: 'small', out: 'small'}
+    ]
+
+    validSizes.forEach((test) => {
+      describe(`When size is set to "${test.in}"`, function () {
+        beforeEach(function () {
+          component.set('size', test.in)
         })
 
-        it('is used with "priority" property', function () {
-          run(() => {
-            component.set('design', design)
-            component.set('priority', priority)
-            component.set('text', text)
+        it(`should include "${test.out}"`, function () {
+          expect(component.get('extraClasses')).to.include(test.out)
+        })
+      })
+    })
+
+    const validPriorities = [
+      {in: 'primary', out: 'primary'},
+      {in: 'confirm', out: 'primary'},
+      {in: 'secondary', out: 'secondary'},
+      {in: 'normal', out: 'secondary'},
+      {in: 'tertiary', out: 'tertiary'},
+      {in: 'cancel', out: 'tertiary'}
+    ]
+
+    validPriorities.forEach((test) => {
+      describe(`When priority is set to "${test.in}"`, function () {
+        beforeEach(function () {
+          component.set('priority', test.in)
+        })
+
+        it(`should include "${test.out}"`, function () {
+          expect(component.get('extraClasses')).to.include(test.out)
+        })
+      })
+    })
+
+    describe('when "design" property is set', function () {
+      beforeEach(function () {
+        sandbox.spy(Logger, 'error')
+        sandbox.spy(Logger, 'warn')
+
+        component.set('design', 'app-bar')
+      })
+
+      describe('but neither "text" nor "icon" are set', function () {
+        let extraClasses
+        beforeEach(function () {
+          component.setProperties({
+            icon: '',
+            text: ''
           })
 
-          component.get('extraClasses')
-
-          expect(
-            EmberLoggerSpy.called,
-            'Ember.Logger.warn is called with warn message'
-          ).to.equal(true)
+          extraClasses = component.get('extraClasses')
         })
 
-        it('is used with "size" property', function () {
-          run(() => {
-            component.set('design', design)
-            component.set('size', size)
-            component.set('text', text)
+        it('should return with no class', function () {
+          expect(extraClasses).to.equal(undefined)
+        })
+
+        it('should log an error', function () {
+          const msg = 'Error: The `design` property requires `text` or `icon` property to be specified.'
+          expect(Logger.error).to.have.been.calledWith(msg)
+        })
+      })
+
+      describe('when "priority" is also set', function () {
+        let extraClasses
+        beforeEach(function () {
+          component.setProperties({
+            priority: 'primary',
+            text: 'some text'
           })
 
-          component.get('extraClasses')
-
-          expect(
-            EmberLoggerSpy.called,
-            'Ember.Logger.warn is called with warn message'
-          ).to.equal(true)
+          extraClasses = component.get('extraClasses')
         })
 
-        it('is used with "priority" and "size" properties', function () {
-          run(() => {
-            component.set('design', design)
-            component.set('priority', priority)
-            component.set('size', size)
-            component.set('text', text)
+        it('should log a warning', function () {
+          const msg = 'Warning: The `design` property takes precedence over `size` and `priority`.'
+          expect(Logger.warn).to.have.been.calledWith(msg)
+        })
+
+        it('should still include the design class', function () {
+          expect(extraClasses).to.include('app-bar')
+        })
+      })
+
+      describe('when "size" is also set', function () {
+        let extraClasses
+        beforeEach(function () {
+          component.setProperties({
+            size: 'small',
+            text: 'some text'
           })
 
-          component.get('extraClasses')
+          extraClasses = component.get('extraClasses')
+        })
 
-          expect(
-            EmberLoggerSpy.called,
-            'Ember.Logger.warn is called with warn message'
-          ).to.equal(true)
+        it('should log a warning', function () {
+          const msg = 'Warning: The `design` property takes precedence over `size` and `priority`.'
+          expect(Logger.warn).to.have.been.calledWith(msg)
+        })
+
+        it('should still include the design class', function () {
+          expect(extraClasses).to.include('app-bar')
+        })
+      })
+
+      describe('when "size" and "priority" are both also set', function () {
+        let extraClasses
+        beforeEach(function () {
+          component.setProperties({
+            priority: 'primary',
+            size: 'small',
+            text: 'some text'
+          })
+
+          extraClasses = component.get('extraClasses')
+        })
+
+        it('should log a warning', function () {
+          const msg = 'Warning: The `design` property takes precedence over `size` and `priority`.'
+          expect(Logger.warn).to.have.been.calledWith(msg)
+        })
+
+        it('should still include the design class', function () {
+          expect(extraClasses).to.include('app-bar')
         })
       })
     })
 
-    it('concatenates the classes when size, priority and vertical are set', function () {
-      const priority = 'primary'
-      const size = 'medium'
-      const vertical = true
-
-      run(() => {
-        component.set('size', size)
-        component.set('priority', priority)
-        component.set('vertical', vertical)
+    describe('When "vertical" is true', function () {
+      beforeEach(function () {
+        component.set('vertical', true)
       })
 
-      expect(
-        component.get('extraClasses'),
-        '"extraClasses" is concatenated correctly'
-      ).to.eql('medium primary vertical')
+      it('should include "vertical" class', function () {
+        expect(component.get('extraClasses')).to.include('vertical')
+      })
     })
 
-    describe('size class', function () {
-      const validSizes = [
-        {in: 'large', out: 'large'},
-        {in: 'medium', out: 'medium'},
-        {in: 'small', out: 'small'}
-      ]
+    describe('When "vertical" is false', function () {
+      beforeEach(function () {
+        component.set('vertical', false)
+      })
 
-      validSizes.forEach((test) => {
-        it(`includes "${test.out}" when size="${test.in}" is passed in`, function () {
-          run(() => component.set('size', test.in))
+      it('should not include "vertical" class', function () {
+        expect(component.get('extraClasses')).not.to.include('vertical')
+      })
+    })
 
-          expect(
-            component.get('extraClasses'),
-            `extraClasses: "${test.out}"`
-          ).to.eql(test.out)
+    describe('when "size", "priority", and "vertical" are all set', function () {
+      let extraClasses, priority, size
+      beforeEach(function () {
+        priority = 'primary'
+        size = 'medium'
+        component.setProperties({
+          priority,
+          size,
+          vertical: true
         })
-      })
-    })
 
-    it('is set to "vertical" when "vertical=true" is passed in', function () {
-      const vertical = true
-
-      run(() => component.set('vertical', vertical))
-
-      expect(
-        component.get('extraClasses'),
-        'extraClasses: "vertical"'
-      ).to.eql('vertical')
-    })
-
-    it('calls addPriorityClass to set the priority class', function () {
-      const addPriorityClassSpy = sinon.spy(component, 'addPriorityClass')
-      const priority = 'primary'
-      const testArray = [ priority ]
-
-      run(() => {
-        component.set('priority', priority)
+        extraClasses = component.get('extraClasses')
       })
 
-      const extraClasses = component.get('extraClasses')
+      it('should include the "priority" class', function () {
+        expect(extraClasses).to.include(priority)
+      })
 
-      expect(
-        extraClasses,
-        'extraClasses: "primary"'
-      ).to.eql('primary')
+      it('should include the "size" class', function () {
+        expect(extraClasses).to.include(size)
+      })
 
-      expect(
-        addPriorityClassSpy.calledWith(priority, testArray),
-        'addPriorityClass method called'
-      ).to.equal(true)
-    })
-  })
-
-  describe('addPriorityClass', function () {
-    it('adds class primary', function () {
-      let testArray = []
-
-      component.addPriorityClass('primary', testArray)
-
-      expect(
-        testArray,
-        'addPriorityClass adds class primary'
-      ).to.include('primary')
-    })
-
-    it('adds class secondary', function () {
-      let testArray = []
-
-      component.addPriorityClass('secondary', testArray)
-
-      expect(
-        testArray,
-        'addPriorityClass adds class secondary'
-      ).to.include('secondary')
-    })
-
-    it('adds class tertiary', function () {
-      let testArray = []
-
-      component.addPriorityClass('tertiary', testArray)
-
-      expect(
-        testArray,
-        'addPriorityClass adds class tertiary'
-      ).to.include('tertiary')
+      it('should include the "vertical" class', function () {
+        expect(extraClasses).to.include('vertical')
+      })
     })
   })
 })

--- a/tests/unit/components/frost-button-test.js
+++ b/tests/unit/components/frost-button-test.js
@@ -1,13 +1,15 @@
 import {expect} from 'chai'
 import Ember from 'ember'
 const {Logger, run} = Ember
-import Component from 'ember-frost-core/components/frost-component'
-import {setupComponentTest} from 'ember-mocha'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
 
-describe('Unit: FrostButtonComponent', function () {
-  setupComponentTest('frost-button', {unit: true})
+import {unit} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
+import Component from 'ember-frost-core/components/frost-component'
+
+const test = unit('frost-button')
+describe(test.label, function () {
+  test.setup()
 
   let component
 


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Updated** `frost-button` tests to use `setupComponentTest` instead of `describeComponent`
* **Updated** `frost-button` tests to use helpers from `ember-test-utils`
* **Refactored** `frost-button` tests to use more `describe` and `beforeEach` blocks to align more with [our testing conventions](https://github.com/ciena-frost/ember-frost-test#testing-conventions)