### PR TITLE
Fix select in demo

### DIFF
--- a/addon/components/frost-select-li.js
+++ b/addon/components/frost-select-li.js
@@ -2,29 +2,14 @@
  * Component definition for the frost-select-li component
  */
 import Ember from 'ember'
-const {get, on} = Ember
+const {on} = Ember
+import computed, {readOnly} from 'ember-computed-decorators'
 import {PropTypes} from 'ember-prop-types'
 
 import layout from '../templates/components/frost-select-li'
 import Component from './frost-component'
 
 const regexEscapeChars = '-[]/{}()*+?.^$|'.split('')
-
-// FIXME: jsdoc
-function getLabel (data, filter) {
-  if (filter) {
-    // Make sure special chars are escaped in filter so we can use it as a
-    // regular expression pattern
-    filter = filter.replace(`[${regexEscapeChars.join('\\')}]`, 'g')
-
-    const pattern = new RegExp(filter, 'gi')
-    const label = data.label.replace(pattern, '<u>$&</u>')
-
-    return Ember.String.htmlSafe(label)
-  }
-
-  return data && data.label || ''
-}
 
 export default Component.extend({
   // == Dependencies ==========================================================
@@ -51,6 +36,24 @@ export default Component.extend({
 
   // == Computed Properties ===================================================
 
+  @readOnly
+  @computed('data', 'filter')
+  // FIXME: jsdoc
+  label (data, filter) {
+    if (filter) {
+      // Make sure special chars are escaped in filter so we can use it as a
+      // regular expression pattern
+      filter = filter.replace(`[${regexEscapeChars.join('\\')}]`, 'g')
+
+      const pattern = new RegExp(filter, 'gi')
+      const label = data.label.replace(pattern, '<u>$&</u>')
+
+      return Ember.String.htmlSafe(label)
+    }
+
+    return data && data.label || ''
+  },
+
   // == Functions =============================================================
 
   // == DOM Events ============================================================
@@ -69,17 +72,6 @@ export default Component.extend({
   }),
 
   // == Lifecycle Hooks =======================================================
-
-  didReceiveAttrs (attrs) {
-    const data = get(attrs, 'newAttrs.data')
-    const filter = get(attrs, 'newAttrs.filter.value')
-    const newLabel = getLabel(data, filter)
-    const oldLabel = this.get('label')
-
-    if (newLabel !== oldLabel) {
-      this.set('label', newLabel)
-    }
-  },
 
   // == Actions ===============================================================
   actions: {}

--- a/addon/components/frost-select-li.js
+++ b/addon/components/frost-select-li.js
@@ -1,14 +1,30 @@
 /**
  * Component definition for the frost-select-li component
  */
+import Ember from 'ember'
+const {get, on} = Ember
+import {PropTypes} from 'ember-prop-types'
+
 import layout from '../templates/components/frost-select-li'
 import Component from './frost-component'
-import Ember from 'ember'
-import computed, {readOnly} from 'ember-computed-decorators'
-import {PropTypes} from 'ember-prop-types'
-const {on} = Ember
 
 const regexEscapeChars = '-[]/{}()*+?.^$|'.split('')
+
+// FIXME: jsdoc
+function getLabel (data, filter) {
+  if (filter) {
+    // Make sure special chars are escaped in filter so we can use it as a
+    // regular expression pattern
+    filter = filter.replace(`[${regexEscapeChars.join('\\')}]`, 'g')
+
+    const pattern = new RegExp(filter, 'gi')
+    const label = data.label.replace(pattern, '<u>$&</u>')
+
+    return Ember.String.htmlSafe(label)
+  }
+
+  return data && data.label || ''
+}
 
 export default Component.extend({
   // == Dependencies ==========================================================
@@ -35,24 +51,6 @@ export default Component.extend({
 
   // == Computed Properties ===================================================
 
-  @readOnly
-  @computed('data', 'filter')
-  // FIXME: jsdoc
-  label (data, filter) {
-    if (filter) {
-      // Make sure special chars are escaped in filter so we can use it as a
-      // regular expression pattern
-      filter = filter.replace(`[${regexEscapeChars.join('\\')}]`, 'g')
-
-      const pattern = new RegExp(filter, 'gi')
-      const label = data.label.replace(pattern, '<u>$&</u>')
-
-      return Ember.String.htmlSafe(label)
-    }
-
-    return data && data.label || ''
-  },
-
   // == Functions =============================================================
 
   // == DOM Events ============================================================
@@ -71,6 +69,17 @@ export default Component.extend({
   }),
 
   // == Lifecycle Hooks =======================================================
+
+  didReceiveAttrs (attrs) {
+    const data = get(attrs, 'newAttrs.data')
+    const filter = get(attrs, 'newAttrs.filter.value')
+    const newLabel = getLabel(data, filter)
+    const oldLabel = this.get('label')
+
+    if (newLabel !== oldLabel) {
+      this.set('label', newLabel)
+    }
+  },
 
   // == Actions ===============================================================
   actions: {}

--- a/addon/components/frost-select.js
+++ b/addon/components/frost-select.js
@@ -368,7 +368,9 @@ export default Component.extend({
       const onChange = this.get('onChange')
 
       if (typeOf(onChange) === 'function') {
-        this.onChange(selectedValue)
+        run.next(() => {
+          this.onChange(selectedValue)
+        })
       }
 
       // We need to make sure focus goes back to select since it is on the

--- a/tests/acceptance/application-test.js
+++ b/tests/acceptance/application-test.js
@@ -8,6 +8,7 @@ describe('Acceptance: Application', function () {
 
   before(function () {
     application = startApp()
+    server.loadFixtures()
   })
 
   after(function () {
@@ -29,10 +30,16 @@ describe('Acceptance: Application', function () {
     'button',
     'checkbox',
     'field',
+    'helpers',
     'icons',
     'layout',
+    'loading',
     'palette',
     'password',
+    'radio',
+    'scroll',
+    'select',
+    'toggle',
     'typography'
   ]
     .forEach((path) => {

--- a/tests/dummy/app/models/link.js
+++ b/tests/dummy/app/models/link.js
@@ -1,5 +1,5 @@
-import Model from 'ember-data/attr'
-import attr from 'ember-data/model'
+import attr from 'ember-data/attr'
+import Model from 'ember-data/model'
 
 export default Model.extend({
   text: attr('string')

--- a/tests/dummy/app/models/node.js
+++ b/tests/dummy/app/models/node.js
@@ -1,5 +1,5 @@
-import Model from 'ember-data/attr'
-import attr from 'ember-data/model'
+import attr from 'ember-data/attr'
+import Model from 'ember-data/model'
 
 export default Model.extend({
   label: attr('string'),

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -41,6 +41,10 @@ module.exports = function (environment) {
     ENV.rootURL = '/'
     ENV.locationType = 'none'
 
+    ENV['ember-cli-mirage'] = {
+      enabled: true
+    }
+
     // keep test console output quieter
     ENV.APP.LOG_ACTIVE_GENERATION = false
     ENV.APP.LOG_VIEW_LOOKUPS = false

--- a/tests/integration/components/frost-multi-select-test.js
+++ b/tests/integration/components/frost-multi-select-test.js
@@ -1,8 +1,6 @@
 import {expect} from 'chai'
-import {expectSelectWithState} from 'dummy/tests/helpers/ember-frost-core'
-import {integration} from 'dummy/tests/helpers/ember-test-utils/describe-component'
 import Ember from 'ember'
-import keyCodes from 'ember-frost-core/utils/key-codes'
+const {$} = Ember
 import {$hook, initialize as initializeHook} from 'ember-hook'
 import {describeComponent, it} from 'ember-mocha'
 import wait from 'ember-test-helpers/wait'
@@ -10,7 +8,9 @@ import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe} from 'mocha'
 import sinon from 'sinon'
 
-const {$} = Ember
+import {expectSelectWithState} from 'dummy/tests/helpers/ember-frost-core'
+import {integration} from 'dummy/tests/helpers/ember-test-utils/describe-component'
+import keyCodes from 'ember-frost-core/utils/key-codes'
 const {DOWN_ARROW, ENTER, ESCAPE, SPACE, TAB, UP_ARROW} = keyCodes
 
 /**

--- a/tests/integration/components/frost-multi-select-test.js
+++ b/tests/integration/components/frost-multi-select-test.js
@@ -1,6 +1,6 @@
 import {expect} from 'chai'
 import Ember from 'ember'
-const {$} = Ember
+const {$, run} = Ember
 import {$hook, initialize as initializeHook} from 'ember-hook'
 import {describeComponent, it} from 'ember-mocha'
 import wait from 'ember-test-helpers/wait'
@@ -94,7 +94,7 @@ describeComponent(...integration('frost-multi-select'), function () {
         })
 
         expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-        expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+        expect(onChange.callCount, 'onChange is not called').to.equal(0)
         expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
       })
 
@@ -116,7 +116,7 @@ describeComponent(...integration('frost-multi-select'), function () {
           })
 
           expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-          expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+          expect(onChange.callCount, 'onChange is not called').to.equal(0)
           expect(onFocus.callCount, 'onFocus is called').to.equal(1)
         })
 
@@ -138,7 +138,7 @@ describeComponent(...integration('frost-multi-select'), function () {
             })
 
             expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-            expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+            expect(onChange.callCount, 'onChange is not called').to.equal(0)
             expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
           })
         })
@@ -177,7 +177,7 @@ describeComponent(...integration('frost-multi-select'), function () {
           })
 
           expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-          expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+          expect(onChange.callCount, 'onChange is not called').to.equal(0)
           expect(onFocus.callCount, 'onFocus is called').not.to.equal(0)
         })
       })
@@ -195,7 +195,7 @@ describeComponent(...integration('frost-multi-select'), function () {
           })
 
           expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-          expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+          expect(onChange.callCount, 'onChange is not called').to.equal(0)
           expect(onFocus.callCount, 'onFocus is called').not.to.equal(0)
         })
 
@@ -212,7 +212,7 @@ describeComponent(...integration('frost-multi-select'), function () {
             })
 
             expect(onBlur.callCount, 'onBlur is called').not.to.equal(0)
-            expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+            expect(onChange.callCount, 'onChange is not called').to.equal(0)
           })
         })
 
@@ -236,7 +236,7 @@ describeComponent(...integration('frost-multi-select'), function () {
             })
 
             expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-            expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+            expect(onChange.callCount, 'onChange is not called').to.equal(0)
             expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
           })
 
@@ -253,7 +253,7 @@ describeComponent(...integration('frost-multi-select'), function () {
               })
 
               expect(onBlur.callCount, 'onBlur is called').not.to.equal(0)
-              expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+              expect(onChange.callCount, 'onChange is not called').to.equal(0)
             })
           })
 
@@ -275,7 +275,7 @@ describeComponent(...integration('frost-multi-select'), function () {
               })
 
               expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-              expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+              expect(onChange.callCount, 'onChange is not called').to.equal(0)
               expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
             })
           })
@@ -299,7 +299,7 @@ describeComponent(...integration('frost-multi-select'), function () {
               })
 
               expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-              expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+              expect(onChange.callCount, 'onChange is not called').to.equal(0)
               expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
             })
           })
@@ -325,7 +325,7 @@ describeComponent(...integration('frost-multi-select'), function () {
             })
 
             expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-            expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+            expect(onChange.callCount, 'onChange is not called').to.equal(0)
             expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
           })
         })
@@ -350,7 +350,7 @@ describeComponent(...integration('frost-multi-select'), function () {
             })
 
             expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-            expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+            expect(onChange.callCount, 'onChange is not called').to.equal(0)
             expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
           })
         })
@@ -368,7 +368,7 @@ describeComponent(...integration('frost-multi-select'), function () {
           })
 
           expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-          expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+          expect(onChange.callCount, 'onChange is not called').to.equal(0)
           expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
         })
 
@@ -389,7 +389,7 @@ describeComponent(...integration('frost-multi-select'), function () {
             })
 
             expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-            expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+            expect(onChange.callCount, 'onChange is not called').to.equal(0)
             expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
           })
         })
@@ -435,7 +435,7 @@ describeComponent(...integration('frost-multi-select'), function () {
               .to.equal(document.activeElement)
 
             expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-            expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+            expect(onChange.callCount, 'onChange is not called').to.equal(0)
             expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
           })
         })
@@ -453,7 +453,7 @@ describeComponent(...integration('frost-multi-select'), function () {
           })
 
           expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-          expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+          expect(onChange.callCount, 'onChange is not called').to.equal(0)
           expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
         })
       })
@@ -470,7 +470,7 @@ describeComponent(...integration('frost-multi-select'), function () {
           })
 
           expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-          expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+          expect(onChange.callCount, 'onChange is not called').to.equal(0)
           expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
         })
       })
@@ -490,7 +490,7 @@ describeComponent(...integration('frost-multi-select'), function () {
         })
 
         expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-        expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+        expect(onChange.callCount, 'onChange is not called').to.equal(0)
         expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
       })
 
@@ -513,7 +513,7 @@ describeComponent(...integration('frost-multi-select'), function () {
           })
 
           expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-          expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+          expect(onChange.callCount, 'onChange is not called').to.equal(0)
           expect(onFocus.callCount, 'onFocus is called').to.equal(1)
         })
 
@@ -535,7 +535,7 @@ describeComponent(...integration('frost-multi-select'), function () {
             })
 
             expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-            expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+            expect(onChange.callCount, 'onChange is not called').to.equal(0)
             expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
           })
         })
@@ -574,7 +574,7 @@ describeComponent(...integration('frost-multi-select'), function () {
           })
 
           expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-          expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+          expect(onChange.callCount, 'onChange is not called').to.equal(0)
           expect(onFocus.callCount, 'onFocus is called').not.to.equal(0)
         })
       })
@@ -592,7 +592,7 @@ describeComponent(...integration('frost-multi-select'), function () {
           })
 
           expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-          expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+          expect(onChange.callCount, 'onChange is not called').to.equal(0)
           expect(onFocus.callCount, 'onFocus is called').not.to.equal(0)
         })
 
@@ -609,7 +609,7 @@ describeComponent(...integration('frost-multi-select'), function () {
             })
 
             expect(onBlur.callCount, 'onBlur is called').not.to.equal(0)
-            expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+            expect(onChange.callCount, 'onChange is not called').to.equal(0)
           })
         })
 
@@ -631,7 +631,7 @@ describeComponent(...integration('frost-multi-select'), function () {
             })
 
             expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-            expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+            expect(onChange.callCount, 'onChange is not called').to.equal(0)
             expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
           })
         })
@@ -657,7 +657,7 @@ describeComponent(...integration('frost-multi-select'), function () {
             })
 
             expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-            expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+            expect(onChange.callCount, 'onChange is not called').to.equal(0)
             expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
           })
 
@@ -674,7 +674,7 @@ describeComponent(...integration('frost-multi-select'), function () {
               })
 
               expect(onBlur.callCount, 'onBlur is called').not.to.equal(0)
-              expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+              expect(onChange.callCount, 'onChange is not called').to.equal(0)
             })
           })
 
@@ -697,13 +697,13 @@ describeComponent(...integration('frost-multi-select'), function () {
               })
 
               expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-              expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+              expect(onChange.callCount, 'onChange is not called').to.equal(0)
               expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
             })
           })
 
           describe('when enter key pressed', function () {
-            beforeEach(function () {
+            beforeEach(function (done) {
               [onBlur, onChange, onFocus].forEach((func) => func.reset())
 
               $(document)
@@ -712,6 +712,10 @@ describeComponent(...integration('frost-multi-select'), function () {
                     keyCode: ENTER
                   })
                 )
+
+              run.next(() => {
+                done()
+              })
             })
 
             it('renders as expected', function () {
@@ -758,8 +762,8 @@ describeComponent(...integration('frost-multi-select'), function () {
                 expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
               })
 
-              describe('when enter key is pressed', function () {
-                beforeEach(function () {
+              describe('when enter key pressed', function () {
+                beforeEach(function (done) {
                   [onBlur, onChange, onFocus].forEach((func) => func.reset())
 
                   $(document)
@@ -768,6 +772,10 @@ describeComponent(...integration('frost-multi-select'), function () {
                         keyCode: ENTER
                       })
                     )
+
+                  run.next(() => {
+                    done()
+                  })
                 })
 
                 it('renders as expected', function () {
@@ -813,7 +821,7 @@ describeComponent(...integration('frost-multi-select'), function () {
               })
 
               expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-              expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+              expect(onChange.callCount, 'onChange is not called').to.equal(0)
               expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
             })
           })
@@ -839,7 +847,7 @@ describeComponent(...integration('frost-multi-select'), function () {
               })
 
               expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-              expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+              expect(onChange.callCount, 'onChange is not called').to.equal(0)
               expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
             })
 
@@ -864,7 +872,7 @@ describeComponent(...integration('frost-multi-select'), function () {
                 })
 
                 expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-                expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+                expect(onChange.callCount, 'onChange is not called').to.equal(0)
                 expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
               })
             })
@@ -890,13 +898,13 @@ describeComponent(...integration('frost-multi-select'), function () {
                 })
 
                 expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-                expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+                expect(onChange.callCount, 'onChange is not called').to.equal(0)
                 expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
               })
             })
 
             describe('when enter key pressed', function () {
-              beforeEach(function () {
+              beforeEach(function (done) {
                 [onBlur, onChange, onFocus].forEach((func) => func.reset())
 
                 $(document)
@@ -905,6 +913,10 @@ describeComponent(...integration('frost-multi-select'), function () {
                       keyCode: ENTER
                     })
                   )
+
+                run.next(() => {
+                  done()
+                })
               })
 
               it('renders as expected', function () {
@@ -929,9 +941,12 @@ describeComponent(...integration('frost-multi-select'), function () {
           })
 
           describe('when first item clicked', function () {
-            beforeEach(function () {
+            beforeEach(function (done) {
               [onBlur, onChange, onFocus].forEach((func) => func.reset())
               $hook('select-item', {index: 0}).trigger('mousedown')
+              run.next(() => {
+                done()
+              })
             })
 
             it('renders as expected', function () {
@@ -942,7 +957,6 @@ describeComponent(...integration('frost-multi-select'), function () {
                 text: 'Foo'
               })
 
-              expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
               expect(onChange.callCount, 'onChange is called').to.equal(1)
               expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
 
@@ -955,9 +969,12 @@ describeComponent(...integration('frost-multi-select'), function () {
           })
 
           describe('when second item clicked', function () {
-            beforeEach(function () {
+            beforeEach(function (done) {
               [onBlur, onChange, onFocus].forEach((func) => func.reset())
               $hook('select-item', {index: 1}).trigger('mousedown')
+              run.next(() => {
+                done()
+              })
             })
 
             it('renders as expected', function () {
@@ -968,7 +985,6 @@ describeComponent(...integration('frost-multi-select'), function () {
                 text: 'Bar'
               })
 
-              expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
               expect(onChange.callCount, 'onChange is called').to.equal(1)
               expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
 
@@ -1002,7 +1018,7 @@ describeComponent(...integration('frost-multi-select'), function () {
             })
 
             expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-            expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+            expect(onChange.callCount, 'onChange is not called').to.equal(0)
             expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
           })
         })
@@ -1028,7 +1044,7 @@ describeComponent(...integration('frost-multi-select'), function () {
             })
 
             expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-            expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+            expect(onChange.callCount, 'onChange is not called').to.equal(0)
             expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
           })
         })
@@ -1046,7 +1062,7 @@ describeComponent(...integration('frost-multi-select'), function () {
           })
 
           expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-          expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+          expect(onChange.callCount, 'onChange is not called').to.equal(0)
           expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
         })
 
@@ -1067,7 +1083,7 @@ describeComponent(...integration('frost-multi-select'), function () {
             })
 
             expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-            expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+            expect(onChange.callCount, 'onChange is not called').to.equal(0)
             expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
           })
         })
@@ -1113,7 +1129,7 @@ describeComponent(...integration('frost-multi-select'), function () {
               .to.equal(document.activeElement)
 
             expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-            expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+            expect(onChange.callCount, 'onChange is not called').to.equal(0)
             expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
           })
         })
@@ -1131,7 +1147,7 @@ describeComponent(...integration('frost-multi-select'), function () {
           })
 
           expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-          expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+          expect(onChange.callCount, 'onChange is not called').to.equal(0)
           expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
         })
       })
@@ -1148,7 +1164,7 @@ describeComponent(...integration('frost-multi-select'), function () {
           })
 
           expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-          expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+          expect(onChange.callCount, 'onChange is not called').to.equal(0)
           expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
         })
       })

--- a/tests/integration/components/frost-select-test.js
+++ b/tests/integration/components/frost-select-test.js
@@ -1,6 +1,6 @@
 import {expect} from 'chai'
 import Ember from 'ember'
-const {$} = Ember
+const {$, run} = Ember
 import {$hook} from 'ember-hook'
 import {describeComponent, it} from 'ember-mocha'
 import wait from 'ember-test-helpers/wait'
@@ -102,7 +102,7 @@ describeComponent(...integration('frost-select'), function () {
         })
 
         expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-        expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+        expect(onChange.callCount, 'onChange is not called').to.equal(0)
         expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
       })
 
@@ -124,7 +124,7 @@ describeComponent(...integration('frost-select'), function () {
           })
 
           expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-          expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+          expect(onChange.callCount, 'onChange is not called').to.equal(0)
           expect(onFocus.callCount, 'onFocus is called').to.equal(1)
         })
 
@@ -146,7 +146,7 @@ describeComponent(...integration('frost-select'), function () {
             })
 
             expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-            expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+            expect(onChange.callCount, 'onChange is not called').to.equal(0)
             expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
           })
         })
@@ -185,7 +185,7 @@ describeComponent(...integration('frost-select'), function () {
           })
 
           expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-          expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+          expect(onChange.callCount, 'onChange is not called').to.equal(0)
           expect(onFocus.callCount, 'onFocus is called').not.to.equal(0)
         })
       })
@@ -203,7 +203,7 @@ describeComponent(...integration('frost-select'), function () {
           })
 
           expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-          expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+          expect(onChange.callCount, 'onChange is not called').to.equal(0)
           expect(onFocus.callCount, 'onFocus is called').not.to.equal(0)
         })
 
@@ -220,7 +220,7 @@ describeComponent(...integration('frost-select'), function () {
             })
 
             expect(onBlur.callCount, 'onBlur is called').not.to.equal(0)
-            expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+            expect(onChange.callCount, 'onChange is not called').to.equal(0)
           })
         })
 
@@ -244,7 +244,7 @@ describeComponent(...integration('frost-select'), function () {
             })
 
             expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-            expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+            expect(onChange.callCount, 'onChange is not called').to.equal(0)
             expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
           })
 
@@ -261,7 +261,7 @@ describeComponent(...integration('frost-select'), function () {
               })
 
               expect(onBlur.callCount, 'onBlur is called').not.to.equal(0)
-              expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+              expect(onChange.callCount, 'onChange is not called').to.equal(0)
             })
           })
 
@@ -283,7 +283,7 @@ describeComponent(...integration('frost-select'), function () {
               })
 
               expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-              expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+              expect(onChange.callCount, 'onChange is not called').to.equal(0)
               expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
             })
           })
@@ -307,7 +307,7 @@ describeComponent(...integration('frost-select'), function () {
               })
 
               expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-              expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+              expect(onChange.callCount, 'onChange is not called').to.equal(0)
               expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
             })
           })
@@ -333,7 +333,7 @@ describeComponent(...integration('frost-select'), function () {
             })
 
             expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-            expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+            expect(onChange.callCount, 'onChange is not called').to.equal(0)
             expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
           })
         })
@@ -358,7 +358,7 @@ describeComponent(...integration('frost-select'), function () {
             })
 
             expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-            expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+            expect(onChange.callCount, 'onChange is not called').to.equal(0)
             expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
           })
         })
@@ -376,7 +376,7 @@ describeComponent(...integration('frost-select'), function () {
           })
 
           expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-          expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+          expect(onChange.callCount, 'onChange is not called').to.equal(0)
           expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
         })
 
@@ -397,7 +397,7 @@ describeComponent(...integration('frost-select'), function () {
             })
 
             expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-            expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+            expect(onChange.callCount, 'onChange is not called').to.equal(0)
             expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
           })
         })
@@ -443,7 +443,7 @@ describeComponent(...integration('frost-select'), function () {
               .to.equal(document.activeElement)
 
             expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-            expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+            expect(onChange.callCount, 'onChange is not called').to.equal(0)
             expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
           })
         })
@@ -461,7 +461,7 @@ describeComponent(...integration('frost-select'), function () {
           })
 
           expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-          expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+          expect(onChange.callCount, 'onChange is not called').to.equal(0)
           expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
         })
 
@@ -482,7 +482,7 @@ describeComponent(...integration('frost-select'), function () {
               })
 
               expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-              expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+              expect(onChange.callCount, 'onChange is not called').to.equal(0)
               expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
             })
           })
@@ -503,7 +503,7 @@ describeComponent(...integration('frost-select'), function () {
               })
 
               expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-              expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+              expect(onChange.callCount, 'onChange is not called').to.equal(0)
               expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
             })
           })
@@ -522,7 +522,7 @@ describeComponent(...integration('frost-select'), function () {
           })
 
           expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-          expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+          expect(onChange.callCount, 'onChange is not called').to.equal(0)
           expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
         })
       })
@@ -544,7 +544,7 @@ describeComponent(...integration('frost-select'), function () {
         })
 
         expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-        expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+        expect(onChange.callCount, 'onChange is not called').to.equal(0)
         expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
       })
 
@@ -567,7 +567,7 @@ describeComponent(...integration('frost-select'), function () {
           })
 
           expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-          expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+          expect(onChange.callCount, 'onChange is not called').to.equal(0)
           expect(onFocus.callCount, 'onFocus is called').to.equal(1)
         })
 
@@ -589,7 +589,7 @@ describeComponent(...integration('frost-select'), function () {
             })
 
             expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-            expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+            expect(onChange.callCount, 'onChange is not called').to.equal(0)
             expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
           })
         })
@@ -628,7 +628,7 @@ describeComponent(...integration('frost-select'), function () {
           })
 
           expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-          expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+          expect(onChange.callCount, 'onChange is not called').to.equal(0)
           expect(onFocus.callCount, 'onFocus is called').not.to.equal(0)
         })
       })
@@ -646,7 +646,7 @@ describeComponent(...integration('frost-select'), function () {
           })
 
           expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-          expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+          expect(onChange.callCount, 'onChange is not called').to.equal(0)
           expect(onFocus.callCount, 'onFocus is called').not.to.equal(0)
         })
 
@@ -663,7 +663,7 @@ describeComponent(...integration('frost-select'), function () {
             })
 
             expect(onBlur.callCount, 'onBlur is called').not.to.equal(0)
-            expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+            expect(onChange.callCount, 'onChange is not called').to.equal(0)
           })
         })
 
@@ -685,7 +685,7 @@ describeComponent(...integration('frost-select'), function () {
             })
 
             expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-            expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+            expect(onChange.callCount, 'onChange is not called').to.equal(0)
             expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
           })
         })
@@ -711,7 +711,7 @@ describeComponent(...integration('frost-select'), function () {
             })
 
             expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-            expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+            expect(onChange.callCount, 'onChange is not called').to.equal(0)
             expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
           })
 
@@ -728,7 +728,7 @@ describeComponent(...integration('frost-select'), function () {
               })
 
               expect(onBlur.callCount, 'onBlur is called').not.to.equal(0)
-              expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+              expect(onChange.callCount, 'onChange is not called').to.equal(0)
             })
           })
 
@@ -751,13 +751,13 @@ describeComponent(...integration('frost-select'), function () {
               })
 
               expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-              expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+              expect(onChange.callCount, 'onChange is not called').to.equal(0)
               expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
             })
           })
 
           describe('when enter key pressed', function () {
-            beforeEach(function () {
+            beforeEach(function (done) {
               [onBlur, onChange, onFocus].forEach((func) => func.reset())
 
               $(document)
@@ -766,6 +766,10 @@ describeComponent(...integration('frost-select'), function () {
                     keyCode: ENTER
                   })
                 )
+
+              run.next(() => {
+                done()
+              })
             })
 
             it('renders as expected', function () {
@@ -775,7 +779,6 @@ describeComponent(...integration('frost-select'), function () {
                 text: 'Foo'
               })
 
-              expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
               expect(onChange.callCount, 'onChange is called').to.equal(1)
               expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
 
@@ -808,7 +811,7 @@ describeComponent(...integration('frost-select'), function () {
               })
 
               expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-              expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+              expect(onChange.callCount, 'onChange is not called').to.equal(0)
               expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
             })
           })
@@ -834,7 +837,7 @@ describeComponent(...integration('frost-select'), function () {
               })
 
               expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-              expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+              expect(onChange.callCount, 'onChange is not called').to.equal(0)
               expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
             })
 
@@ -859,7 +862,7 @@ describeComponent(...integration('frost-select'), function () {
                 })
 
                 expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-                expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+                expect(onChange.callCount, 'onChange is not called').to.equal(0)
                 expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
               })
             })
@@ -885,13 +888,13 @@ describeComponent(...integration('frost-select'), function () {
                 })
 
                 expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-                expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+                expect(onChange.callCount, 'onChange is not called').to.equal(0)
                 expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
               })
             })
 
             describe('when enter key pressed', function () {
-              beforeEach(function () {
+              beforeEach(function (done) {
                 [onBlur, onChange, onFocus].forEach((func) => func.reset())
 
                 $(document)
@@ -900,6 +903,10 @@ describeComponent(...integration('frost-select'), function () {
                       keyCode: ENTER
                     })
                   )
+
+                run.next(() => {
+                  done()
+                })
               })
 
               it('renders as expected', function () {
@@ -909,7 +916,6 @@ describeComponent(...integration('frost-select'), function () {
                   text: 'Bar'
                 })
 
-                expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
                 expect(onChange.callCount, 'onChange is called').to.equal(1)
                 expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
 
@@ -923,9 +929,12 @@ describeComponent(...integration('frost-select'), function () {
           })
 
           describe('when first item clicked', function () {
-            beforeEach(function () {
+            beforeEach(function (done) {
               [onBlur, onChange, onFocus].forEach((func) => func.reset())
               $hook('select-item', {index: 0}).trigger('mousedown')
+              run.next(() => {
+                done()
+              })
             })
 
             it('renders as expected', function () {
@@ -935,7 +944,6 @@ describeComponent(...integration('frost-select'), function () {
                 text: 'Foo'
               })
 
-              expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
               expect(onChange.callCount, 'onChange is called').to.equal(1)
               expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
 
@@ -948,9 +956,12 @@ describeComponent(...integration('frost-select'), function () {
           })
 
           describe('when second item clicked', function () {
-            beforeEach(function () {
+            beforeEach(function (done) {
               [onBlur, onChange, onFocus].forEach((func) => func.reset())
               $hook('select-item', {index: 1}).trigger('mousedown')
+              run.next(() => {
+                done()
+              })
             })
 
             it('renders as expected', function () {
@@ -960,7 +971,6 @@ describeComponent(...integration('frost-select'), function () {
                 text: 'Bar'
               })
 
-              expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
               expect(onChange.callCount, 'onChange is called').to.equal(1)
               expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
 
@@ -985,7 +995,7 @@ describeComponent(...integration('frost-select'), function () {
               })
 
               expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-              expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+              expect(onChange.callCount, 'onChange is not called').to.equal(0)
               expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
             })
           })
@@ -1010,7 +1020,7 @@ describeComponent(...integration('frost-select'), function () {
                 .to.eql('<u>Baz</u>')
 
               expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-              expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+              expect(onChange.callCount, 'onChange is not called').to.equal(0)
               expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
             })
           })
@@ -1047,7 +1057,7 @@ describeComponent(...integration('frost-select'), function () {
                 .to.eql('<u>Ba</u> <u>ba</u> black sheep')
 
               expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-              expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+              expect(onChange.callCount, 'onChange is not called').to.equal(0)
               expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
             })
           })
@@ -1074,7 +1084,7 @@ describeComponent(...integration('frost-select'), function () {
             })
 
             expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-            expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+            expect(onChange.callCount, 'onChange is not called').to.equal(0)
             expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
           })
         })
@@ -1100,7 +1110,7 @@ describeComponent(...integration('frost-select'), function () {
             })
 
             expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-            expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+            expect(onChange.callCount, 'onChange is not called').to.equal(0)
             expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
           })
         })
@@ -1118,7 +1128,7 @@ describeComponent(...integration('frost-select'), function () {
           })
 
           expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-          expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+          expect(onChange.callCount, 'onChange is not called').to.equal(0)
           expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
         })
 
@@ -1139,7 +1149,7 @@ describeComponent(...integration('frost-select'), function () {
             })
 
             expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-            expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+            expect(onChange.callCount, 'onChange is not called').to.equal(0)
             expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
           })
         })
@@ -1185,7 +1195,7 @@ describeComponent(...integration('frost-select'), function () {
               .to.equal(document.activeElement)
 
             expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-            expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+            expect(onChange.callCount, 'onChange is not called').to.equal(0)
             expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
           })
         })
@@ -1203,7 +1213,7 @@ describeComponent(...integration('frost-select'), function () {
           })
 
           expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-          expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+          expect(onChange.callCount, 'onChange is not called').to.equal(0)
           expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
         })
       })
@@ -1220,7 +1230,7 @@ describeComponent(...integration('frost-select'), function () {
           })
 
           expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
-          expect(onChange.callCount, 'OnChange is not called').to.equal(0)
+          expect(onChange.callCount, 'onChange is not called').to.equal(0)
           expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
         })
       })

--- a/tests/integration/components/frost-select-test.js
+++ b/tests/integration/components/frost-select-test.js
@@ -1,8 +1,6 @@
 import {expect} from 'chai'
-import {expectSelectWithState, filterSelect} from 'dummy/tests/helpers/ember-frost-core'
-import {integration} from 'dummy/tests/helpers/ember-test-utils/describe-component'
 import Ember from 'ember'
-import {keyCodes} from 'ember-frost-core/utils'
+const {$} = Ember
 import {$hook} from 'ember-hook'
 import {describeComponent, it} from 'ember-mocha'
 import wait from 'ember-test-helpers/wait'
@@ -10,7 +8,9 @@ import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe} from 'mocha'
 import sinon from 'sinon'
 
-const {$} = Ember
+import {expectSelectWithState, filterSelect} from 'dummy/tests/helpers/ember-frost-core'
+import {integration} from 'dummy/tests/helpers/ember-test-utils/describe-component'
+import {keyCodes} from 'ember-frost-core/utils'
 const {DOWN_ARROW, ENTER, ESCAPE, SPACE, TAB, UP_ARROW} = keyCodes
 
 /**


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

I've also integration tested this fix against an app running on Ember 2.8 to make sure the addition of the `run.ext` call within the `frost-select` didn't cause any issues.

# CHANGELOG

* **Addedd** missing acceptance tests to visit remaining routes in demo app to ensure all pages continue to load without issue.
* **Fixed** deprecation warning about modifying property twice in one render (which became an error in Ember 2.10).
* **Fixed** select route in demo.
