### PR TITLE
Added min/max properties to frost-text

### DIFF
--- a/addon/components/frost-text.js
+++ b/addon/components/frost-text.js
@@ -29,6 +29,8 @@ export default Component.extend(FrostEventsProxyMixin, {
     isClearEnabled: PropTypes.bool,
     isClearVisible: PropTypes.bool,
     isHookEmbedded: PropTypes.bool,
+    max: PropTypes.number,
+    min: PropTypes.number,
     receivedHook: PropTypes.string,
     tabindex: PropTypes.number,
     type: PropTypes.string,

--- a/addon/templates/components/frost-text.hbs
+++ b/addon/templates/components/frost-text.hbs
@@ -8,7 +8,9 @@
   disabled=disabled
   form=form
   hook=(concat receivedHook '-input')
+  max=max
   maxlength=maxlength
+  min=min
   placeholder=placeholder
   readonly=readonly
   required=required

--- a/docs/frost-text.md
+++ b/docs/frost-text.md
@@ -22,7 +22,9 @@
 | | | `true` | disabled text field |
 | `form` | `string` | `<form-owner>` | form element that this is associated with (its form owner) |
 | `hook` | `string` | `<unique-name>` | name used for testing with ember-hook |
+| `max` | `number` | `<maximum-numerical-value>` | the maximum value, relevant when `type='number'` |
 | `maxlength` | `number` | `<maxlength-value>` | maximum number of characters a user can enter |
+| `min` | `number` | `<minimum-numerical-value>` | the minimum value, relevant when `type='number'` |
 | `options` | `object` | `{<attributes>}` | property object used to spread the attributes to the top level of the component with ember-spread. |
 | `placeholder` | `string` | `<text>` | placeholder text |
 | `readonly` | `boolean` | `false` | **default** - normal text field |
@@ -34,6 +36,8 @@
 | | | `default` | defer to default behavior |
 | `tabindex` | `number` | `<tabindex-value>` | the tabindex value |
 | `title` | `string` | `<tooltip-text>` | tooltip text to display on hover |
+| `type` | `string` | `text` | **default** - normal text field |
+| | | `number` | text field for entering a number |
 | `value` | `string` | `<value-text>` | text to be displayed in text field |
 
 ### Event Handlers

--- a/tests/integration/components/frost-text-test.js
+++ b/tests/integration/components/frost-text-test.js
@@ -121,6 +121,24 @@ describeComponent(
       ).to.equal(true)
     })
 
+    it('sets max property', function () {
+      const max = 30
+
+      this.set('max', max)
+
+      this.render(hbs`
+        {{frost-text
+          hook='myTextInput'
+          max=max
+        }}
+     `)
+
+      expect(
+        Number(this.$('input').prop('max')),
+        'max is set'
+      ).to.eql(max)
+    })
+
     it('sets maxlength property', function () {
       const maxlength = 30
 
@@ -137,6 +155,24 @@ describeComponent(
         this.$('input').prop('maxlength'),
         'maxlength is set'
       ).to.eql(maxlength)
+    })
+
+    it('sets min property', function () {
+      const min = 0
+
+      this.set('min', min)
+
+      this.render(hbs`
+        {{frost-text
+          hook='myTextInput'
+          min=min
+        }}
+     `)
+
+      expect(
+        Number(this.$('input').prop('min')),
+        'min is set'
+      ).to.eql(min)
     })
 
     it('sets placeholder property', function () {


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* Added min/max properties to `frost-text` component
