### PR TITLE
Fixing a corner case for the text argument in frost-link

### DIFF
--- a/addon/components/frost-link.js
+++ b/addon/components/frost-link.js
@@ -379,18 +379,23 @@ export default LinkComponent.extend(PropTypeMixin, HookMixin, SpreadMixin, {
   didReceiveAttrs ({newAttrs}) {
     let params = getAttr(newAttrs, 'params')
 
+    // Ugly hack to get access to hasBlock so that we can determine if the text
+    // is coming from the block
+    const hasBlockKey = Object.keys(this).find(entry => entry.startsWith('HAS_BLOCK'))
+    const hasBlock = hasBlockKey && this[hasBlockKey]
+
     // On pre-Ember 2.10 params can be an array with undefined as an item
     if (isArray(params)) {
       params = params.filter((param) => param)
 
       // Handle the 'text' property being passed using positional params / block
       // mixed with named properties
-      if (params.length === 1 && isNone(newAttrs.text)) {
+      if (!hasBlock && params.length === 1 && isNone(newAttrs.text)) {
         newAttrs['text'] = params[0]
       }
     }
 
-    if (!isArray(params) || params.length <= 1) {
+    if (!isArray(params) || (!hasBlock && params.length <= 1)) {
       const params = getParams(newAttrs)
 
       this.set('params', params)

--- a/addon/components/frost-link.js
+++ b/addon/components/frost-link.js
@@ -395,7 +395,13 @@ export default LinkComponent.extend(PropTypeMixin, HookMixin, SpreadMixin, {
       }
     }
 
-    if (!isArray(params) || (!hasBlock && params.length <= 1)) {
+    const newAttrsKeys = Object.keys(newAttrs)
+    const hasNamedProperties = ['options', 'route', 'routeModels', 'routeNames', 'routeQueryParams', 'routes', 'text']
+      .any(namedPropertyKey => {
+        return newAttrsKeys.includes(namedPropertyKey)
+      })
+
+    if (!isArray(params) || hasNamedProperties) {
       const params = getParams(newAttrs)
 
       this.set('params', params)

--- a/addon/components/frost-link.js
+++ b/addon/components/frost-link.js
@@ -2,7 +2,7 @@
  * Component definition for frost-link component
  */
 import Ember from 'ember'
-const {LinkComponent, Logger, assign, deprecate, get, isEmpty, isPresent, run, set, typeOf} = Ember
+const {LinkComponent, Logger, assign, deprecate, get, isEmpty, isNone, isPresent, run, set, typeOf} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import {HookMixin} from 'ember-hook'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
@@ -382,9 +382,15 @@ export default LinkComponent.extend(PropTypeMixin, HookMixin, SpreadMixin, {
     // On pre-Ember 2.10 params can be an array with undefined as an item
     if (isArray(params)) {
       params = params.filter((param) => param)
+
+      // Handle the 'text' property being passed using positional params / block
+      // mixed with named properties
+      if (params.length === 1 && isNone(newAttrs.text)) {
+        newAttrs['text'] = params[0]
+      }
     }
 
-    if (!isArray(params) || params.length === 0) {
+    if (!isArray(params) || params.length <= 1) {
       const params = getParams(newAttrs)
 
       this.set('params', params)

--- a/tests/integration/components/frost-link-test.js
+++ b/tests/integration/components/frost-link-test.js
@@ -45,11 +45,31 @@ describe('Integration: FrostLinkComponent', function () {
     sandbox.restore()
   })
 
-  describe('when instantiated using inline format', function () {
+  describe('when instantiated using inline positional params format', function () {
     beforeEach(function () {
       this.render(hbs`
         {{frost-link 'Test' 'link.min'
           hook='myLink'
+        }}
+      `)
+    })
+
+    it('has expected class name', function () {
+      expect(this.$('> *').hasClass('frost-link')).to.equal(true)
+    })
+
+    it('has expected text content', function () {
+      expect(this.$('.frost-link').text().trim()).to.equal('Test')
+    })
+  })
+
+  describe('when instantiated using inline hash format', function () {
+    beforeEach(function () {
+      this.render(hbs`
+        {{frost-link
+          hook='myLink'
+          text='Test'
+          routeName='link.min'
         }}
       `)
     })
@@ -110,59 +130,57 @@ describe('Integration: FrostLinkComponent', function () {
     })
 
     describe('when clicked', function () {
-      describe('when clicked', function () {
-        describe('when pop-up blocker enabled', function () {
-          beforeEach(function () {
-            sandbox.stub(Logger, 'warn')
-            sandbox.stub(windowUtils, 'open').returns(null)
-            this.$('.frost-link').click()
-          })
-
-          it('tries to open correct number of links', function () {
-            expect(windowUtils.open.callCount).to.equal(2)
-          })
-
-          it('tries to open first link as expected', function () {
-            expect(windowUtils.open.firstCall.args).to.eql(['link.min'])
-          })
-
-          it('tries to open second link as expected', function () {
-            expect(windowUtils.open.lastCall.args).to.eql(['link.max'])
-          })
-
-          it('logs warning', function () {
-            expect(Logger.warn.callCount).to.equal(3)
-            expect(Logger.warn.secondCall.args).to.eql([
-              'Warning: Make sure that the pop-ups are not blocked'
-            ])
-            expect(Logger.warn.lastCall.args).to.eql([
-              'Warning: Make sure that the pop-ups are not blocked'
-            ])
-          })
+      describe('when pop-up blocker enabled', function () {
+        beforeEach(function () {
+          sandbox.stub(Logger, 'warn')
+          sandbox.stub(windowUtils, 'open').returns(null)
+          this.$('.frost-link').click()
         })
 
-        describe('when pop-up blocker disabled', function () {
-          beforeEach(function () {
-            sandbox.stub(Logger, 'warn')
-            sandbox.stub(windowUtils, 'open').returns(1)
-            this.$('.frost-link').click()
-          })
+        it('tries to open correct number of links', function () {
+          expect(windowUtils.open.callCount).to.equal(2)
+        })
 
-          it('opens correct number of links', function () {
-            expect(windowUtils.open.callCount).to.equal(2)
-          })
+        it('tries to open first link as expected', function () {
+          expect(windowUtils.open.firstCall.args).to.eql(['link.min'])
+        })
 
-          it('opens first link as expected', function () {
-            expect(windowUtils.open.firstCall.args).to.eql(['link.min'])
-          })
+        it('tries to open second link as expected', function () {
+          expect(windowUtils.open.lastCall.args).to.eql(['link.max'])
+        })
 
-          it('opens second link as expected', function () {
-            expect(windowUtils.open.lastCall.args).to.eql(['link.max'])
-          })
+        it('logs warning', function () {
+          expect(Logger.warn.callCount).to.equal(2)
+          expect(Logger.warn.secondCall.args).to.eql([
+            'Warning: Make sure that the pop-ups are not blocked'
+          ])
+          expect(Logger.warn.lastCall.args).to.eql([
+            'Warning: Make sure that the pop-ups are not blocked'
+          ])
+        })
+      })
 
-          it('does not log warning', function () {
-            expect(Logger.warn.callCount).to.equal(1)
-          })
+      describe('when pop-up blocker disabled', function () {
+        beforeEach(function () {
+          sandbox.stub(Logger, 'warn')
+          sandbox.stub(windowUtils, 'open').returns(1)
+          this.$('.frost-link').click()
+        })
+
+        it('opens correct number of links', function () {
+          expect(windowUtils.open.callCount).to.equal(2)
+        })
+
+        it('opens first link as expected', function () {
+          expect(windowUtils.open.firstCall.args).to.eql(['link.min'])
+        })
+
+        it('opens second link as expected', function () {
+          expect(windowUtils.open.lastCall.args).to.eql(['link.max'])
+        })
+
+        it('does not log warning', function () {
+          expect(Logger.warn.callCount).to.equal(0)
         })
       })
     })
@@ -306,7 +324,7 @@ describe('Integration: FrostLinkComponent', function () {
         })
 
         it('logs warning', function () {
-          expect(Logger.warn.callCount).to.equal(3)
+          expect(Logger.warn.callCount).to.equal(2)
           expect(Logger.warn.secondCall.args).to.eql([
             'Warning: Make sure that the pop-ups are not blocked'
           ])
@@ -336,7 +354,7 @@ describe('Integration: FrostLinkComponent', function () {
         })
 
         it('does not log warning', function () {
-          expect(Logger.warn.callCount).to.equal(1)
+          expect(Logger.warn.callCount).to.equal(0)
         })
       })
     })

--- a/tests/integration/components/frost-link-test.js
+++ b/tests/integration/components/frost-link-test.js
@@ -150,13 +150,9 @@ describe('Integration: FrostLinkComponent', function () {
         })
 
         it('logs warning', function () {
-          expect(Logger.warn.callCount).to.equal(2)
-          expect(Logger.warn.secondCall.args).to.eql([
+          expect(Logger.warn.calledWith(
             'Warning: Make sure that the pop-ups are not blocked'
-          ])
-          expect(Logger.warn.lastCall.args).to.eql([
-            'Warning: Make sure that the pop-ups are not blocked'
-          ])
+          )).to.equal(true)
         })
       })
 
@@ -180,7 +176,9 @@ describe('Integration: FrostLinkComponent', function () {
         })
 
         it('does not log warning', function () {
-          expect(Logger.warn.callCount).to.equal(0)
+          expect(Logger.warn.calledWith(
+            'Warning: Make sure that the pop-ups are not blocked'
+          )).to.equal(false)
         })
       })
     })
@@ -236,13 +234,9 @@ describe('Integration: FrostLinkComponent', function () {
         })
 
         it('logs warning', function () {
-          expect(Logger.warn.callCount).to.equal(2)
-          expect(Logger.warn.secondCall.args).to.eql([
+          expect(Logger.warn.calledWith(
             'Warning: Make sure that the pop-ups are not blocked'
-          ])
-          expect(Logger.warn.lastCall.args).to.eql([
-            'Warning: Make sure that the pop-ups are not blocked'
-          ])
+          )).to.equal(true)
         })
       })
 
@@ -266,7 +260,9 @@ describe('Integration: FrostLinkComponent', function () {
         })
 
         it('does not log warning', function () {
-          expect(Logger.warn.callCount).to.equal(0)
+          expect(Logger.warn.calledWith(
+            'Warning: Make sure that the pop-ups are not blocked'
+          )).to.equal(false)
         })
       })
     })
@@ -324,13 +320,9 @@ describe('Integration: FrostLinkComponent', function () {
         })
 
         it('logs warning', function () {
-          expect(Logger.warn.callCount).to.equal(2)
-          expect(Logger.warn.secondCall.args).to.eql([
+          expect(Logger.warn.calledWith(
             'Warning: Make sure that the pop-ups are not blocked'
-          ])
-          expect(Logger.warn.lastCall.args).to.eql([
-            'Warning: Make sure that the pop-ups are not blocked'
-          ])
+          )).to.equal(true)
         })
       })
 
@@ -354,7 +346,9 @@ describe('Integration: FrostLinkComponent', function () {
         })
 
         it('does not log warning', function () {
-          expect(Logger.warn.callCount).to.equal(0)
+          expect(Logger.warn.calledWith(
+            'Warning: Make sure that the pop-ups are not blocked'
+          )).to.equal(false)
         })
       })
     })
@@ -415,10 +409,9 @@ describe('Integration: FrostLinkComponent', function () {
         })
 
         it('logs warning', function () {
-          expect(Logger.warn.callCount).to.equal(2)
-          expect(Logger.warn.lastCall.args).to.eql([
+          expect(Logger.warn.calledWith(
             'Warning: Make sure that the pop-ups are not blocked'
-          ])
+          )).to.equal(true)
         })
       })
 
