### PR TITLE
Getting the `css` class name binding to play nice with others

### DIFF
--- a/addon/mixins/css.js
+++ b/addon/mixins/css.js
@@ -3,7 +3,7 @@
  * The `css` property will be the introspected name of the component
  */
 import Ember from 'ember'
-const {Mixin} = Ember
+const {Mixin, isArray, isBlank} = Ember
 import {PropTypes} from 'ember-prop-types'
 
 export default Mixin.create({
@@ -11,8 +11,6 @@ export default Mixin.create({
   // == Dependencies ==========================================================
 
   // == Keyword Properties ====================================================
-
-  classNameBindings: ['css'],
 
   // == PropTypes =============================================================
 
@@ -48,9 +46,16 @@ export default Mixin.create({
    * It lets us test the functionality in the `init()` method w/o having to call
    * the real this._super() which was breaking when testing with tagName === '' for some reason
    */
-  maybeClearClassNameBindings () {
-    if (this.get('tagName') === '') {
-      this.set('classNameBindings', undefined)
+  setClassNameBindings () {
+    if (isBlank(this.get('tagName'))) {
+      return
+    }
+
+    const classNameBindings = this.get('classNameBindings')
+    if (isArray(classNameBindings)) {
+      classNameBindings.push('css')
+    } else {
+      this.set('classNameBindings', ['css'])
     }
   },
 
@@ -61,7 +66,7 @@ export default Mixin.create({
   // Strip classNameBindings from tagless components
   init () {
     this._super(...arguments)
-    this.maybeClearClassNameBindings()
+    this.setClassNameBindings()
   },
 
   // == Actions ===============================================================

--- a/tests/unit/mixins/css-test.js
+++ b/tests/unit/mixins/css-test.js
@@ -20,10 +20,6 @@ describe('Unit / Mixin / css', function () {
     sandbox.restore()
   })
 
-  it('has classNameBindings set to include "css"', function () {
-    expect(component.get('classNameBindings')).to.include('css')
-  })
-
   it('defaults "css" to the component name', function () {
     expect(component.get('css')).to.equal('css-component')
   })
@@ -41,23 +37,23 @@ describe('Unit / Mixin / css', function () {
 
   describe('.init()', function () {
     beforeEach(function () {
-      sandbox.stub(component, 'maybeClearClassNameBindings')
+      sandbox.stub(component, 'setClassNameBindings')
       component.init()
     })
 
-    it('should call .maybeClearClassNameBindings()', function () {
-      expect(component.maybeClearClassNameBindings).to.have.callCount(1)
+    it('should call .setClassNameBindings()', function () {
+      expect(component.setClassNameBindings).to.have.callCount(1)
     })
   })
 
-  describe('.maybeClearClassNameBindings()', function () {
+  describe('.setClassNameBindings()', function () {
     describe('when "tagName" is set', function () {
       beforeEach(function () {
         component.set('tagName', 'div')
-        component.maybeClearClassNameBindings()
+        component.setClassNameBindings()
       })
 
-      it('should leave "classNameBindings" alone', function () {
+      it('has classNameBindings set to include "css"', function () {
         expect(component.get('classNameBindings')).to.include('css')
       })
     })
@@ -65,11 +61,25 @@ describe('Unit / Mixin / css', function () {
     describe('when "tagName" is not blank', function () {
       beforeEach(function () {
         component.set('tagName', '')
-        component.maybeClearClassNameBindings()
+        component.setClassNameBindings()
       })
 
-      it('should remove "classNameBindings"', function () {
-        expect(component.get('classNameBindings')).to.equal(undefined)
+      it('should have empty "classNameBindings"', function () {
+        expect(component.get('classNameBindings')).to.eql([])
+      })
+    })
+
+    describe('when other "classNameBindings" are present', function () {
+      beforeEach(function () {
+        component.set('tagName', 'div')
+        component.set('classNameBindings', ['foo', 'bar'])
+        component.setClassNameBindings()
+      })
+
+      it('should merge the "classNameBindings"', function () {
+        expect(component.get('classNameBindings')).to.include('css')
+        expect(component.get('classNameBindings')).to.include('foo')
+        expect(component.get('classNameBindings')).to.include('bar')
       })
     })
   })


### PR DESCRIPTION
Fixed the css mixin to work with other classNameBindings

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* Fixed the css mixin to work with other classNameBindings
