### PR TITLE
Fix bug when using frost-text with type=number

### DIFF
--- a/addon/components/frost-text.js
+++ b/addon/components/frost-text.js
@@ -62,7 +62,6 @@ export default Component.extend(FrostEventsProxyMixin, {
       isHookEmbedded: false,
       readonly: false,
       required: false,
-      selectionDirection: 'none',
       spellcheck: false,
       tabindex: 0,
       type: 'text',

--- a/tests/integration/components/frost-text-test.js
+++ b/tests/integration/components/frost-text-test.js
@@ -14,6 +14,21 @@ describeComponent(
     integration: true
   },
   function () {
+    describe('when type is set to "number"', function () {
+      beforeEach(function () {
+        this.render(hbs`
+          {{frost-text
+            hook='myTextInput'
+            type='number'
+          }}
+        `)
+      })
+
+      it('renders', function () {
+        expect(this.$('.frost-text')).to.have.length(1)
+      })
+    })
+
     it('renders', function () {
       this.render(hbs`
           {{frost-text hook='myTextInput'}}

--- a/tests/unit/components/frost-text-test.js
+++ b/tests/unit/components/frost-text-test.js
@@ -67,11 +67,6 @@ describeComponent(
       ).to.equal(false)
 
       expect(
-        component.get('selectionDirection'),
-        'selectionDirection: none'
-      ).to.be.eql('none')
-
-      expect(
         component.get('spellcheck'),
         'spellcheck: false'
       ).to.equal(false)


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** bug when trying to use `frost-text` with `type="number"`. The error that was occurring was:

  ```
  Uncaught DOMException: Failed to set the 'selectionDirection' property on 'HTMLInputElement': The input element's type ('number') does not support selection.
  ```