@@ -442,7 +435,9 @@ describe('Integration: FrostLinkComponent', function () {
         })
 
         it('does not log warning', function () {
-          expect(Logger.warn.callCount).to.equal(0)
+          expect(Logger.warn.calledWith(
+            'Warning: Make sure that the pop-ups are not blocked'
+          )).to.equal(false)
         })
       })
     })
@@ -462,10 +457,9 @@ describe('Integration: FrostLinkComponent', function () {
     })
 
     it('logs warning', function () {
-      expect(Logger.warn.callCount).to.equal(1)
-      expect(Logger.warn.lastCall.args).eql([
+      expect(Logger.warn.calledWith(
         'Warning: The `design` property takes precedence over `size` and `priority`.'
-      ])
+      )).to.equal(true)
     })
   })
 
@@ -483,10 +477,9 @@ describe('Integration: FrostLinkComponent', function () {
     })
 
     it('logs warning', function () {
-      expect(Logger.warn.callCount).to.equal(1)
-      expect(Logger.warn.lastCall.args).eql([
+      expect(Logger.warn.calledWith(
         'Warning: The `design` property takes precedence over `size` and `priority`.'
-      ])
+      )).to.equal(true)
     })
   })
 


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* Fixed frost-link to support providing text via name properties, positional params or the yield block
