### PR TITLE
Added support for multiple routes

### DIFF
--- a/addon/components/frost-link.js
+++ b/addon/components/frost-link.js
@@ -7,7 +7,7 @@ import computed, {readOnly} from 'ember-computed-decorators'
 import {HookMixin} from 'ember-hook'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 import SpreadMixin from 'ember-spread'
-const {LinkComponent, Logger, deprecate, get, isEmpty, isPresent, run, set} = Ember
+const {LinkComponent, Logger, deprecate, isEmpty, isPresent, run, set} = Ember
 
 /**
  * List of valid values to pass into `design` propery
@@ -172,7 +172,7 @@ export default LinkComponent.extend(PropTypeMixin, HookMixin, SpreadMixin, {
    * @returns {boolean} true if we should open the link in the current tab and false otherwise
    */
   _shouldOpenInSameTab () {
-    return !(get(this, 'priority') === 'primary' && get(this, 'disabled') === false)
+    return !(this.get('priority') === 'primary' && this.get('disabled') === false)
   },
 
   /**
@@ -180,27 +180,27 @@ export default LinkComponent.extend(PropTypeMixin, HookMixin, SpreadMixin, {
    * @returns {boolean} true if we need to open multiple links on click and false otherwise
    */
   _hasMultipleLinks () {
-    return (get(this, 'routeNames') !== undefined && get(this, 'routeNames').length !== 0) ||
-      (get(this, 'routes') !== undefined && get(this, 'routes').length !== 0)
+    return (this.get('routeNames') !== undefined && this.get('routeNames').length !== 0) ||
+      (this.get('routes') !== undefined && this.get('routes').length !== 0)
   },
 
   /**
    * Open multiple links.
    */
   _openLinks () {
-    const routeNames = get(this, 'routeNames')
-    const routes = get(this, 'routes')
+    const routeNames = this.get('routeNames')
+    const routes = this.get('routes')
 
     if (!isEmpty(routeNames)) {
-      let models = get(this, 'models')
-      let queryParams = get(this, 'queryParams.values')
+      let models = this.get('models')
+      let queryParams = this.get('queryParams.values')
 
       routeNames.forEach((routeName) => {
         this._openLink(routeName, models, queryParams)
       })
     } else if (!isEmpty(routes)) {
-      routes.forEach((route) => {
-        this._openLink(get(route, 'name'), get(route, 'models'), get(route, 'queryParams'))
+      routes.forEach(({name, models, queryParams}) => {
+        this._openLink(name, models, queryParams)
       })
     }
   },
@@ -213,7 +213,7 @@ export default LinkComponent.extend(PropTypeMixin, HookMixin, SpreadMixin, {
    */
   _openLink (routeName, models, queryParams) {
     if (routeName) {
-      let routing = get(this, '_routing')
+      let routing = this.get('_routing')
       const url = routing.generateURL(routeName, models, queryParams)
       const windowHandler = window.open(url)
       if (!windowHandler) {
@@ -229,11 +229,11 @@ export default LinkComponent.extend(PropTypeMixin, HookMixin, SpreadMixin, {
   _setupRouting () {
     if (!this._shouldOpenInSameTab()) {
       if (this._hasMultipleLinks()) {
-        const params = get(this, 'params')
+        const params = this.get('params')
         // When we have the block format, LinkComponent expect a minimum of 1 element in params so we hardcode the
         // first parameter
         if (params && params.length === 0) {
-          params.push(get(this, '_routing.currentRouteName'))
+          params.push(this.get('_routing.currentRouteName'))
         }
 
         // Remove the link destination
@@ -248,9 +248,9 @@ export default LinkComponent.extend(PropTypeMixin, HookMixin, SpreadMixin, {
 
   _warnPropertyPrecedence () {
     let attributeName
-    if (get(this, 'routeName')) {
-      attributeName = 'routeName'
-    } else if (get(this, 'routes')) {
+    if (this.get('routeNames')) {
+      attributeName = 'routeNames'
+    } else if (this.get('routes')) {
       attributeName = 'routes'
     }
 
@@ -313,6 +313,9 @@ export default LinkComponent.extend(PropTypeMixin, HookMixin, SpreadMixin, {
 
       this.set('params', params)
     }
+
+    deprecate('routeNames attribute is deprecated, please use routes', isEmpty(this.get('routeNames')),
+      {id: 'ember-frost-core:link:routeNames', until: 'ember-frost-core@2.0.0'})
 
     this._super(...arguments)
   },

--- a/addon/components/frost-link.js
+++ b/addon/components/frost-link.js
@@ -206,7 +206,7 @@ export default LinkComponent.extend(PropTypeMixin, HookMixin, SpreadMixin, {
   },
 
   /**
-   * Open a link in a new window.
+   * Open a link in a new tabs.
    * @param {String} routeName the name of the route
    * @param {Array} models the route models
    * @param {Object} queryParams the route queryParams

--- a/addon/components/frost-link.js
+++ b/addon/components/frost-link.js
@@ -71,6 +71,11 @@ export default LinkComponent.extend(PropTypeMixin, HookMixin, SpreadMixin, {
     icon: PropTypes.string,
     priority: PropTypes.oneOf(validPriorities),
     routeNames: PropTypes.array,
+    routes: PropTypes.arrayOf(PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      models: PropTypes.array,
+      queryParams: PropTypes.object
+    })),
     size: PropTypes.oneOf(validSizes),
     linkTitle: PropTypes.string,
     onClick: PropTypes.func
@@ -86,6 +91,7 @@ export default LinkComponent.extend(PropTypeMixin, HookMixin, SpreadMixin, {
       icon: '',
       priority: '',
       routeNames: [],
+      routes: [],
       size: '',
       linkTitle: ''
     }
@@ -174,26 +180,45 @@ export default LinkComponent.extend(PropTypeMixin, HookMixin, SpreadMixin, {
    * @returns {boolean} true if we need to open multiple links on click and false otherwise
    */
   _hasMultipleLinks () {
-    return get(this, 'routeNames') !== undefined && get(this, 'routeNames').length !== 0
+    return (get(this, 'routeNames') !== undefined && get(this, 'routeNames').length !== 0) ||
+      (get(this, 'routes') !== undefined && get(this, 'routes').length !== 0)
   },
 
   /**
    * Open multiple links.
    */
   _openLinks () {
-    let routing = get(this, '_routing')
-    let models = get(this, 'models')
-    let queryParams = get(this, 'queryParams.values')
-
     const routeNames = get(this, 'routeNames')
+    const routes = get(this, 'routes')
 
-    if (routeNames) {
+    if (!isEmpty(routeNames)) {
+      let models = get(this, 'models')
+      let queryParams = get(this, 'queryParams.values')
+
       routeNames.forEach((routeName) => {
-        const windowHandler = window.open(routing.generateURL(routeName, models, queryParams))
-        if (!windowHandler) {
-          Logger.warn('Warning: Make sure that the pop-ups are not blocked')
-        }
+        this._openLink(routeName, models, queryParams)
       })
+    } else if (!isEmpty(routes)) {
+      routes.forEach((route) => {
+        this._openLink(get(route, 'name'), get(route, 'models'), get(route, 'queryParams'))
+      })
+    }
+  },
+
+  /**
+   * Open a link in a new window.
+   * @param {String} routeName the name of the route
+   * @param {Array} models the route models
+   * @param {Object} queryParams the route queryParams
+   */
+  _openLink (routeName, models, queryParams) {
+    if (routeName) {
+      let routing = get(this, '_routing')
+      const url = routing.generateURL(routeName, models, queryParams)
+      const windowHandler = window.open(url)
+      if (!windowHandler) {
+        Logger.warn('Warning: Make sure that the pop-ups are not blocked')
+      }
     }
   },
 
@@ -213,12 +238,24 @@ export default LinkComponent.extend(PropTypeMixin, HookMixin, SpreadMixin, {
 
         // Remove the link destination
         set(this, 'href', null)
-        if (get(this, 'routeName')) {
-          Logger.warn('Warning: The `routeNames` property takes precedence over `routeName`.')
-        }
+
+        this._warnPropertyPrecedence()
       } else {
         set(this, 'target', '_blank')
       }
+    }
+  },
+
+  _warnPropertyPrecedence () {
+    let attributeName
+    if (get(this, 'routeName')) {
+      attributeName = 'routeName'
+    } else if (get(this, 'routes')) {
+      attributeName = 'routes'
+    }
+
+    if (attributeName) {
+      Logger.warn(`Warning: The \`${attributeName}\` property takes precedence over \`routeName\`.`)
     }
   },
   // == DOM Events ============================================================

--- a/docs/frost-link.md
+++ b/docs/frost-link.md
@@ -16,7 +16,8 @@
 | `options` | `object` | `{<attributes>}` | property object used to spread the attributes to the top level of the component with ember-spread. |
 | `priority` | `string` | `primary` | primary link - opens content in a new tab |
 |  |  | `secondary` | secondary link - opens content in the same tab |
-| `routeNames` | `array` | `[...]` | list of the routes to open in new tabs on click <i>(only available for non disabled primary link)</i>. |
+| `routeNames` | `array` | `[...]` | list of the route names to open in new tabs on click <i>(only available for non disabled primary link)</i>. |
+| `routes` | `array` | `[...]` | list of the routes to open in new tabs on click <i>(only available for non disabled primary link)</i>. |
 | `size` | `string` | `small` | small size link |
 |  |  | `medium` | medium size link |
 |  |  | `large` | large size link |
@@ -47,10 +48,30 @@ The link component use ember-spread to `spread` a property object against the to
 }}
 ```
 
-### Primary - multiple routes
+### Primary - multiple routes names
 ```handlebars
 {{frost-link 'Text'
   routeNames=(array 'route name 1' 'route name 2')
+  hook='mySmallLink'
+  priority='primary'
+  size='small'
+}}
+```
+
+### Primary - multiple routes
+```handlebars
+{{frost-link 'Text'
+  routes=(array
+    (hash
+      name= 'route name 1'
+      models= (array '1')
+    )
+    (hash
+      name= 'route name 2'
+      models= (array '1' '2')
+    )
+  )
+  routeNames=(array '' 'route name 2')
   hook='mySmallLink'
   priority='primary'
   size='small'

--- a/tests/dummy/app/pods/link/template.hbs
+++ b/tests/dummy/app/pods/link/template.hbs
@@ -107,7 +107,7 @@
       </div>
     </div>
     <div class="example">
-      <div class="title">multiple routes</div>
+      <div class="title">multiple routes names</div>
       <div class="demo">
         {{frost-link 'Text'
           hook='myMultipleRoutesLink'
@@ -163,6 +163,45 @@
     }}
       Text
     {{/frost-link}}
+  ```"}}
+      </div>
+    </div>
+    <div class="example">
+      <div class="title">multiple routes</div>
+      <div class="demo">
+        {{frost-link 'Text'
+          hook='myMultipleRoutesLink'
+          priority='primary'
+          routes=(array
+            (hash
+              name= 'link.first'
+              models= (array '1')
+            )
+            (hash
+              name= 'link.first.second'
+              models= (array '1' '2')
+            )
+          )
+          size='small'
+        }}
+      </div>
+      <div class="snippet">
+        {{format-markdown "```handlebars
+    {{frost-link 'Text'
+      hook='myMultipleRoutesLink'
+      priority='primary'
+      routes=(array
+        (hash
+          name= 'link.first'
+          models= (array '1')
+        )
+        (hash
+          name= 'link.first.second'
+          models= (array '2')
+        )
+      )
+      size='small'
+    }}
   ```"}}
       </div>
     </div>
@@ -359,7 +398,7 @@
         {{#frost-link 'link.min'
           design='info-bar'
           hook='myInfoBarLink'
-          icon='infobar-find'
+          icon='round-add'
         }}
           Action
         {{/frost-link}}
@@ -369,7 +408,7 @@
 {{#frost-link 'link.min'
   design='info-bar'
   hook='myInfoBarLink'
-  icon='infobar-find'
+  icon='round-add'
 }}
   Action
 {{/frost-link}}
@@ -384,7 +423,7 @@
           disabled=true
           design='info-bar'
           hook='myDisabledInfoBarLink'
-          icon='infobar-find'
+          icon='round-add'
         }}
           Action
         {{/frost-link}}
@@ -395,7 +434,7 @@
   disabled=true
   hook='myDisabledInfoBarLink'
   design='info-bar'
-  icon='infobar-find'
+  icon='round-add'
 }}
   Action
 {{/frost-link}}

--- a/tests/dummy/app/pods/link/template.hbs
+++ b/tests/dummy/app/pods/link/template.hbs
@@ -134,7 +134,7 @@
       </div>
     </div>
     <div class="example">
-      <div class="title">multiple routes - block format</div>
+      <div class="title">multiple routes names - block format</div>
       <div class="demo">
         {{#frost-link
           hook='myMultipleRoutesBlockFormatLink'

--- a/tests/dummy/app/pods/link/template.hbs
+++ b/tests/dummy/app/pods/link/template.hbs
@@ -107,7 +107,7 @@
       </div>
     </div>
     <div class="example">
-      <div class="title">multiple routes names</div>
+      <div class="title">multiple routes names (deprecated)</div>
       <div class="demo">
         {{frost-link 'Text'
           hook='myMultipleRoutesLink'
@@ -134,7 +134,7 @@
       </div>
     </div>
     <div class="example">
-      <div class="title">multiple routes names - block format</div>
+      <div class="title">multiple routes names - block format (deprecated)</div>
       <div class="demo">
         {{#frost-link
           hook='myMultipleRoutesBlockFormatLink'


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

With the current implementation of `frost-link` we can open multiple tabs with different route names but not with different models or query params. I'm proposing this new implementation to be able to have different routes with different models and query params.

Current implementation:
```
{{frost-link 'Text'
      hook='myMultipleRoutesLink'
      priority='primary'
      routeNames=(array
        'link.min'
        'link.max'
      )
      size='small'
}}
```

New feature:
```
{{frost-link 'Text'
      hook='myMultipleRoutesLink'
      priority='primary'
      routes=(array
        (hash
          name= 'link.first'
          models= (array '1')
        )
        (hash
          name= 'link.first.second'
          models= (array '2')
        )
      )
      size='small'
}}
```

Note: 
* This is a proposition. Feel free to comment or reject.
* <b>There is no test in this PR<b>. I can raise an issue to add those. I will take care of it once our current task is done.

# CHANGELOG
* Added support for multiple routes for `frost-link`
