### PR TITLE
fixed incorrect default props for placeholder, form, value, title in frost-text

### DIFF
--- a/addon/components/frost-text.js
+++ b/addon/components/frost-text.js
@@ -64,15 +64,7 @@ export default Component.extend(FrostEventsProxyMixin, {
       required: false,
       spellcheck: false,
       tabindex: 0,
-      type: 'text',
-
-      // Setting these as part of establishing an initial value
-      form: '',
-      placeholder: '',
-      title: '',
-      value: ''
-
-      // state
+      type: 'text'
     }
   },
 

--- a/addon/components/frost-text.js
+++ b/addon/components/frost-text.js
@@ -67,11 +67,10 @@ export default Component.extend(FrostEventsProxyMixin, {
       type: 'text',
 
       // Setting these as part of establishing an initial value
-      form: null,
-      maxlength: null,
-      placeholder: null,
-      title: null,
-      value: null
+      form: '',
+      placeholder: '',
+      title: '',
+      value: ''
 
       // state
     }

--- a/tests/integration/components/frost-text-test.js
+++ b/tests/integration/components/frost-text-test.js
@@ -78,36 +78,6 @@ describeComponent(
       ).to.equal(true)
     })
 
-    // "autocapitalize" only works in Chrome and iOS Safari Mobile
-
-    // it('sets autocapitalize property', function () {
-    //   this.render(hbs`
-    //       {{frost-text
-    //         autocapitalize='sentences'
-    //       }}
-    //   `)
-
-    //   expect(
-    //     this.$('input').prop('autocapitalize'),
-    //     'autocapitalize attribute is set'
-    //   ).to.eql('sentences')
-    // })
-
-    // "autocorrect" doesn't pass in Chrome, Safari and Firefox
-
-    // it('sets autocorrect property', function () {
-    //   this.render(hbs`
-    //       {{frost-text
-    //         autocorrect=true
-    //       }}
-    //   `)
-
-    //   expect(
-    //     this.$('input').prop('autocorrect'),
-    //     'autocorrect attribute is set'
-    //   ).to.equal(true)
-    // })
-
     it('sets autofocus property', function () {
       this.render(hbs`
           {{frost-text

--- a/tests/unit/components/frost-text-test.js
+++ b/tests/unit/components/frost-text-test.js
@@ -83,28 +83,28 @@ describeComponent(
 
       expect(
         component.get('form'),
-        'form: null'
-      ).to.equal(null)
+        'form: \'\''
+      ).to.equal('')
 
       expect(
         component.get('maxlength'),
-        'maxlength: null'
-      ).to.equal(null)
+        'maxlength: undefined'
+      ).to.equal(undefined)
 
       expect(
         component.get('placeholder'),
-        'placeholder: null'
-      ).to.equal(null)
+        'placeholder: \'\''
+      ).to.equal('')
 
       expect(
         component.get('title'),
-        'title: null'
-      ).to.equal(null)
+        'title: \'\''
+      ).to.equal('')
 
       expect(
         component.get('value'),
-        'value: null'
-      ).to.equal(null)
+        'value: \'\''
+      ).to.equal('')
     })
 
     it('extends the commone frost component', function () {

--- a/tests/unit/components/frost-text-test.js
+++ b/tests/unit/components/frost-text-test.js
@@ -82,29 +82,9 @@ describeComponent(
       ).to.be.eql('text')
 
       expect(
-        component.get('form'),
-        'form: \'\''
-      ).to.equal('')
-
-      expect(
         component.get('maxlength'),
         'maxlength: undefined'
       ).to.equal(undefined)
-
-      expect(
-        component.get('placeholder'),
-        'placeholder: \'\''
-      ).to.equal('')
-
-      expect(
-        component.get('title'),
-        'title: \'\''
-      ).to.equal('')
-
-      expect(
-        component.get('value'),
-        'value: \'\''
-      ).to.equal('')
     })
 
     it('extends the commone frost component', function () {


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* in frost text:
* removed null default value for maxLength, since that is propType.number, and the null default isn't needed
* changed null default values to empty string for properties that are propType.string