### PR TITLE
Refactor test helpers and add new selectAtIndex frost-select helper

### DIFF
--- a/addon/components/frost-select-dropdown.js
+++ b/addon/components/frost-select-dropdown.js
@@ -46,11 +46,17 @@ export default Component.extend({
     selectedItems: PropTypes.arrayOf(PropTypes.object),
 
     // state
-    bottom: PropTypes.number,
+    bottom: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.string
+    ]),
     focusedIndex: PropTypes.number,
     left: PropTypes.number,
     maxHeight: PropTypes.number,
-    top: PropTypes.number,
+    top: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.string
+    ]),
     width: PropTypes.number
   },
 
@@ -254,7 +260,7 @@ export default Component.extend({
     this._isUpdating = true
 
     while (Date.now() - this._lastInteraction < 250) {
-      const $element = get(this.attrs, '$element.value')
+      const $element = get(this.attrs, '$element.value') || get(this.attrs, '$element')
 
       if ($element) {
         this._updatePosition($element)

--- a/addon/components/frost-select-li.js
+++ b/addon/components/frost-select-li.js
@@ -17,7 +17,6 @@ export default Component.extend({
 
   // == Keyword Properties ====================================================
 
-  attributeBindings: ['data-text'],
   tagName: 'li',
   layout,
 
@@ -58,7 +57,7 @@ export default Component.extend({
 
   @readOnly
   @computed('data')
-  'data-text': function (data) {
+  fullText: function (data) {
     if (typeOf(data) !== 'object') return ''
     return data.label || ''
   },
@@ -83,14 +82,15 @@ export default Component.extend({
   // == Lifecycle Hooks =======================================================
 
   didRender () {
-    trimLongDataInElement(this.$().get(0))
-
+    const $text = this.$('.frost-select-list-item-text')
     const filter = this.get('filter')
+
+    trimLongDataInElement($text.get(0))
 
     if (filter) {
       const pattern = new RegExp(filter, 'gi')
-      const textWithMatch = this.$().text().replace(pattern, '<u>$&</u>')
-      this.$().html(textWithMatch)
+      const textWithMatch = $text.text().replace(pattern, '<u>$&</u>')
+      $text.html(textWithMatch)
     }
   },
 

--- a/addon/components/frost-select-li.js
+++ b/addon/components/frost-select-li.js
@@ -2,11 +2,12 @@
  * Component definition for the frost-select-li component
  */
 import Ember from 'ember'
-const {on} = Ember
+const {on, typeOf} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import {PropTypes} from 'ember-prop-types'
 
 import layout from '../templates/components/frost-select-li'
+import {trimLongDataInElement} from '../utils/text'
 import Component from './frost-component'
 
 const regexEscapeChars = '-[]/{}()*+?.^$|'.split('')
@@ -16,6 +17,7 @@ export default Component.extend({
 
   // == Keyword Properties ====================================================
 
+  attributeBindings: ['data-text'],
   tagName: 'li',
   layout,
 
@@ -54,6 +56,13 @@ export default Component.extend({
     return data && data.label || ''
   },
 
+  @readOnly
+  @computed('data')
+  'data-text': function (data) {
+    if (typeOf(data) !== 'object') return ''
+    return data.label || ''
+  },
+
   // == Functions =============================================================
 
   // == DOM Events ============================================================
@@ -72,6 +81,18 @@ export default Component.extend({
   }),
 
   // == Lifecycle Hooks =======================================================
+
+  didRender () {
+    trimLongDataInElement(this.$().get(0))
+
+    const filter = this.get('filter')
+
+    if (filter) {
+      const pattern = new RegExp(filter, 'gi')
+      const textWithMatch = this.$().text().replace(pattern, '<u>$&</u>')
+      this.$().html(textWithMatch)
+    }
+  },
 
   // == Actions ===============================================================
   actions: {}

--- a/addon/styles/_frost-select.scss
+++ b/addon/styles/_frost-select.scss
@@ -160,7 +160,7 @@ $frost-select-placeholder-color: $frost-color-grey-6;
 }
 
 .frost-select-list-item {
-  display: inline-block;
+  display: flex;
   flex: 1 0 auto;
   width: 100%;
   height: $frost-input-select-option-row-height;
@@ -200,6 +200,10 @@ $frost-select-placeholder-color: $frost-color-grey-6;
 .frost-select-list-item-selected {
   color: $frost-color-grey-2;
   font-weight: 500;
+}
+
+.frost-select-list-item-text {
+  flex: 1 0 auto;
 }
 
 .frost-select-overlay {

--- a/addon/templates/components/frost-select-li.hbs
+++ b/addon/templates/components/frost-select-li.hbs
@@ -7,4 +7,6 @@
     size='medium'
   }}
 {{/if}}
-{{label}}
+<span class="frost-select-list-item-text" data-text={{fullText}}>
+  {{label}}
+</span>

--- a/addon/utils/text.js
+++ b/addon/utils/text.js
@@ -1,0 +1,97 @@
+import Ember from 'ember'
+const {$} = Ember
+
+const ctx = $('<canvas />').get(0).getContext('2d')
+
+/**
+ * Get width of text for a specific font
+ *
+ * @param {String} text - text to measure width of
+ * @param {String} [font] - font to measure text in
+ * @returns {Number} width of text using font
+ */
+export function getTextWidth (text, font) {
+  if (font) {
+    ctx.font = font
+  }
+
+  return Math.ceil(ctx.measureText(text).width)
+}
+
+/**
+ * Trim text to fit within a specified width by removing characters from the center out and replacing with an ellipsis
+ * Note: Replaces just enough characters from the center so that the text fills the width to the best of its ability
+ *
+ * @param {String} text - text to trim
+ * @param {Number} width - width trimmed text needs to fit within in pixels
+ * @param {String} [font] - font to measure text in
+ * @returns {String} trimmed text
+ */
+export function trimDataToFit (text, width, font) {
+  if (!text) {
+    return text
+  }
+
+  // Start at two end characters
+  let leftIndex = 0
+  let rightIndex = text.length - 1
+
+  if (getTextWidth(text, font) <= width) {
+    return text
+  }
+
+  // Start total width as width of ellipsis since it will be added to the middle of the text
+  let total = getTextWidth('…', font)
+
+  while (leftIndex < rightIndex) {
+    // Determine width of next two characters inward
+    let current = getTextWidth(text[leftIndex]) + getTextWidth(text[rightIndex], font)
+
+    // Determine total width including next two characters inward
+    let newTotal = total + current
+
+    // If adding next two characters makes string too long let's go ahead and stop
+    if (newTotal > width) {
+      leftIndex -= 1
+      rightIndex += 1
+      break
+    }
+
+    total = newTotal
+    leftIndex += 1
+    rightIndex -= 1
+  }
+
+  // Get trimmed text
+  return text.slice(0, leftIndex + 1) + '…' + text.slice(rightIndex, text.length)
+}
+
+/**
+ * If data is too long for element without wrapping trim with ellipsis in middle
+ * Note: expects data-text attribute to be on element with full text
+ *
+ * @param {HTMLElement} element - HTML element to trim data within
+ */
+export function trimLongDataInElement (element) {
+  let text = element.textContent
+  let $element = $(element)
+  let tooltip = ''
+  const width = $element.width()
+
+  const fontFamily = $element.css('font-family')
+  const fontSize = $element.css('font-size')
+  ctx.font = `${fontSize} ${fontFamily}`
+
+  // Determine width of all text
+  let textWidth = ctx.measureText(text).width
+
+  // If text won't fit in cell figure out how much will
+  if (textWidth > width) {
+    text = trimDataToFit(text, width)
+    tooltip = $(element).data('text')
+  }
+
+  $element
+    .text(text)
+    .prop('title', tooltip)
+}

--- a/test-support/helpers/ember-frost-core.js
+++ b/test-support/helpers/ember-frost-core.js
@@ -1,74 +1,23 @@
-/* eslint-disable ember-standard/destructure */
-
-import {expect} from 'chai'
 import Ember from 'ember'
-const {$, typeOf} = Ember
+const {$, typeOf} = Ember // eslint-disable-line
 import {$hook} from 'ember-hook'
 
-const assign = Object.assign || Ember.assign || Ember.merge
+const assign = Object.assign || Ember.assign || Ember.merge // eslint-disable-line
 
-/**
- * @typedef {Object} FrostButtonState
- * @property {Boolean} [disabled=false] - whether or not button is disabled
- * @property {String} [icon] - name of button icon
- * @property {String} [pack="frost"] - name of icon pack for button's icon
- * @property {String} [text] - button text
- */
+import {
+  expectWithState as _expectButtonWithState,
+  find as _findButtons
+} from './ember-frost-core/frost-button'
 
- /**
-  * @typedef {Object} FrostSelectState
-  * @property {Boolean} [disabled=false] - whether or not select is disabled
-  * @property {Boolean} [error=false] - whether or not select has error
-  * @property {Boolean} [focused] - whether or not select is focused
-  * @property {String} [focusedItem] - label of focused item
-  * @property {String} [items] - list of item labels present in dropdown
-  * @property {Boolean} [opened=false] - whether or not select is opened
-  * @property {Number} [tabIndex=0] - tab index of root element
-  * @property {String} [text=''] - text in select for describing what is selected
-  */
+import {
+  expectWithState as _expectSelectWithState,
+  filter as _filterSelect
+} from './ember-frost-core/frost-select'
 
-/**
- * @typedef {Object} FrostTextState
- * @property {String} [align="left"] - text alignment
- * @property {Boolean} [disabled=false] - whether or not input is disabled
- * @property {Boolean} [error=false] - whether or not input is in error state
- * @property {String} [placeholder] - placeholder text
- * @property {Number} [tabIndex=0] - tab index
- * @property {String} [type='text'] - input type
- * @property {String} [value] - value of input
- */
-
-/**
- * Expect element to have disabled state
- * @param {jQuery} $element - element
- * @param {Boolean} disabled - disabled
- * @param {String} [type='element'] - type of element
- */
-function expectDisabledState ($element, disabled, type = 'element') {
-  expect(
-    $element.is(':disabled'),
-    `${type} is ${disabled ? 'disabled' : 'enabled'}`
-  )
-    .to.equal(disabled)
-}
-
-/**
- * Expect class on element depending on boolean state
- * @param {jQuery} $element - element to check for class on
- * @param {String} className - name of class
- * @param {Boolean} state - whether or not class should be present
- */
-function expectToggleClass ($element, className, state) {
-  if (state === undefined) {
-    return
-  }
-
-  expect(
-    $element.hasClass(className),
-    `${state ? 'has' : 'does not have'} ${className} class`
-  )
-    .to.equal(state)
-}
+import {
+  expectWithState as _expectTextInputWithState,
+  find as _findTextInputs
+} from './ember-frost-core/frost-text'
 
 /**
  * Click on element
@@ -77,168 +26,6 @@ function expectToggleClass ($element, className, state) {
 export function click (element) {
   const $element = typeOf(element) === 'string' ? $hook(element) : element
   $element.click()
-}
-
-/**
- * Filter frost-select
- * @param {String} filter - filter to apply to select
- */
-export function filterSelect (filter) {
-  $('.frost-select-dropdown .frost-text-input')
-    .val(filter)
-    .trigger('input')
-}
-
-/**
- * Verify button exists with expected state
- * @param {jQuery|String} button - name of Ember hook or jQuery instance
- * @param {FrostButtonState} state - expected button state
- */
-export function expectButtonWithState (button, state) {
-  const defaults = {
-    disabled: false,
-    pack: 'frost'
-  }
-
-  const $button = typeOf(button) === 'string' ? $hook(button) : button
-  state = assign(defaults, state)
-
-  expectDisabledState($button, state.disabled, 'button')
-
-  if (state.icon && state.pack) {
-    expect(
-      $button.find(`.frost-icon-${state.pack}-${state.icon}`),
-      'button has expected icon'
-    )
-      .to.have.length(1)
-  }
-
-  if (state.text) {
-    expect(
-      $button.find('.text:not(.icon-text)').text().trim(),
-      'button has expected text'
-    )
-      .to.equal(state.text)
-  }
-}
-
-/* eslint-disable complexity */
-/**
- * Verify select exists with expected state
- * @param {jQuery|String} select - name of Ember hook or jQuery instance
- * @param {FrostSelectState} state - expected select state
- */
-export function expectSelectWithState (select, state) {
-  const defaults = {
-    disabled: false,
-    error: false,
-    opened: false,
-    tabIndex: 0,
-    text: ''
-  }
-
-  const $select = typeOf(select) === 'string' ? $hook(select) : select
-  state = assign(defaults, state)
-
-  expect(
-    $select.hasClass('frost-select'),
-    'has frost-select class'
-  )
-    .to.equal(true)
-
-  expectToggleClass($select, 'frost-select-disabled', state.disabled)
-  expectToggleClass($select, 'frost-select-error', state.error)
-  expectToggleClass($select, 'frost-select-focused', state.focused)
-  expectToggleClass($select, 'frost-select-opened', state.opened)
-
-  expect(
-    $select.prop('tabindex'),
-    'has expected tab index'
-  )
-    .to.equal(state.disabled ? -1 : state.tabIndex)
-
-  if (state.focusedItem) {
-    expect(
-      $('.frost-select-list-item-focused').text().trim(),
-      'is focused on expected item'
-    )
-      .to.equal(state.focusedItem)
-  }
-
-  const $emptyMessage = $('.frost-select-dropdown-empty-msg')
-
-  if (state.items && state.items.length !== 0) {
-    const labels = $('.frost-select-dropdown li')
-      .toArray()
-      .map((element) => element.textContent.trim())
-
-    expect(labels, 'has expected items').to.eql(state.items)
-    expect($emptyMessage, 'does not show empty message').to.have.length(0)
-  } else if (state.opened) {
-    expect($emptyMessage, 'shows empty message').to.have.length(1)
-  }
-
-  expect(
-    $select.find('.frost-select-text').text().trim(),
-    'has expected text'
-  )
-    .to.equal(state.text)
-}
-/* eslint-disable complexity */
-
-/**
- * Verify text input exists with expected state
- * @param {jQuery|String} input - name of Ember hook or jQuery instance
- * @param {FrostTextState} state - expected input state
- */
-export function expectTextInputWithState (input, state) {
-  const defaults = {
-    align: 'left',
-    disabled: false,
-    error: false,
-    tabIndex: 0,
-    type: 'text'
-  }
-
-  const $input = typeOf(input) === 'string' ? $hook(input) : input
-  state = assign(defaults, state)
-
-  expect(
-    $input.hasClass(state.align),
-    'input has correct text alignment'
-  )
-    .to.equal(true)
-
-  expectDisabledState($input, state.disabled, 'input')
-
-  expect(
-    $input.hasClass('error'),
-    `input ${state.error ? 'has' : 'does not have'} error class`
-  )
-    .to.equal(state.error)
-
-  ;[
-    'placeholder',
-    'tabIndex',
-    'type'
-  ]
-    .forEach((key) => {
-      if (state[key]) {
-        expect(
-          $input.prop(key),
-          `input as expected ${key}`
-        )
-          .to.equal(state[key])
-      }
-    })
-
-  if (state.value) {
-    expect(
-      $input.val(),
-      'input has expected value'
-    )
-      .to.equal(state.value)
-  }
 }
 
 /**
@@ -252,38 +39,6 @@ export function fillIn (element, value) {
 }
 
 /**
- * Get list of buttons
- * @returns {jQuery} buttons
- */
-export function findButtons () {
-  return $('.frost-button')
-}
-
-/**
- * Get list of text inputs
- * @returns {jQuery} text inputs
- * @param {FrostTextState} state - find inputs with state
- */
-export function findTextInputs (state) {
-  let $inputs = $('.frost-text input')
-
-  if (typeOf(state) !== 'object') {
-    return $inputs
-  }
-
-  return $inputs.filter((index, input) => {
-    if (
-      ('disabled' in state && input.disabled !== state.disabled) ||
-      ('type' in state && input.type !== state.type)
-    ) {
-      return false
-    }
-
-    return true
-  })
-}
-
-/**
  * Remove focus from element
  * @param {jQuery|String} element - name of Ember hook or jQuery instance
  */
@@ -291,6 +46,16 @@ export function focusout (element) {
   const $element = typeOf(element) === 'string' ? $hook(element) : element
   $element.focusout()
 }
+
+// TODO: Remove these as part of next major release, expecting consumers to
+// import {expectWithState} from 'dummy/tests/helpers/ember-frost-core/frost-select'
+// instead so we don't have to manange this import/re-export madness.
+export const expectButtonWithState = _expectButtonWithState
+export const expectSelectWithState = _expectSelectWithState
+export const expectTextInputWithState = _expectTextInputWithState
+export const filterSelect = _filterSelect
+export const findButtons = _findButtons
+export const findTextInputs = _findTextInputs
 
 export default {
   click,

--- a/test-support/helpers/ember-frost-core/frost-button.js
+++ b/test-support/helpers/ember-frost-core/frost-button.js
@@ -1,0 +1,57 @@
+/**
+ * @typedef {Object} FrostButtonState
+ * @property {Boolean} [disabled=false] - whether or not button is disabled
+ * @property {String} [icon] - name of button icon
+ * @property {String} [pack="frost"] - name of icon pack for button's icon
+ * @property {String} [text] - button text
+ */
+
+import {expect} from 'chai'
+import Ember from 'ember'
+const {$, typeOf} = Ember // eslint-disable-line
+import {$hook} from 'ember-hook'
+
+import {expectDisabledState} from './utils'
+
+const assign = Object.assign || Ember.assign || Ember.merge // eslint-disable-line
+
+/**
+ * Verify button exists with expected state
+ * @param {jQuery|String} button - name of Ember hook or jQuery instance
+ * @param {FrostButtonState} state - expected button state
+ */
+export function expectWithState (button, state) {
+  const defaults = {
+    disabled: false,
+    pack: 'frost'
+  }
+
+  const $button = typeOf(button) === 'string' ? $hook(button) : button
+  state = assign(defaults, state)
+
+  expectDisabledState($button, state.disabled, 'button')
+
+  if (state.icon && state.pack) {
+    expect(
+      $button.find(`.frost-icon-${state.pack}-${state.icon}`),
+      'button has expected icon'
+    )
+      .to.have.length(1)
+  }
+
+  if (state.text) {
+    expect(
+      $button.find('.text:not(.icon-text)').text().trim(),
+      'button has expected text'
+    )
+      .to.equal(state.text)
+  }
+}
+
+/**
+ * Get list of buttons
+ * @returns {jQuery} buttons
+ */
+export function find () {
+  return $('.frost-button')
+}

--- a/test-support/helpers/ember-frost-core/frost-select.js
+++ b/test-support/helpers/ember-frost-core/frost-select.js
@@ -56,7 +56,7 @@ export function expectWithState (select, state) {
 
   if (state.focusedItem) {
     expect(
-      $('.frost-select-list-item-focused').text().trim(),
+      $('.frost-select-list-item-focused .frost-select-list-item-text').data('text'),
       'is focused on expected item'
     )
       .to.equal(state.focusedItem)
@@ -67,7 +67,7 @@ export function expectWithState (select, state) {
   if (state.items && state.items.length !== 0) {
     const labels = $('.frost-select-dropdown li')
       .toArray()
-      .map((element) => element.textContent.trim())
+      .map((element) => $(element).find('.frost-select-list-item-text').data('text'))
 
     expect(labels, 'has expected items').to.eql(state.items)
     expect($emptyMessage, 'does not show empty message').to.have.length(0)

--- a/test-support/helpers/ember-frost-core/frost-select.js
+++ b/test-support/helpers/ember-frost-core/frost-select.js
@@ -94,6 +94,18 @@ export function filter (filter) {
 }
 
 /**
+ * Open frost-select dropdown
+ * @param {String} hook - frost-select hook
+ */
+export function open (hook) {
+  // In a real browser when you click on the select with your mouse a
+  // focusin event is fired on the component. However when using jQuery's
+  // click() method the focusin is not fired so we are programitcally
+  // triggering that in this test.
+  $hook('select').click().trigger('focusin')
+}
+
+/**
  * Select item in select dropdown at given index
  * NOTE: using done() instead of Promise based because promised based causes
  * select to lose focus for some reason. This may have something to with with

--- a/test-support/helpers/ember-frost-core/frost-select.js
+++ b/test-support/helpers/ember-frost-core/frost-select.js
@@ -88,6 +88,7 @@ export function expectWithState (select, state) {
  * @param {String} filter - filter to apply to select
  */
 export function filter (filter) {
+  $(window).trigger('resize') // For some reason we need to do this in Ember 2.3
   $('.frost-select-dropdown .frost-text-input')
     .val(filter)
     .trigger('input')

--- a/test-support/helpers/ember-frost-core/frost-select.js
+++ b/test-support/helpers/ember-frost-core/frost-select.js
@@ -1,0 +1,110 @@
+/**
+ * @typedef {Object} FrostSelectState
+ * @property {Boolean} [disabled=false] - whether or not select is disabled
+ * @property {Boolean} [error=false] - whether or not select has error
+ * @property {Boolean} [focused] - whether or not select is focused
+ * @property {String} [focusedItem] - label of focused item
+ * @property {String} [items] - list of item labels present in dropdown
+ * @property {Boolean} [opened=false] - whether or not select is opened
+ * @property {Number} [tabIndex=0] - tab index of root element
+ * @property {String} [text=''] - text in select for describing what is selected
+ */
+
+import {expect} from 'chai'
+import Ember from 'ember'
+const {$, RSVP, run, typeOf} = Ember // eslint-disable-line
+import {$hook} from 'ember-hook'
+
+import {expectToggleClass} from './utils'
+
+const assign = Object.assign || Ember.assign || Ember.merge // eslint-disable-line
+
+/* eslint-disable complexity */
+/**
+ * Verify select exists with expected state
+ * @param {jQuery|String} select - name of Ember hook or jQuery instance
+ * @param {FrostSelectState} state - expected select state
+ */
+export function expectWithState (select, state) {
+  const defaults = {
+    disabled: false,
+    error: false,
+    opened: false,
+    tabIndex: 0,
+    text: ''
+  }
+
+  const $select = typeOf(select) === 'string' ? $hook(select) : select
+  state = assign(defaults, state)
+
+  expect(
+    $select.hasClass('frost-select'),
+    'has frost-select class'
+  )
+    .to.equal(true)
+
+  expectToggleClass($select, 'frost-select-disabled', state.disabled)
+  expectToggleClass($select, 'frost-select-error', state.error)
+  expectToggleClass($select, 'frost-select-focused', state.focused)
+  expectToggleClass($select, 'frost-select-opened', state.opened)
+
+  expect(
+    $select.prop('tabindex'),
+    'has expected tab index'
+  )
+    .to.equal(state.disabled ? -1 : state.tabIndex)
+
+  if (state.focusedItem) {
+    expect(
+      $('.frost-select-list-item-focused').text().trim(),
+      'is focused on expected item'
+    )
+      .to.equal(state.focusedItem)
+  }
+
+  const $emptyMessage = $('.frost-select-dropdown-empty-msg')
+
+  if (state.items && state.items.length !== 0) {
+    const labels = $('.frost-select-dropdown li')
+      .toArray()
+      .map((element) => element.textContent.trim())
+
+    expect(labels, 'has expected items').to.eql(state.items)
+    expect($emptyMessage, 'does not show empty message').to.have.length(0)
+  } else if (state.opened) {
+    expect($emptyMessage, 'shows empty message').to.have.length(1)
+  }
+
+  expect(
+    $select.find('.frost-select-text').text().trim(),
+    'has expected text'
+  )
+    .to.equal(state.text)
+}
+/* eslint-disable complexity */
+
+/**
+ * Filter frost-select
+ * @param {String} filter - filter to apply to select
+ */
+export function filter (filter) {
+  $('.frost-select-dropdown .frost-text-input')
+    .val(filter)
+    .trigger('input')
+}
+
+/**
+ * Select item in select dropdown at given index
+ * NOTE: using done() instead of Promise based because promised based causes
+ * select to lose focus for some reason. This may have something to with with
+ * how mocha is handling done vs promise returns.
+ * @param {String} hook - frost-select hook
+ * @param {Number} index - index of item to select
+ * @param {Function} done - mocha done callback
+ */
+export function selectItemAtIndex (hook, index, done) {
+  $hook(`${hook}-item`, {index}).trigger('mousedown')
+  run.next(() => {
+    done()
+  })
+}

--- a/test-support/helpers/ember-frost-core/frost-text.js
+++ b/test-support/helpers/ember-frost-core/frost-text.js
@@ -1,0 +1,98 @@
+/**
+ * @typedef {Object} FrostTextState
+ * @property {String} [align="left"] - text alignment
+ * @property {Boolean} [disabled=false] - whether or not input is disabled
+ * @property {Boolean} [error=false] - whether or not input is in error state
+ * @property {String} [placeholder] - placeholder text
+ * @property {Number} [tabIndex=0] - tab index
+ * @property {String} [type='text'] - input type
+ * @property {String} [value] - value of input
+ */
+
+import {expect} from 'chai'
+import Ember from 'ember'
+const {$, typeOf} = Ember // eslint-disable-line
+import {$hook} from 'ember-hook'
+
+import {expectDisabledState} from './utils'
+
+const assign = Object.assign || Ember.assign || Ember.merge // eslint-disable-line
+
+/**
+ * Verify text input exists with expected state
+ * @param {jQuery|String} input - name of Ember hook or jQuery instance
+ * @param {FrostTextState} state - expected input state
+ */
+export function expectWithState (input, state) {
+  const defaults = {
+    align: 'left',
+    disabled: false,
+    error: false,
+    tabIndex: 0,
+    type: 'text'
+  }
+
+  const $input = typeOf(input) === 'string' ? $hook(input) : input
+  state = assign(defaults, state)
+
+  expect(
+    $input.hasClass(state.align),
+    'input has correct text alignment'
+  )
+    .to.equal(true)
+
+  expectDisabledState($input, state.disabled, 'input')
+
+  expect(
+    $input.hasClass('error'),
+    `input ${state.error ? 'has' : 'does not have'} error class`
+  )
+    .to.equal(state.error)
+
+  ;[
+    'placeholder',
+    'tabIndex',
+    'type'
+  ]
+    .forEach((key) => {
+      if (state[key]) {
+        expect(
+          $input.prop(key),
+          `input as expected ${key}`
+        )
+          .to.equal(state[key])
+      }
+    })
+
+  if (state.value) {
+    expect(
+      $input.val(),
+      'input has expected value'
+    )
+      .to.equal(state.value)
+  }
+}
+
+/**
+ * Get list of text inputs
+ * @returns {jQuery} text inputs
+ * @param {FrostTextState} state - find inputs with state
+ */
+export function find (state) {
+  let $inputs = $('.frost-text input')
+
+  if (typeOf(state) !== 'object') {
+    return $inputs
+  }
+
+  return $inputs.filter((index, input) => {
+    if (
+      ('disabled' in state && input.disabled !== state.disabled) ||
+      ('type' in state && input.type !== state.type)
+    ) {
+      return false
+    }
+
+    return true
+  })
+}

--- a/test-support/helpers/ember-frost-core/utils.js
+++ b/test-support/helpers/ember-frost-core/utils.js
@@ -1,0 +1,33 @@
+import {expect} from 'chai'
+
+/**
+ * Expect element to have disabled state
+ * @param {jQuery} $element - element
+ * @param {Boolean} disabled - disabled
+ * @param {String} [type='element'] - type of element
+ */
+export function expectDisabledState ($element, disabled, type = 'element') {
+  expect(
+    $element.is(':disabled'),
+    `${type} is ${disabled ? 'disabled' : 'enabled'}`
+  )
+    .to.equal(disabled)
+}
+
+/**
+ * Expect class on element depending on boolean state
+ * @param {jQuery} $element - element to check for class on
+ * @param {String} className - name of class
+ * @param {Boolean} state - whether or not class should be present
+ */
+export function expectToggleClass ($element, className, state) {
+  if (state === undefined) {
+    return
+  }
+
+  expect(
+    $element.hasClass(className),
+    `${state ? 'has' : 'does not have'} ${className} class`
+  )
+    .to.equal(state)
+}

--- a/tests/integration/components/frost-multi-select-test.js
+++ b/tests/integration/components/frost-multi-select-test.js
@@ -9,6 +9,7 @@ import {afterEach, beforeEach, describe} from 'mocha'
 import sinon from 'sinon'
 
 import {expectSelectWithState} from 'dummy/tests/helpers/ember-frost-core'
+import {selectItemAtIndex} from 'dummy/tests/helpers/ember-frost-core/frost-select'
 import {integration} from 'dummy/tests/helpers/ember-test-utils/describe-component'
 import keyCodes from 'ember-frost-core/utils/key-codes'
 const {DOWN_ARROW, ENTER, ESCAPE, SPACE, TAB, UP_ARROW} = keyCodes
@@ -943,10 +944,7 @@ describeComponent(...integration('frost-multi-select'), function () {
           describe('when first item clicked', function () {
             beforeEach(function (done) {
               [onBlur, onChange, onFocus].forEach((func) => func.reset())
-              $hook('select-item', {index: 0}).trigger('mousedown')
-              run.next(() => {
-                done()
-              })
+              return selectItemAtIndex('select', 0, done)
             })
 
             it('renders as expected', function () {
@@ -971,10 +969,7 @@ describeComponent(...integration('frost-multi-select'), function () {
           describe('when second item clicked', function () {
             beforeEach(function (done) {
               [onBlur, onChange, onFocus].forEach((func) => func.reset())
-              $hook('select-item', {index: 1}).trigger('mousedown')
-              run.next(() => {
-                done()
-              })
+              return selectItemAtIndex('select', 1, done)
             })
 
             it('renders as expected', function () {

--- a/tests/integration/components/frost-multi-select-test.js
+++ b/tests/integration/components/frost-multi-select-test.js
@@ -9,7 +9,7 @@ import {afterEach, beforeEach, describe} from 'mocha'
 import sinon from 'sinon'
 
 import {expectSelectWithState} from 'dummy/tests/helpers/ember-frost-core'
-import {selectItemAtIndex} from 'dummy/tests/helpers/ember-frost-core/frost-select'
+import {open, selectItemAtIndex} from 'dummy/tests/helpers/ember-frost-core/frost-select'
 import {integration} from 'dummy/tests/helpers/ember-test-utils/describe-component'
 import keyCodes from 'ember-frost-core/utils/key-codes'
 const {DOWN_ARROW, ENTER, ESCAPE, SPACE, TAB, UP_ARROW} = keyCodes
@@ -101,12 +101,7 @@ describeComponent(...integration('frost-multi-select'), function () {
 
       describe('click on component', function () {
         beforeEach(function () {
-          // In a real browser when you click on the select with your mouse a
-          // focusin event is fired on the component. However when using jQuery's
-          // click() method the focusin is not fired so we are programitcally
-          // triggering that in this test.
-
-          $hook('select').click().trigger('focusin')
+          open('select')
         })
 
         it('renders as expected', function () {
@@ -375,12 +370,7 @@ describeComponent(...integration('frost-multi-select'), function () {
 
         describe('click on component', function () {
           beforeEach(function () {
-            // In a real browser when you click on the select with your mouse a
-            // focusin event is fired on the component. However when using jQuery's
-            // click() method the focusin is not fired so we are programitcally
-            // triggering that in this test.
-
-            $hook('select').click().trigger('focusin')
+            open('select')
           })
 
           it('renders as expected', function () {
@@ -497,12 +487,7 @@ describeComponent(...integration('frost-multi-select'), function () {
 
       describe('click on component', function () {
         beforeEach(function () {
-          // In a real browser when you click on the select with your mouse a
-          // focusin event is fired on the component. However when using jQuery's
-          // click() method the focusin is not fired so we are programitcally
-          // triggering that in this test.
-
-          $hook('select').click().trigger('focusin')
+          open('select')
         })
 
         it('renders as expected', function () {
@@ -1063,12 +1048,7 @@ describeComponent(...integration('frost-multi-select'), function () {
 
         describe('click on component', function () {
           beforeEach(function () {
-            // In a real browser when you click on the select with your mouse a
-            // focusin event is fired on the component. However when using jQuery's
-            // click() method the focusin is not fired so we are programitcally
-            // triggering that in this test.
-
-            $hook('select').click().trigger('focusin')
+            open('select')
           })
 
           it('renders as expected', function () {

--- a/tests/integration/components/frost-select-test.js
+++ b/tests/integration/components/frost-select-test.js
@@ -9,7 +9,7 @@ import {afterEach, beforeEach, describe} from 'mocha'
 import sinon from 'sinon'
 
 import {expectSelectWithState, filterSelect} from 'dummy/tests/helpers/ember-frost-core'
-import {selectItemAtIndex} from 'dummy/tests/helpers/ember-frost-core/frost-select'
+import {open, selectItemAtIndex} from 'dummy/tests/helpers/ember-frost-core/frost-select'
 import {integration} from 'dummy/tests/helpers/ember-test-utils/describe-component'
 import {keyCodes} from 'ember-frost-core/utils'
 const {DOWN_ARROW, ENTER, ESCAPE, SPACE, TAB, UP_ARROW} = keyCodes
@@ -109,12 +109,7 @@ describeComponent(...integration('frost-select'), function () {
 
       describe('click on component', function () {
         beforeEach(function () {
-          // In a real browser when you click on the select with your mouse a
-          // focusin event is fired on the component. However when using jQuery's
-          // click() method the focusin is not fired so we are programitcally
-          // triggering that in this test.
-
-          $hook('select').click().trigger('focusin')
+          open('select')
         })
 
         it('renders as expected', function () {
@@ -383,12 +378,7 @@ describeComponent(...integration('frost-select'), function () {
 
         describe('click on component', function () {
           beforeEach(function () {
-            // In a real browser when you click on the select with your mouse a
-            // focusin event is fired on the component. However when using jQuery's
-            // click() method the focusin is not fired so we are programitcally
-            // triggering that in this test.
-
-            $hook('select').click().trigger('focusin')
+            open('select')
           })
 
           it('renders as expected', function () {
@@ -551,12 +541,7 @@ describeComponent(...integration('frost-select'), function () {
 
       describe('click on component', function () {
         beforeEach(function () {
-          // In a real browser when you click on the select with your mouse a
-          // focusin event is fired on the component. However when using jQuery's
-          // click() method the focusin is not fired so we are programitcally
-          // triggering that in this test.
-
-          $hook('select').click().trigger('focusin')
+          open('select')
         })
 
         it('renders as expected', function () {
@@ -1129,12 +1114,7 @@ describeComponent(...integration('frost-select'), function () {
 
         describe('click on component', function () {
           beforeEach(function () {
-            // In a real browser when you click on the select with your mouse a
-            // focusin event is fired on the component. However when using jQuery's
-            // click() method the focusin is not fired so we are programitcally
-            // triggering that in this test.
-
-            $hook('select').click().trigger('focusin')
+            open('select')
           })
 
           it('renders as expected', function () {

--- a/tests/integration/components/frost-select-test.js
+++ b/tests/integration/components/frost-select-test.js
@@ -9,6 +9,7 @@ import {afterEach, beforeEach, describe} from 'mocha'
 import sinon from 'sinon'
 
 import {expectSelectWithState, filterSelect} from 'dummy/tests/helpers/ember-frost-core'
+import {selectItemAtIndex} from 'dummy/tests/helpers/ember-frost-core/frost-select'
 import {integration} from 'dummy/tests/helpers/ember-test-utils/describe-component'
 import {keyCodes} from 'ember-frost-core/utils'
 const {DOWN_ARROW, ENTER, ESCAPE, SPACE, TAB, UP_ARROW} = keyCodes
@@ -931,10 +932,7 @@ describeComponent(...integration('frost-select'), function () {
           describe('when first item clicked', function () {
             beforeEach(function (done) {
               [onBlur, onChange, onFocus].forEach((func) => func.reset())
-              $hook('select-item', {index: 0}).trigger('mousedown')
-              run.next(() => {
-                done()
-              })
+              return selectItemAtIndex('select', 0, done)
             })
 
             it('renders as expected', function () {
@@ -958,10 +956,7 @@ describeComponent(...integration('frost-select'), function () {
           describe('when second item clicked', function () {
             beforeEach(function (done) {
               [onBlur, onChange, onFocus].forEach((func) => func.reset())
-              $hook('select-item', {index: 1}).trigger('mousedown')
-              run.next(() => {
-                done()
-              })
+              selectItemAtIndex('select', 1, done)
             })
 
             it('renders as expected', function () {

--- a/tests/integration/components/frost-select-test.js
+++ b/tests/integration/components/frost-select-test.js
@@ -50,7 +50,7 @@ function focusNext ($element) {
  * @returns {String} list item's HTML
  */
 function getItemHtml (index) {
-  return $(`.frost-select-dropdown li:nth-child(${index})`)
+  return $(`.frost-select-dropdown li:nth-child(${index}) .frost-select-list-item-text`)
     .html()
     .replace('<!---->', '')
     .trim()

--- a/tests/unit/utils/text-test.js
+++ b/tests/unit/utils/text-test.js
@@ -1,0 +1,77 @@
+import {expect} from 'chai'
+import Ember from 'ember'
+const {$} = Ember
+import {afterEach, beforeEach, describe, it} from 'mocha'
+
+import {trimDataToFit, trimLongDataInElement} from 'ember-frost-core/utils/text'
+
+describe('Unit / Utils / text', () => {
+  describe('.trimDataToFit()', () => {
+    it('does not throw an error when text is undefined', () => {
+      expect(() => {
+        trimDataToFit(undefined, 300)
+      }).not.to.throw()
+    })
+
+    it('does not throw an error when text is empty', () => {
+      expect(() => {
+        trimDataToFit('', 300)
+      }).not.to.throw()
+    })
+
+    it('returns original text when width is wider than text width', () => {
+      const text = 'my text'
+      expect(trimDataToFit(text, 5000)).to.equal(text)
+    })
+  })
+
+  describe('.trimLongDataInElement()', () => {
+    let $element, text
+
+    beforeEach(() => {
+      text = 'The quick brown fox'
+      $element = $(`<div data-text="${text}">${text}</div>`).appendTo('body')
+      $element.css({
+        font: 'normal normal normal 10px/14px Arial'
+      })
+    })
+
+    afterEach(() => {
+      $element.remove()
+    })
+
+    describe('when text fits within element', () => {
+      beforeEach(() => {
+        $element.width(200)
+        trimLongDataInElement($element.get(0))
+      })
+
+      it('does not trim text', () => {
+        expect($element).to.have.text(text)
+      })
+
+      it('does not set title', () => {
+        expect($element).to.have.prop('title', '')
+      })
+    })
+
+    describe('when text does not fit within element', () => {
+      beforeEach(() => {
+        $element.width(80)
+        trimLongDataInElement($element.get(0))
+      })
+
+      it('trims text', () => {
+        let currentText = $element.text()
+
+        expect(currentText.indexOf('The')).to.eql(0)
+        expect(currentText.indexOf('…')).not.to.eql(-1)
+        expect(currentText.indexOf('fox')).to.eql(currentText.length - 3)
+      })
+
+      it('sets title to full text', () => {
+        expect($element).to.have.prop('title', text)
+      })
+    })
+  })
+})


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

![select-trimmed-text](https://cloud.githubusercontent.com/assets/422902/22540880/930a0578-e8d7-11e6-8fd8-0cd759adf1f9.gif)


# CHANGELOG

* **Added** ellipsis in middle of select item labels when the text is trimmed instead of at the end as well as show the full label on mouseover. Prior to this change there was no way to see the full label when it is too wide.

* **Added** new `open()` and `selectItemAtIndex()` test helpers for `frost-select` which can be used like so (in example the hook for the select being tested is `mySelect`):

  ```js
  import {
    expectWithState as expectSelectWithState,
    open,
    selectItemAtIndex
  } from 'dummy/tests/helpers/ember-frost-core/frost-select'

  // before below test can run you'd need to render whatever DOM is necessary for your test

  describe('when select opened', function () {
    beforeEach(function () {
      open('mySelect')
    })

    describe('when first item selected', function () {
      beforeEach(function (done) {
        selectItemAtIndex('mySelect', 0, done)
      })

      it('renders as expected', function () {
        expectSelectWithState('mySelect', {
          focused: true,
          opened: false,
          text: 'My first item'
        })
      })
    })
  })
  ```
