### PR TITLE
update unit and integration tests to not use deprecated describeComponent()

### DIFF
--- a/tests/integration/components/frost-checkbox-test.js
+++ b/tests/integration/components/frost-checkbox-test.js
@@ -1,304 +1,301 @@
 import {expect} from 'chai'
-import {describeComponent, it} from 'ember-mocha'
 import wait from 'ember-test-helpers/wait'
 import hbs from 'htmlbars-inline-precompile'
-import {describe} from 'mocha'
+import {describe, it} from 'mocha'
 import sinon from 'sinon'
 
-describeComponent(
-  'frost-checkbox',
-  'Integration: FrostCheckboxComponent',
-  {
-    integration: true
-  },
-  function () {
-    it('renders default values', function () {
-      this.render(hbs`
-        {{frost-checkbox hook='myCheckbox'}}
-      `)
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
-      expect(
-        this.$('.frost-checkbox').hasClass('small'),
-        'Has class "small"'
-      ).to.equal(true)
+const test = integration('frost-checkbox')
+describe(test.label, function () {
+  test.setup()
 
-      expect(
-        this.$('.frost-checkbox').find('label').prop('for'),
-        '"label for" property has the correct value'
-      ).to.eql(
-        this.$('.frost-checkbox').find('input').prop('id')
-      )
+  it('renders default values', function () {
+    this.render(hbs`
+      {{frost-checkbox hook='myCheckbox'}}
+    `)
 
-      expect(
-        this.$('.frost-checkbox').find('label').prop('tabIndex'),
-        'label tabindex set to 0'
-      ).to.eql(0)
+    expect(
+      this.$('.frost-checkbox').hasClass('small'),
+      'Has class "small"'
+    ).to.equal(true)
+
+    expect(
+      this.$('.frost-checkbox').find('label').prop('for'),
+      '"label for" property has the correct value'
+    ).to.eql(
+      this.$('.frost-checkbox').find('input').prop('id')
+    )
+
+    expect(
+      this.$('.frost-checkbox').find('label').prop('tabIndex'),
+      'label tabindex set to 0'
+    ).to.eql(0)
+  })
+
+  it('sets size class correctly', function () {
+    this.set('size', 'medium')
+
+    this.render(hbs`
+      {{frost-checkbox hook='myCheckbox' size=size}}
+    `)
+
+    expect(
+      this.$('.frost-checkbox').hasClass('medium'),
+      'Has class "medium"'
+    ).to.equal(true)
+
+    this.set('size', 'large')
+
+    expect(
+      this.$('.frost-checkbox').hasClass('large'),
+      'Has class "large"'
+    ).to.equal(true)
+  })
+
+  it('sets checked state property to input', function () {
+    this.render(hbs`
+      {{frost-checkbox hook='myCheckbox'}}
+    `)
+
+    expect(
+      this.$('.frost-checkbox').find('input').prop('checked'),
+      'Rendered input is not checked'
+    ).to.equal(false)
+
+    this.render(hbs`
+      {{frost-checkbox checked=true hook='myCheckbox'}}
+    `)
+
+    expect(
+      this.$('.frost-checkbox').find('input').prop('checked'),
+      'Rendered input is checked'
+    ).to.equal(true)
+  })
+
+  it('sets error class correctly', function () {
+    this.render(hbs`
+      {{frost-checkbox hook='myCheckbox'}}
+    `)
+
+    expect(
+      this.$('.frost-checkbox').hasClass('error'),
+      'Initially does not have class "error"'
+    ).to.equal(false)
+
+    this.render(hbs`
+      {{frost-checkbox class="error" hook='myCheckbox'}}
+    `)
+
+    expect(
+      this.$('.frost-checkbox').hasClass('error'),
+      'Has class "error"'
+    ).to.equal(true)
+  })
+
+  it('sets disabled state property to input', function () {
+    this.render(hbs`
+      {{frost-checkbox hook='myCheckbox'}}
+    `)
+
+    expect(
+      this.$('.frost-checkbox').find('input').prop('disabled'),
+      'Rendered input is initially enabled'
+    ).to.equal(false)
+
+    this.render(hbs`
+      {{frost-checkbox disabled=true hook='myCheckbox'}}
+    `)
+
+    expect(
+      this.$('.frost-checkbox').find('input').prop('disabled'),
+      'Rendered input is disabled'
+    ).to.equal(true)
+  })
+
+  it('renders label when it is set', function () {
+    this.render(hbs`
+      {{frost-checkbox hook='myCheckbox'}}
+    `)
+
+    expect(
+      this.$('.frost-checkbox').find('label').text().trim(),
+      'The "label" property text is not set'
+    ).to.eql('')
+
+    this.render(hbs`
+      {{frost-checkbox hook='myCheckbox' label="lorem ipsum"}}
+    `)
+
+    expect(
+      this.$('.frost-checkbox').find('label').text().trim(),
+      'The "label" property text was set'
+    ).to.eql('lorem ipsum')
+  })
+
+  it('triggers value change', function () {
+    this.set('checkbox-value', false)
+    this.on('valueChange', function (attrs) {
+      this.set('checkbox-value', attrs.value)
     })
+    this.render(hbs`{{frost-checkbox
+      hook='myCheckbox'
+      id="value"
+      value="value"
+      onInput=(action 'valueChange')
+      label='value'}}
+    `)
 
-    it('sets size class correctly', function () {
-      this.set('size', 'medium')
+    var input = this.$('input')
+    input.trigger('click')
 
-      this.render(hbs`
-        {{frost-checkbox hook='myCheckbox' size=size}}
-      `)
-
-      expect(
-        this.$('.frost-checkbox').hasClass('medium'),
-        'Has class "medium"'
-      ).to.equal(true)
-
-      this.set('size', 'large')
-
-      expect(
-        this.$('.frost-checkbox').hasClass('large'),
-        'Has class "large"'
-      ).to.equal(true)
-    })
-
-    it('sets checked state property to input', function () {
-      this.render(hbs`
-        {{frost-checkbox hook='myCheckbox'}}
-      `)
-
-      expect(
-        this.$('.frost-checkbox').find('input').prop('checked'),
-        'Rendered input is not checked'
-      ).to.equal(false)
-
-      this.render(hbs`
-        {{frost-checkbox checked=true hook='myCheckbox'}}
-      `)
-
-      expect(
-        this.$('.frost-checkbox').find('input').prop('checked'),
-        'Rendered input is checked'
-      ).to.equal(true)
-    })
-
-    it('sets error class correctly', function () {
-      this.render(hbs`
-        {{frost-checkbox hook='myCheckbox'}}
-      `)
-
-      expect(
-        this.$('.frost-checkbox').hasClass('error'),
-        'Initially does not have class "error"'
-      ).to.equal(false)
-
-      this.render(hbs`
-        {{frost-checkbox class="error" hook='myCheckbox'}}
-      `)
-
-      expect(
-        this.$('.frost-checkbox').hasClass('error'),
-        'Has class "error"'
-      ).to.equal(true)
-    })
-
-    it('sets disabled state property to input', function () {
-      this.render(hbs`
-        {{frost-checkbox hook='myCheckbox'}}
-      `)
-
-      expect(
-        this.$('.frost-checkbox').find('input').prop('disabled'),
-        'Rendered input is initially enabled'
-      ).to.equal(false)
-
-      this.render(hbs`
-        {{frost-checkbox disabled=true hook='myCheckbox'}}
-      `)
-
-      expect(
-        this.$('.frost-checkbox').find('input').prop('disabled'),
-        'Rendered input is disabled'
-      ).to.equal(true)
-    })
-
-    it('renders label when it is set', function () {
-      this.render(hbs`
-        {{frost-checkbox hook='myCheckbox'}}
-      `)
-
-      expect(
-        this.$('.frost-checkbox').find('label').text().trim(),
-        'The "label" property text is not set'
-      ).to.eql('')
-
-      this.render(hbs`
-        {{frost-checkbox hook='myCheckbox' label="lorem ipsum"}}
-      `)
-
-      expect(
-        this.$('.frost-checkbox').find('label').text().trim(),
-        'The "label" property text was set'
-      ).to.eql('lorem ipsum')
-    })
-
-    it('triggers value change', function () {
-      this.set('checkbox-value', false)
-      this.on('valueChange', function (attrs) {
-        this.set('checkbox-value', attrs.value)
+    return wait()
+      .then(() => {
+        expect(this.get('checkbox-value')).to.eql(true)
       })
-      this.render(hbs`{{frost-checkbox
+  })
+
+  describe('calls onInput closure action', function () {
+    it('has an object with id set to value', function () {
+      const externalActionSpy = sinon.spy()
+      const testValue = 'test'
+
+      this.set('testValue', testValue)
+
+      this.on('externalAction', externalActionSpy)
+
+      this.render(hbs`
+        {{frost-checkbox
+          hook='myCheckbox'
+          onInput=(action 'externalAction')
+          value=testValue
+        }}
+      `)
+
+      this.$('input').trigger('click')
+
+      expect(
+        externalActionSpy.calledWith({
+          id: testValue,
+          value: true
+        }),
+        'onInput() is called with id set to value'
+      ).to.equal(true)
+    })
+
+    it('has an object with id set to elementId', function () {
+      const externalActionSpy = sinon.spy()
+
+      this.on('externalAction', externalActionSpy)
+
+      this.render(hbs`
+        {{frost-checkbox
+          hook='myCheckbox'
+          onInput=(action 'externalAction')
+        }}
+      `)
+
+      this.$('input').trigger('click')
+
+      expect(
+        externalActionSpy.calledWith({
+          id: this.$('.frost-checkbox').prop('id'),
+          value: true
+        }),
+        'onInput() is called with id set to value'
+      ).to.equal(true)
+    })
+  })
+
+  it('calls onBlur callback when focus is lost', function () {
+    const externalActionSpy = sinon.spy()
+
+    this.on('externalAction', externalActionSpy)
+
+    this.render(hbs`
+      {{frost-checkbox
         hook='myCheckbox'
-        id="value"
-        value="value"
-        onInput=(action 'valueChange')
-        label='value'}}
-      `)
+        onBlur=(action 'externalAction')
+      }}
+    `)
 
-      var input = this.$('input')
-      input.trigger('click')
+    this.$('label').trigger('blur')
 
-      return wait()
-        .then(() => {
-          expect(this.get('checkbox-value')).to.eql(true)
-        })
-    })
+    expect(
+      externalActionSpy.called,
+      'onBlur closure action called'
+    ).to.equal(true)
+  })
 
-    describe('calls onInput closure action', function () {
-      it('has an object with id set to value', function () {
-        const externalActionSpy = sinon.spy()
-        const testValue = 'test'
+  it('calls onFocus closure action', function () {
+    const externalActionSpy = sinon.spy()
 
-        this.set('testValue', testValue)
+    this.on('externalAction', externalActionSpy)
 
-        this.on('externalAction', externalActionSpy)
+    this.render(hbs`
+      {{frost-checkbox
+        hook='myCheckbox'
+        onFocus=(action 'externalAction')
+      }}
+    `)
 
-        this.render(hbs`
-          {{frost-checkbox
-            hook='myCheckbox'
-            onInput=(action 'externalAction')
-            value=testValue
-          }}
-        `)
+    this.$('input').trigger('focusin')
 
-        this.$('input').trigger('click')
+    expect(
+      externalActionSpy.called,
+      'onFocus closure action called'
+    ).to.equal(true)
+  })
 
-        expect(
-          externalActionSpy.calledWith({
-            id: testValue,
-            value: true
-          }),
-          'onInput() is called with id set to value'
-        ).to.equal(true)
-      })
+  // https://github.com/juwara0/ember-frost-core/issues/1
+  it.skip('sets focus on render when autofocus is true', function () {
+    const focusSpy = sinon.spy(this.$.prototype, 'focus')
 
-      it('has an object with id set to elementId', function () {
-        const externalActionSpy = sinon.spy()
+    this.render(hbs`
+      {{frost-checkbox
+        autofocus=true
+        hook='myCheckbox'
+      }}
+    `)
 
-        this.on('externalAction', externalActionSpy)
+    expect(
+      focusSpy.called,
+      'autofocus is set'
+    ).to.equal(true)
 
-        this.render(hbs`
-          {{frost-checkbox
-            hook='myCheckbox'
-            onInput=(action 'externalAction')
-          }}
-        `)
+    this.$.prototype.focus.restore()
+  })
 
-        this.$('input').trigger('click')
-
-        expect(
-          externalActionSpy.calledWith({
-            id: this.$('.frost-checkbox').prop('id'),
-            value: true
-          }),
-          'onInput() is called with id set to value'
-        ).to.equal(true)
-      })
-    })
-
-    it('calls onBlur callback when focus is lost', function () {
-      const externalActionSpy = sinon.spy()
-
-      this.on('externalAction', externalActionSpy)
-
-      this.render(hbs`
-        {{frost-checkbox
+  it('renders using spread', function () {
+    this.render(hbs`
+      {{frost-checkbox
+        options=(hash
+          checked=true
           hook='myCheckbox'
-          onBlur=(action 'externalAction')
-        }}
-      `)
+        )
+      }}
+    `)
 
-      this.$('label').trigger('blur')
+    expect(
+      this.$('.frost-checkbox').hasClass('small'),
+      'Has class "small"'
+    ).to.equal(true)
 
-      expect(
-        externalActionSpy.called,
-        'onBlur closure action called'
-      ).to.equal(true)
-    })
+    expect(
+      this.$('.frost-checkbox').find('label').prop('for'),
+      '"label for" property has the correct value'
+    ).to.eql(
+      this.$('.frost-checkbox').find('input').prop('id')
+    )
 
-    it('calls onFocus closure action', function () {
-      const externalActionSpy = sinon.spy()
+    expect(
+      this.$('.frost-checkbox').find('label').prop('tabIndex'),
+      'label tabindex set to 0'
+    ).to.eql(0)
 
-      this.on('externalAction', externalActionSpy)
-
-      this.render(hbs`
-        {{frost-checkbox
-          hook='myCheckbox'
-          onFocus=(action 'externalAction')
-        }}
-      `)
-
-      this.$('input').trigger('focusin')
-
-      expect(
-        externalActionSpy.called,
-        'onFocus closure action called'
-      ).to.equal(true)
-    })
-
-    // https://github.com/juwara0/ember-frost-core/issues/1
-    it.skip('sets focus on render when autofocus is true', function () {
-      const focusSpy = sinon.spy(this.$.prototype, 'focus')
-
-      this.render(hbs`
-        {{frost-checkbox
-          autofocus=true
-          hook='myCheckbox'
-        }}
-      `)
-
-      expect(
-        focusSpy.called,
-        'autofocus is set'
-      ).to.equal(true)
-
-      this.$.prototype.focus.restore()
-    })
-
-    it('renders using spread', function () {
-      this.render(hbs`
-        {{frost-checkbox
-          options=(hash
-            checked=true
-            hook='myCheckbox'
-          )
-        }}
-      `)
-
-      expect(
-        this.$('.frost-checkbox').hasClass('small'),
-        'Has class "small"'
-      ).to.equal(true)
-
-      expect(
-        this.$('.frost-checkbox').find('label').prop('for'),
-        '"label for" property has the correct value'
-      ).to.eql(
-        this.$('.frost-checkbox').find('input').prop('id')
-      )
-
-      expect(
-        this.$('.frost-checkbox').find('label').prop('tabIndex'),
-        'label tabindex set to 0'
-      ).to.eql(0)
-
-      expect(
-        this.$('.frost-checkbox').find('input').prop('checked'),
-        'Rendered input is checked'
-      ).to.equal(true)
-    })
-  }
-)
+    expect(
+      this.$('.frost-checkbox').find('input').prop('checked'),
+      'Rendered input is checked'
+    ).to.equal(true)
+  })
+})

--- a/tests/integration/components/frost-events-test.js
+++ b/tests/integration/components/frost-events-test.js
@@ -1,163 +1,160 @@
 import {expect} from 'chai'
 import Ember from 'ember'
-import FrostEventsProxy from 'ember-frost-core/mixins/frost-events-proxy'
-import {describeComponent, it} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
-import {beforeEach, describe} from 'mocha'
+import {beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
+
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
+import FrostEventsProxy from 'ember-frost-core/mixins/frost-events-proxy'
 
 const {Component, Handlebars} = Ember
 
-describeComponent(
-  'frost-events',
-  'Integration: FrostEventsComponent',
-  {
-    integration: true
-  },
-  function () {
-    beforeEach(function () {
-      const mockComponentTemplate = hbs`
-        {{hookable-input
-          change=_eventProxy.change
-          click=_eventProxy.click
-          contextMenu=_eventProxy.contextMenu
-          doubleClick=_eventProxy.doubleClick
-          drag=_eventProxy.drag
-          dragEnd=_eventProxy.dragEnd
-          dragEnter=_eventProxy.dragEnter
-          dragLeave=_eventProxy.dragLeave
-          dragOver=_eventProxy.dragOver
-          dragStart=_eventProxy.dragStart
-          drop=_eventProxy.drop
-          focusIn=_eventProxy.focusIn
-          focusOut=_eventProxy.focusOut
-          input=_eventProxy.input
-          keyDown=_eventProxy.keyDown
-          keyPress=_eventProxy.keyPress
-          keyUp=_eventProxy.keyUp
-          mouseDown=_eventProxy.mouseDown
-          mouseEnter=_eventProxy.mouseEnter
-          mouseLeave=_eventProxy.mouseLeave
-          mouseMove=_eventProxy.mouseMove
-          mouseUp=_eventProxy.mouseUp
-          submit=_eventProxy.submit
-          touchCancel=_eventProxy.touchCancel
-          touchEnd=_eventProxy.touchEnd
-          touchMove=_eventProxy.touchMove
-          touchStart=_eventProxy.touchStart
-        }}
-      `
+const test = integration('frost-events')
+describe(test.label, function () {
+  test.setup()
 
-      const mockComponent = Component.extend(FrostEventsProxy, {
-        layoutName: 'mock-component'
-      })
+  beforeEach(function () {
+    const mockComponentTemplate = hbs`
+      {{hookable-input
+        change=_eventProxy.change
+        click=_eventProxy.click
+        contextMenu=_eventProxy.contextMenu
+        doubleClick=_eventProxy.doubleClick
+        drag=_eventProxy.drag
+        dragEnd=_eventProxy.dragEnd
+        dragEnter=_eventProxy.dragEnter
+        dragLeave=_eventProxy.dragLeave
+        dragOver=_eventProxy.dragOver
+        dragStart=_eventProxy.dragStart
+        drop=_eventProxy.drop
+        focusIn=_eventProxy.focusIn
+        focusOut=_eventProxy.focusOut
+        input=_eventProxy.input
+        keyDown=_eventProxy.keyDown
+        keyPress=_eventProxy.keyPress
+        keyUp=_eventProxy.keyUp
+        mouseDown=_eventProxy.mouseDown
+        mouseEnter=_eventProxy.mouseEnter
+        mouseLeave=_eventProxy.mouseLeave
+        mouseMove=_eventProxy.mouseMove
+        mouseUp=_eventProxy.mouseUp
+        submit=_eventProxy.submit
+        touchCancel=_eventProxy.touchCancel
+        touchEnd=_eventProxy.touchEnd
+        touchMove=_eventProxy.touchMove
+        touchStart=_eventProxy.touchStart
+      }}
+    `
 
-      this.register('template:mock-component', mockComponentTemplate)
-      this.register('component:mock-component', mockComponent)
-
-      // Create mock component to test the text support events
-      const textSupportComponentTemplate = hbs`
-        {{hookable-input
-          escape-press=_eventProxy.escape-press
-          insert-newline=_eventProxy.enter
-        }}
-      `
-
-      const textSupportComponent = Component.extend(FrostEventsProxy, {
-        layoutName: 'text-support'
-      })
-
-      this.register('template:text-support', textSupportComponentTemplate)
-      this.register('component:text-support', textSupportComponent)
+    const mockComponent = Component.extend(FrostEventsProxy, {
+      layoutName: 'mock-component'
     })
 
-    describe('Event types', function () {
-      const eventTypes = [
-        {in: 'onChange', out: 'change'},
-        {in: 'onClick', out: 'click'},
-        {in: 'onContextMenu', out: 'contextmenu'},
-        {in: 'onDoubleClick', out: 'dblclick'},
-        {in: 'onDrag', out: 'drag'},
-        {in: 'onDragEnd', out: 'dragend'},
-        {in: 'onDragEnter', out: 'dragenter'},
-        {in: 'onDragLeave', out: 'dragleave'},
-        {in: 'onDragOver', out: 'dragover'},
-        {in: 'onDragStart', out: 'dragstart'},
-        {in: 'onDrop', out: 'drop'},
-        {in: 'onFocusIn', out: 'focusin'},
-        {in: 'onFocus', out: 'focusin'},
-        {in: 'onFocusOut', out: 'focusout'},
-        {in: 'onBlur', out: 'focusout'},
-        {in: 'onInput', out: 'input'},
-        {in: 'onKeyDown', out: 'keydown'},
-        {in: 'onKeyPress', out: 'keypress'},
-        {in: 'onKeyUp', out: 'keyup'},
-        {in: 'onMouseDown', out: 'mousedown'},
-        {in: 'onMouseEnter', out: 'mouseenter'},
-        {in: 'onMouseLeave', out: 'mouseleave'},
-        {in: 'onMouseMove', out: 'mousemove'},
-        {in: 'onMouseUp', out: 'mouseup'},
-        {in: 'onSubmit', out: 'submit'},
-        {in: 'onTouchCancel', out: 'touchcancel'},
-        {in: 'onTouchEnd', out: 'touchend'},
-        {in: 'onTouchMove', out: 'touchmove'},
-        {in: 'onTouchStart', out: 'touchstart'}
-      ]
+    this.register('template:mock-component', mockComponentTemplate)
+    this.register('component:mock-component', mockComponent)
 
-      eventTypes.forEach((test) => {
-        it(`calls ${test.in} closure action`, function () {
-          const externalActionSpy = sinon.spy()
-          const template = Handlebars.compile(`
-            {{mock-component ${test.in}=(action 'externalAction')}}
-          `)
+    // Create mock component to test the text support events
+    const textSupportComponentTemplate = hbs`
+      {{hookable-input
+        escape-press=_eventProxy.escape-press
+        insert-newline=_eventProxy.enter
+      }}
+    `
 
-          this.on('externalAction', externalActionSpy)
-
-          this.render(template)
-
-          this.$('input').trigger(`${test.out}`)
-
-          expect(
-            externalActionSpy.called,
-            `${test.in} closure action called`
-          ).to.equal(true)
-        })
-      })
+    const textSupportComponent = Component.extend(FrostEventsProxy, {
+      layoutName: 'text-support'
     })
 
-    /* trigger pressing the `escape` or the `enter` key
-     *
-     * keypress doesn't seem to be handled consistently between browsers so using
-     *  keyup since it is consistent. Specifying `which: <keycode>` instead of the
-     *  `keyCode: <keycode>` did not work though.
-     *
-     * http://stackoverflow.com/questions/1160008/which-keycode-for-escape-key-with-jquery/28502629#28502629
-     */
-    describe('Text support event types', function () {
-      const eventTypes = [
-        {in: 'onEscape', out: '27'},
-        {in: 'onEnter', out: '13'}
-      ]
+    this.register('template:text-support', textSupportComponentTemplate)
+    this.register('component:text-support', textSupportComponent)
+  })
 
-      eventTypes.forEach((test) => {
-        it(`calls ${test.in} closure action`, function () {
-          const externalActionSpy = sinon.spy()
-          const template = Handlebars.compile(`
-            {{text-support ${test.in}=(action 'externalAction')}}
-          `)
+  describe('Event types', function () {
+    const eventTypes = [
+      {in: 'onChange', out: 'change'},
+      {in: 'onClick', out: 'click'},
+      {in: 'onContextMenu', out: 'contextmenu'},
+      {in: 'onDoubleClick', out: 'dblclick'},
+      {in: 'onDrag', out: 'drag'},
+      {in: 'onDragEnd', out: 'dragend'},
+      {in: 'onDragEnter', out: 'dragenter'},
+      {in: 'onDragLeave', out: 'dragleave'},
+      {in: 'onDragOver', out: 'dragover'},
+      {in: 'onDragStart', out: 'dragstart'},
+      {in: 'onDrop', out: 'drop'},
+      {in: 'onFocusIn', out: 'focusin'},
+      {in: 'onFocus', out: 'focusin'},
+      {in: 'onFocusOut', out: 'focusout'},
+      {in: 'onBlur', out: 'focusout'},
+      {in: 'onInput', out: 'input'},
+      {in: 'onKeyDown', out: 'keydown'},
+      {in: 'onKeyPress', out: 'keypress'},
+      {in: 'onKeyUp', out: 'keyup'},
+      {in: 'onMouseDown', out: 'mousedown'},
+      {in: 'onMouseEnter', out: 'mouseenter'},
+      {in: 'onMouseLeave', out: 'mouseleave'},
+      {in: 'onMouseMove', out: 'mousemove'},
+      {in: 'onMouseUp', out: 'mouseup'},
+      {in: 'onSubmit', out: 'submit'},
+      {in: 'onTouchCancel', out: 'touchcancel'},
+      {in: 'onTouchEnd', out: 'touchend'},
+      {in: 'onTouchMove', out: 'touchmove'},
+      {in: 'onTouchStart', out: 'touchstart'}
+    ]
 
-          this.on('externalAction', externalActionSpy)
+    eventTypes.forEach((test) => {
+      it(`calls ${test.in} closure action`, function () {
+        const externalActionSpy = sinon.spy()
+        const template = Handlebars.compile(`
+          {{mock-component ${test.in}=(action 'externalAction')}}
+        `)
 
-          this.render(template)
+        this.on('externalAction', externalActionSpy)
 
-          this.$('input').trigger({type: 'keyup', keyCode: `${test.out}`})
+        this.render(template)
 
-          expect(
-            externalActionSpy.called,
-            `${test.in} closure action called`
-          ).to.equal(true)
-        })
+        this.$('input').trigger(`${test.out}`)
+
+        expect(
+          externalActionSpy.called,
+          `${test.in} closure action called`
+        ).to.equal(true)
       })
     })
-  }
-)
+  })
+
+  /* trigger pressing the `escape` or the `enter` key
+   *
+   * keypress doesn't seem to be handled consistently between browsers so using
+   *  keyup since it is consistent. Specifying `which: <keycode>` instead of the
+   *  `keyCode: <keycode>` did not work though.
+   *
+   * http://stackoverflow.com/questions/1160008/which-keycode-for-escape-key-with-jquery/28502629#28502629
+   */
+  describe('Text support event types', function () {
+    const eventTypes = [
+      {in: 'onEscape', out: '27'},
+      {in: 'onEnter', out: '13'}
+    ]
+
+    eventTypes.forEach((test) => {
+      it(`calls ${test.in} closure action`, function () {
+        const externalActionSpy = sinon.spy()
+        const template = Handlebars.compile(`
+          {{text-support ${test.in}=(action 'externalAction')}}
+        `)
+
+        this.on('externalAction', externalActionSpy)
+
+        this.render(template)
+
+        this.$('input').trigger({type: 'keyup', keyCode: `${test.out}`})
+
+        expect(
+          externalActionSpy.called,
+          `${test.in} closure action called`
+        ).to.equal(true)
+      })
+    })
+  })
+})

--- a/tests/integration/components/frost-icon-test.js
+++ b/tests/integration/components/frost-icon-test.js
@@ -1,50 +1,47 @@
 import {expect} from 'chai'
-import {describeComponent, it} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
+import {describe, it} from 'mocha'
 
-describeComponent(
-  'frost-icon',
-  'Integration: FrostIconComponent',
-  {
-    integration: true
-  },
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
-  function () {
-    it('sets icon class', function () {
-      this.render(hbs`
-        {{frost-icon hook='myIcon' icon='round-add'}}
-      `)
+const test = integration('frost-icon')
+describe(test.label, function () {
+  test.setup()
 
-      expect(
-        this.$('.frost-icon-frost-round-add'),
-        'Icon class is set correctly.'
-      ).to.have.length(1)
-    })
+  it('sets icon class', function () {
+    this.render(hbs`
+      {{frost-icon hook='myIcon' icon='round-add'}}
+    `)
 
-    it('sets the pack property', function () {
-      this.render(hbs`
-        {{frost-icon
-          hook='myIcon'
-          pack='test'
-          icon='round-add'
-        }}
-      `)
+    expect(
+      this.$('.frost-icon-frost-round-add'),
+      'Icon class is set correctly.'
+    ).to.have.length(1)
+  })
 
-      expect(
-        this.$('.frost-icon-test-round-add'),
-        'Icon class updates correctly when pack is set.'
-      ).to.have.length(1)
-    })
+  it('sets the pack property', function () {
+    this.render(hbs`
+      {{frost-icon
+        hook='myIcon'
+        pack='test'
+        icon='round-add'
+      }}
+    `)
 
-    it('renders using spread', function () {
-      this.render(hbs`
-        {{frost-icon hook='myIcon' options=(hash icon='round-add')}}
-      `)
+    expect(
+      this.$('.frost-icon-test-round-add'),
+      'Icon class updates correctly when pack is set.'
+    ).to.have.length(1)
+  })
 
-      expect(
-        this.$('.frost-icon-frost-round-add'),
-        'Icon class is set correctly.'
-      ).to.have.length(1)
-    })
-  }
-)
+  it('renders using spread', function () {
+    this.render(hbs`
+      {{frost-icon hook='myIcon' options=(hash icon='round-add')}}
+    `)
+
+    expect(
+      this.$('.frost-icon-frost-round-add'),
+      'Icon class is set correctly.'
+    ).to.have.length(1)
+  })
+})

--- a/tests/integration/components/frost-link-test.js
+++ b/tests/integration/components/frost-link-test.js
@@ -1,12 +1,12 @@
 import {expect} from 'chai'
 import Ember from 'ember'
 const {Logger} = Ember
-import {setupComponentTest} from 'ember-mocha'
 import wait from 'ember-test-helpers/wait'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
 
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 import windowUtils from 'ember-frost-core/utils/window'
 
 const RouterStub = Ember.Object.extend({
@@ -29,10 +29,9 @@ const RouterStub = Ember.Object.extend({
   }
 })
 
-describe('Integration: FrostLinkComponent', function () {
-  setupComponentTest('frost-link', {
-    integration: true
-  })
+const test = integration('frost-link')
+describe(test.label, function () {
+  test.setup()
 
   let sandbox
 

--- a/tests/integration/components/frost-loading-test.js
+++ b/tests/integration/components/frost-loading-test.js
@@ -1,53 +1,51 @@
 import {expect} from 'chai'
-import {describeComponent, it} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
+import {describe, it} from 'mocha'
 
-describeComponent(
-  'frost-loading',
-  'Integration: FrostLoadingComponent',
-  {
-    integration: true
-  },
-  function () {
-    it('renders default values', function () {
-      this.render(hbs`
-        {{frost-loading hook='myLoader'}}
-      `)
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
-      expect(
-        this.$('.uil-ripple'),
-        'Has class "uil-ripple"'
-      ).to.have.length(1)
-    })
+const test = integration('frost-loading')
+describe(test.label, function () {
+  test.setup()
 
-    it('type property sets class', function () {
-      this.render(hbs`
-        {{frost-loading
+  it('renders default values', function () {
+    this.render(hbs`
+      {{frost-loading hook='myLoader'}}
+    `)
+
+    expect(
+      this.$('.uil-ripple'),
+      'Has class "uil-ripple"'
+    ).to.have.length(1)
+  })
+
+  it('type property sets class', function () {
+    this.render(hbs`
+      {{frost-loading
+        hook='myLoader'
+        type='ring'
+      }}
+    `)
+
+    expect(
+      this.$('.uil-ring'),
+      'Has class "uil-ring"'
+    ).to.have.length(1)
+  })
+
+  it('renders using spread', function () {
+    this.render(hbs`
+      {{frost-loading
+        options=(hash
           hook='myLoader'
           type='ring'
-        }}
-      `)
+        )
+      }}
+    `)
 
-      expect(
-        this.$('.uil-ring'),
-        'Has class "uil-ring"'
-      ).to.have.length(1)
-    })
-
-    it('renders using spread', function () {
-      this.render(hbs`
-        {{frost-loading
-          options=(hash
-            hook='myLoader'
-            type='ring'
-          )
-        }}
-      `)
-
-      expect(
-        this.$('.uil-ring'),
-        'Has class "uil-ring"'
-      ).to.have.length(1)
-    })
-  }
-)
+    expect(
+      this.$('.uil-ring'),
+      'Has class "uil-ring"'
+    ).to.have.length(1)
+  })
+})

--- a/tests/integration/components/frost-multi-select-test.js
+++ b/tests/integration/components/frost-multi-select-test.js
@@ -2,15 +2,14 @@ import {expect} from 'chai'
 import Ember from 'ember'
 const {$, run} = Ember
 import {$hook, initialize as initializeHook} from 'ember-hook'
-import {describeComponent, it} from 'ember-mocha'
 import wait from 'ember-test-helpers/wait'
 import hbs from 'htmlbars-inline-precompile'
-import {afterEach, beforeEach, describe} from 'mocha'
+import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
 
 import {expectSelectWithState} from 'dummy/tests/helpers/ember-frost-core'
 import {open, selectItemAtIndex} from 'dummy/tests/helpers/ember-frost-core/frost-select'
-import {integration} from 'dummy/tests/helpers/ember-test-utils/describe-component'
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 import keyCodes from 'ember-frost-core/utils/key-codes'
 const {DOWN_ARROW, ENTER, ESCAPE, SPACE, TAB, UP_ARROW} = keyCodes
 
@@ -45,7 +44,10 @@ function focusNext ($element) {
   $firstFocusableElement.focusin()[0].focus()
 }
 
-describeComponent(...integration('frost-multi-select'), function () {
+const test = integration('frost-multi-select')
+describe(test.label, function () {
+  test.setup()
+
   beforeEach(function () {
     initializeHook()
   })

--- a/tests/integration/components/frost-password-test.js
+++ b/tests/integration/components/frost-password-test.js
@@ -1,273 +1,270 @@
 import {expect} from 'chai'
 import {$hook} from 'ember-hook'
-import {describeComponent, it} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
-import {describe} from 'mocha'
+import {describe, it} from 'mocha'
 
-describeComponent(
-  'frost-password',
-  'Integration: FrostPasswordComponent',
-  {
-    integration: true
-  },
-  function () {
-    it('renders default values', function () {
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
+
+const test = integration('frost-password')
+describe(test.label, function () {
+  test.setup()
+
+  it('renders default values', function () {
+    this.render(hbs`
+      {{frost-password hook='myPassword'}}
+    `)
+
+    expect(
+      this.$('.frost-password').find('input').prop('tabIndex'),
+      'input tabindex set to 0'
+    ).to.eql(0)
+
+    expect(
+      this.$('.frost-password').find('input').prop('type'),
+      'type set to "password"'
+    ).to.eql('password')
+
+    expect(
+      this.$('.frost-password-input'),
+      'class frost-password-input is set'
+    ).to.have.length(1)
+  })
+
+  it('sets autofocus property', function () {
+    this.render(hbs`
+      {{frost-password
+        autofocus=true
+        hook='myPassword'
+      }}
+   `)
+
+    expect(
+      this.$('.frost-password').find('input').prop('autofocus'),
+      'autofocus is set'
+    ).to.equal(true)
+  })
+
+  it('sets disabled property', function () {
+    this.render(hbs`
+      {{frost-password
+        disabled=true
+        hook='myPassword'
+      }}
+   `)
+
+    expect(
+      this.$('.frost-password').find('input').prop('disabled'),
+      'disabled is set'
+    ).to.equal(true)
+  })
+
+  describe('hook property', function () {
+    it('grabs frost-password as expected', function () {
       this.render(hbs`
-        {{frost-password hook='myPassword'}}
+        {{frost-password
+          hook='myPassword'
+        }}
       `)
 
       expect(
-        this.$('.frost-password').find('input').prop('tabIndex'),
-        'input tabindex set to 0'
-      ).to.eql(0)
+        $hook('myPassword-input').hasClass('frost-text-input'),
+        'input hook is set'
+      ).to.equal(true)
 
       expect(
-        this.$('.frost-password').find('input').prop('type'),
-        'type set to "password"'
-      ).to.eql('password')
-
-      expect(
-        this.$('.frost-password-input'),
-        'class frost-password-input is set'
-      ).to.have.length(1)
+        $hook('myPassword-clear').hasClass('frost-text-clear'),
+        'clear hook is set'
+      ).to.equal(true)
     })
 
-    it('sets autofocus property', function () {
+    it('grabs frost-password-reveal as expected', function () {
       this.render(hbs`
         {{frost-password
-          autofocus=true
           hook='myPassword'
+          revealable=true
+        }}
+      `)
+
+      expect(
+        $hook('myPassword-reveal').hasClass('frost-password-reveal'),
+        'reveal hook is set'
+      ).to.equal(true)
+    })
+  })
+
+  it('sets maxlength property', function () {
+    const maxlength = 30
+
+    this.set('maxlength', maxlength)
+
+    this.render(hbs`
+      {{frost-password
+        hook='myPassword'
+        maxlength=maxlength
+      }}
+   `)
+
+    expect(
+      this.$('.frost-password').find('input').prop('maxlength'),
+      'maxlength is set'
+    ).to.eql(maxlength)
+  })
+
+  it('sets placeholder property', function () {
+    const placeholder = 'Enter your password'
+
+    this.set('placeholder', placeholder)
+
+    this.render(hbs`
+      {{frost-password
+        hook='myPassword'
+        placeholder=placeholder
+      }}
+   `)
+
+    expect(
+      this.$('.frost-password').find('input').prop('placeholder'),
+      'placeholder is set'
+    ).to.eql(placeholder)
+  })
+
+  it('sets readonly property', function () {
+    this.render(hbs`
+      {{frost-password
+        hook='myPassword'
+        readonly=true
+      }}
+   `)
+
+    expect(
+      this.$('.frost-password').find('input').prop('readonly'),
+      'readonly is set'
+    ).to.equal(true)
+  })
+
+  it('sets required property', function () {
+    this.render(hbs`
+      {{frost-password
+        hook='myPassword'
+        required=true
+      }}
+   `)
+
+    expect(
+      this.$('.frost-password').find('input').prop('required'),
+      'required is set'
+    ).to.equal(true)
+  })
+
+  describe('revealable property', function () {
+    it('sets revealable class and text to "Show"', function () {
+      this.render(hbs`
+        {{frost-password
+          hook='myPassword'
+          revealable=true
         }}
      `)
 
       expect(
-        this.$('.frost-password').find('input').prop('autofocus'),
-        'autofocus is set'
+        this.$('.frost-password').hasClass('revealable'),
+        'revealable class is set'
       ).to.equal(true)
+
+      expect(
+        this.$('.frost-password-reveal').text().trim(),
+        'reveal text is set to "Show"'
+      ).to.eql('Show')
     })
 
-    it('sets disabled property', function () {
+    it('changes text to "Hide" upon click and type="text"', function () {
       this.render(hbs`
         {{frost-password
+          hook='myPassword'
+          revealable=true
+        }}
+     `)
+
+      this.$('.frost-password-reveal').trigger('click')
+
+      expect(
+        this.$('.frost-password-reveal').text().trim(),
+        'reveal text is set to "Hide"'
+      ).to.eql('Hide')
+
+      expect(
+      this.$('.frost-password').find('input').prop('type'),
+      'type set to "text"'
+    ).to.eql('text')
+    })
+  })
+
+  it('sets tabindex property', function () {
+    const tabindex = -1
+
+    this.set('tabindex', tabindex)
+
+    this.render(hbs`
+      {{frost-password
+        hook='myPassword'
+        tabindex=tabindex
+      }}
+   `)
+
+    expect(
+      this.$('.frost-password').find('input').prop('tabindex'),
+      'tabindex is set'
+    ).to.eql(tabindex)
+  })
+
+  it('sets title property', function () {
+    const title = 'Enter your password'
+
+    this.set('title', title)
+
+    this.render(hbs`
+      {{frost-password
+        hook='myPassword'
+        title=title
+      }}
+   `)
+
+    expect(
+      this.$('.frost-password').find('input').prop('title'),
+      'title is set'
+    ).to.eql(title)
+  })
+
+  it('sets value property', function () {
+    const value = 'test value'
+
+    this.set('value', value)
+
+    this.render(hbs`
+      {{frost-password
+        hook='myPassword'
+        value=value
+      }}
+   `)
+
+    expect(
+      this.$('.frost-password').find('input').val(),
+      'value is set'
+    ).to.eql(value)
+  })
+
+  it('renders using spread', function () {
+    this.render(hbs`
+      {{frost-password
+        options=(hash
           disabled=true
           hook='myPassword'
-        }}
-     `)
+        )
+      }}
+   `)
 
-      expect(
-        this.$('.frost-password').find('input').prop('disabled'),
-        'disabled is set'
-      ).to.equal(true)
-    })
-
-    describe('hook property', function () {
-      it('grabs frost-password as expected', function () {
-        this.render(hbs`
-          {{frost-password
-            hook='myPassword'
-          }}
-        `)
-
-        expect(
-          $hook('myPassword-input').hasClass('frost-text-input'),
-          'input hook is set'
-        ).to.equal(true)
-
-        expect(
-          $hook('myPassword-clear').hasClass('frost-text-clear'),
-          'clear hook is set'
-        ).to.equal(true)
-      })
-
-      it('grabs frost-password-reveal as expected', function () {
-        this.render(hbs`
-          {{frost-password
-            hook='myPassword'
-            revealable=true
-          }}
-        `)
-
-        expect(
-          $hook('myPassword-reveal').hasClass('frost-password-reveal'),
-          'reveal hook is set'
-        ).to.equal(true)
-      })
-    })
-
-    it('sets maxlength property', function () {
-      const maxlength = 30
-
-      this.set('maxlength', maxlength)
-
-      this.render(hbs`
-        {{frost-password
-          hook='myPassword'
-          maxlength=maxlength
-        }}
-     `)
-
-      expect(
-        this.$('.frost-password').find('input').prop('maxlength'),
-        'maxlength is set'
-      ).to.eql(maxlength)
-    })
-
-    it('sets placeholder property', function () {
-      const placeholder = 'Enter your password'
-
-      this.set('placeholder', placeholder)
-
-      this.render(hbs`
-        {{frost-password
-          hook='myPassword'
-          placeholder=placeholder
-        }}
-     `)
-
-      expect(
-        this.$('.frost-password').find('input').prop('placeholder'),
-        'placeholder is set'
-      ).to.eql(placeholder)
-    })
-
-    it('sets readonly property', function () {
-      this.render(hbs`
-        {{frost-password
-          hook='myPassword'
-          readonly=true
-        }}
-     `)
-
-      expect(
-        this.$('.frost-password').find('input').prop('readonly'),
-        'readonly is set'
-      ).to.equal(true)
-    })
-
-    it('sets required property', function () {
-      this.render(hbs`
-        {{frost-password
-          hook='myPassword'
-          required=true
-        }}
-     `)
-
-      expect(
-        this.$('.frost-password').find('input').prop('required'),
-        'required is set'
-      ).to.equal(true)
-    })
-
-    describe('revealable property', function () {
-      it('sets revealable class and text to "Show"', function () {
-        this.render(hbs`
-          {{frost-password
-            hook='myPassword'
-            revealable=true
-          }}
-       `)
-
-        expect(
-          this.$('.frost-password').hasClass('revealable'),
-          'revealable class is set'
-        ).to.equal(true)
-
-        expect(
-          this.$('.frost-password-reveal').text().trim(),
-          'reveal text is set to "Show"'
-        ).to.eql('Show')
-      })
-
-      it('changes text to "Hide" upon click and type="text"', function () {
-        this.render(hbs`
-          {{frost-password
-            hook='myPassword'
-            revealable=true
-          }}
-       `)
-
-        this.$('.frost-password-reveal').trigger('click')
-
-        expect(
-          this.$('.frost-password-reveal').text().trim(),
-          'reveal text is set to "Hide"'
-        ).to.eql('Hide')
-
-        expect(
-        this.$('.frost-password').find('input').prop('type'),
-        'type set to "text"'
-      ).to.eql('text')
-      })
-    })
-
-    it('sets tabindex property', function () {
-      const tabindex = -1
-
-      this.set('tabindex', tabindex)
-
-      this.render(hbs`
-        {{frost-password
-          hook='myPassword'
-          tabindex=tabindex
-        }}
-     `)
-
-      expect(
-        this.$('.frost-password').find('input').prop('tabindex'),
-        'tabindex is set'
-      ).to.eql(tabindex)
-    })
-
-    it('sets title property', function () {
-      const title = 'Enter your password'
-
-      this.set('title', title)
-
-      this.render(hbs`
-        {{frost-password
-          hook='myPassword'
-          title=title
-        }}
-     `)
-
-      expect(
-        this.$('.frost-password').find('input').prop('title'),
-        'title is set'
-      ).to.eql(title)
-    })
-
-    it('sets value property', function () {
-      const value = 'test value'
-
-      this.set('value', value)
-
-      this.render(hbs`
-        {{frost-password
-          hook='myPassword'
-          value=value
-        }}
-     `)
-
-      expect(
-        this.$('.frost-password').find('input').val(),
-        'value is set'
-      ).to.eql(value)
-    })
-
-    it('renders using spread', function () {
-      this.render(hbs`
-        {{frost-password
-          options=(hash
-            disabled=true
-            hook='myPassword'
-          )
-        }}
-     `)
-
-      expect(
-        this.$('.frost-password').find('input').prop('disabled'),
-        'disabled is set'
-      ).to.equal(true)
-    })
-  }
-)
+    expect(
+      this.$('.frost-password').find('input').prop('disabled'),
+      'disabled is set'
+    ).to.equal(true)
+  })
+})

--- a/tests/integration/components/frost-radio-button-test.js
+++ b/tests/integration/components/frost-radio-button-test.js
@@ -1,25 +1,261 @@
 import {expect} from 'chai'
 import {$hook} from 'ember-hook'
-import {describeComponent, it} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
-import {describe} from 'mocha'
+import {describe, it} from 'mocha'
 import sinon from 'sinon'
 
-describeComponent(
-  'frost-radio-button',
-  'Integration: FrostRadioButtonComponent',
-  {
-    integration: true
-  },
-  function () {
-    describe('Checked property', function () {
-      it('sets checked property', function () {
-        this.render(hbs`
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
+
+const test = integration('frost-radio-button')
+describe(test.label, function () {
+  test.setup()
+
+  describe('Checked property', function () {
+    it('sets checked property', function () {
+      this.render(hbs`
+        {{frost-radio-button
+          checked=true
+          hook='myRadioButton'
+          value='testValue'
+        }}
+      `)
+
+      expect(
+        this.$('.frost-radio-button').hasClass('checked'),
+        'checked class is set'
+      ).to.equal(true)
+
+      expect(
+        this.$('.frost-radio-button-input').prop('checked'),
+        'checked is set'
+      ).to.equal(true)
+    })
+
+    it('does not set checked property', function () {
+      this.render(hbs`
           {{frost-radio-button
-            checked=true
             hook='myRadioButton'
             value='testValue'
           }}
+      `)
+
+      expect(
+        this.$('.frost-radio-button').hasClass('checked'),
+        'checked class is set'
+      ).to.equal(false)
+
+      expect(
+        this.$('.frost-radio-button-input').prop('checked'),
+        'checked is set'
+      ).to.equal(false)
+    })
+  })
+
+  describe('Disabled property', function () {
+    it('sets disabled property', function () {
+      this.render(hbs`
+        {{frost-radio-button
+          disabled=true
+          hook='myRadioButton'
+          value='testValue'
+        }}
+      `)
+
+      expect(
+        this.$('.frost-radio-button').hasClass('disabled'),
+        'disabled class is set'
+      ).to.equal(true)
+
+      expect(
+        this.$('.frost-radio-button-input').prop('disabled'),
+        'disabled class is set'
+      ).to.equal(true)
+    })
+  })
+
+  describe('Hook property', function () {
+    it('sets when passed into radio-button', function () {
+      const value = 'testValue'
+
+      this.set('value', value)
+
+      this.render(hbs`
+        {{frost-radio-button
+          hook='my-radio-button'
+          value=value
+        }}
+      `)
+
+      expect(
+        $hook('my-radio-button-input', {value: value}).hasClass('frost-radio-button-input'),
+        'input hook is set'
+      ).to.equal(true)
+    })
+  })
+
+  describe('Size property', function () {
+    it('has small class set', function () {
+      const size = 'small'
+
+      this.set('size', size)
+
+      this.render(hbs`
+        {{frost-radio-button
+          hook='myRadioButton'
+          size=size
+          value='testValue'
+        }}
+      `)
+
+      expect(
+        this.$('.frost-radio-button').hasClass(size),
+        'small class is set'
+      ).to.equal(true)
+    })
+
+    it('has medium class set', function () {
+      const size = 'medium'
+
+      this.set('size', size)
+
+      this.render(hbs`
+        {{frost-radio-button
+          hook='myRadioButton'
+          size=size
+          value='testValue'
+        }}
+      `)
+
+      expect(
+        this.$('.frost-radio-button').hasClass(size),
+        'medium class is set'
+      ).to.equal(true)
+    })
+
+    it('has large class set', function () {
+      const size = 'large'
+
+      this.set('size', size)
+
+      this.render(hbs`
+        {{frost-radio-button
+          hook='myRadioButton'
+          size=size
+          value='testValue'
+        }}
+      `)
+
+      expect(
+        this.$('.frost-radio-button').hasClass(size),
+        'large class is set'
+      ).to.equal(true)
+    })
+  })
+
+  it('sets required property', function () {
+    this.render(hbs`
+      {{frost-radio-button
+        hook='myRadioButton'
+        required=true
+        value='testValue'
+      }}
+    `)
+
+    expect(
+      this.$('.frost-radio-button').hasClass('required'),
+      'required class is set'
+    ).to.equal(true)
+
+    expect(
+      this.$('.frost-radio-button-input').prop('required'),
+      'required class is set'
+    ).to.equal(true)
+  })
+
+  it('sets type to "radio"', function () {
+    this.render(hbs`
+      {{frost-radio-button
+        hook='myRadioButton'
+        value='testValue'
+      }}
+    `)
+
+    expect(
+      this.$('.frost-radio-button-input').prop('type'),
+      'type is set to radio'
+    ).to.eql('radio')
+  })
+
+  it('sets value property', function () {
+    const value = 'test value'
+
+    this.set('value', value)
+
+    this.render(hbs`
+      {{frost-radio-button
+        hook='myRadioButton'
+        value=value
+      }}
+    `)
+
+    expect(
+      this.$('.frost-radio-button-input').prop('value'),
+      'value is set'
+    ).to.eql(value)
+  })
+
+  describe('Label property', function () {
+    it('inline format', function () {
+      const text = 'my-text'
+
+      this.set('text', text)
+
+      this.render(hbs`
+        {{frost-radio-button
+          hook='myRadioButton'
+          value='test value'
+          label=text
+        }}
+      `)
+
+      expect(
+        this.$('.frost-radio-button').text().trim(),
+        'label is set'
+      ).to.eql(text)
+    })
+
+    it('block format', function () {
+      const text = 'my-text'
+
+      this.set('text', text)
+
+      this.render(hbs`
+        {{#frost-radio-button
+          hook='myRadioButton'
+          value='test value'
+        }}
+          {{text}}
+        {{/frost-radio-button}}
+      `)
+
+      expect(
+        this.$('.frost-radio-button').text().trim(),
+        'label is set'
+      ).to.eql(text)
+    })
+  })
+
+  describe('Radio button in group', function () {
+    describe('Checked property', function () {
+      it('sets checked property', function () {
+        this.render(hbs`
+          {{#frost-radio-group
+            hook='myRadioGroup'
+            selectedValue='testValue'
+            as |controls|
+          }}
+            {{controls.button value='testValue'}}
+          {{/frost-radio-group}}
         `)
 
         expect(
@@ -35,10 +271,9 @@ describeComponent(
 
       it('does not set checked property', function () {
         this.render(hbs`
-            {{frost-radio-button
-              hook='myRadioButton'
-              value='testValue'
-            }}
+          {{#frost-radio-group hook='myRadioGroup' as |controls|}}
+            {{controls.button value='testValue'}}
+          {{/frost-radio-group}}
         `)
 
         expect(
@@ -56,11 +291,12 @@ describeComponent(
     describe('Disabled property', function () {
       it('sets disabled property', function () {
         this.render(hbs`
-          {{frost-radio-button
-            disabled=true
-            hook='myRadioButton'
-            value='testValue'
-          }}
+          {{#frost-radio-group hook='myRadioGroup' as |controls|}}
+            {{controls.button
+              disabled=true
+              value='testValue'
+            }}
+          {{/frost-radio-group}}
         `)
 
         expect(
@@ -76,20 +312,29 @@ describeComponent(
     })
 
     describe('Hook property', function () {
-      it('sets when passed into radio-button', function () {
+      it('sets when passed into radio-group', function () {
         const value = 'testValue'
 
         this.set('value', value)
 
         this.render(hbs`
-          {{frost-radio-button
-            hook='my-radio-button'
-            value=value
+          {{#frost-radio-group
+            hook='my-radio-group'
+            as |controls|
           }}
+            {{controls.button
+              value=value
+            }}
+          {{/frost-radio-group}}
         `)
 
         expect(
-          $hook('my-radio-button-input', {value: value}).hasClass('frost-radio-button-input'),
+          $hook('my-radio-group-button', {value: value}).hasClass('frost-radio-button'),
+          'radio button hook is set'
+        ).to.equal(true)
+
+        expect(
+          $hook('my-radio-group-button-input', {value: value}).hasClass('frost-radio-button-input'),
           'input hook is set'
         ).to.equal(true)
       })
@@ -102,11 +347,12 @@ describeComponent(
         this.set('size', size)
 
         this.render(hbs`
-          {{frost-radio-button
-            hook='myRadioButton'
-            size=size
-            value='testValue'
-          }}
+          {{#frost-radio-group hook='myRadioGroup' as |controls|}}
+            {{controls.button
+              size=size
+              value='testValue'
+            }}
+          {{/frost-radio-group}}
         `)
 
         expect(
@@ -121,11 +367,12 @@ describeComponent(
         this.set('size', size)
 
         this.render(hbs`
-          {{frost-radio-button
-            hook='myRadioButton'
-            size=size
-            value='testValue'
-          }}
+          {{#frost-radio-group hook='myRadioGroup' as |controls|}}
+            {{controls.button
+              size=size
+              value='testValue'
+            }}
+          {{/frost-radio-group}}
         `)
 
         expect(
@@ -140,11 +387,12 @@ describeComponent(
         this.set('size', size)
 
         this.render(hbs`
-          {{frost-radio-button
-            hook='myRadioButton'
-            size=size
-            value='testValue'
-          }}
+          {{#frost-radio-group hook='myRadioGroup' as |controls|}}
+            {{controls.button
+              size=size
+              value='testValue'
+            }}
+          {{/frost-radio-group}}
         `)
 
         expect(
@@ -156,11 +404,12 @@ describeComponent(
 
     it('sets required property', function () {
       this.render(hbs`
-        {{frost-radio-button
-          hook='myRadioButton'
-          required=true
-          value='testValue'
-        }}
+        {{#frost-radio-group hook='myRadioGroup' as |controls|}}
+          {{controls.button
+            required=true
+            value='testValue'
+          }}
+        {{/frost-radio-group}}
       `)
 
       expect(
@@ -174,30 +423,17 @@ describeComponent(
       ).to.equal(true)
     })
 
-    it('sets type to "radio"', function () {
-      this.render(hbs`
-        {{frost-radio-button
-          hook='myRadioButton'
-          value='testValue'
-        }}
-      `)
-
-      expect(
-        this.$('.frost-radio-button-input').prop('type'),
-        'type is set to radio'
-      ).to.eql('radio')
-    })
-
     it('sets value property', function () {
       const value = 'test value'
 
       this.set('value', value)
 
       this.render(hbs`
-        {{frost-radio-button
-          hook='myRadioButton'
-          value=value
-        }}
+        {{#frost-radio-group hook='myRadioGroup' as |controls|}}
+          {{controls.button
+            value=value
+          }}
+        {{/frost-radio-group}}
       `)
 
       expect(
@@ -213,11 +449,12 @@ describeComponent(
         this.set('text', text)
 
         this.render(hbs`
-          {{frost-radio-button
-            hook='myRadioButton'
-            value='test value'
-            label=text
-          }}
+          {{#frost-radio-group hook='myRadioGroup' as |controls|}}
+            {{controls.button
+              value='test value'
+              label=text
+            }}
+          {{/frost-radio-group}}
         `)
 
         expect(
@@ -232,12 +469,13 @@ describeComponent(
         this.set('text', text)
 
         this.render(hbs`
-          {{#frost-radio-button
-            hook='myRadioButton'
-            value='test value'
-          }}
-            {{text}}
-          {{/frost-radio-button}}
+          {{#frost-radio-group hook='myRadioGroup' as |controls|}}
+            {{#controls.button
+              value='test value'
+            }}
+              {{text}}
+            {{/controls.button}}
+          {{/frost-radio-group}}
         `)
 
         expect(
@@ -247,333 +485,18 @@ describeComponent(
       })
     })
 
-    describe('Radio button in group', function () {
-      describe('Checked property', function () {
-        it('sets checked property', function () {
-          this.render(hbs`
-            {{#frost-radio-group
-              hook='myRadioGroup'
-              selectedValue='testValue'
-              as |controls|
-            }}
-              {{controls.button value='testValue'}}
-            {{/frost-radio-group}}
-          `)
-
-          expect(
-            this.$('.frost-radio-button').hasClass('checked'),
-            'checked class is set'
-          ).to.equal(true)
-
-          expect(
-            this.$('.frost-radio-button-input').prop('checked'),
-            'checked is set'
-          ).to.equal(true)
-        })
-
-        it('does not set checked property', function () {
-          this.render(hbs`
-            {{#frost-radio-group hook='myRadioGroup' as |controls|}}
-              {{controls.button value='testValue'}}
-            {{/frost-radio-group}}
-          `)
-
-          expect(
-            this.$('.frost-radio-button').hasClass('checked'),
-            'checked class is set'
-          ).to.equal(false)
-
-          expect(
-            this.$('.frost-radio-button-input').prop('checked'),
-            'checked is set'
-          ).to.equal(false)
-        })
-      })
-
-      describe('Disabled property', function () {
-        it('sets disabled property', function () {
-          this.render(hbs`
-            {{#frost-radio-group hook='myRadioGroup' as |controls|}}
-              {{controls.button
-                disabled=true
-                value='testValue'
-              }}
-            {{/frost-radio-group}}
-          `)
-
-          expect(
-            this.$('.frost-radio-button').hasClass('disabled'),
-            'disabled class is set'
-          ).to.equal(true)
-
-          expect(
-            this.$('.frost-radio-button-input').prop('disabled'),
-            'disabled class is set'
-          ).to.equal(true)
-        })
-      })
-
-      describe('Hook property', function () {
-        it('sets when passed into radio-group', function () {
-          const value = 'testValue'
-
-          this.set('value', value)
-
-          this.render(hbs`
-            {{#frost-radio-group
-              hook='my-radio-group'
-              as |controls|
-            }}
-              {{controls.button
-                value=value
-              }}
-            {{/frost-radio-group}}
-          `)
-
-          expect(
-            $hook('my-radio-group-button', {value: value}).hasClass('frost-radio-button'),
-            'radio button hook is set'
-          ).to.equal(true)
-
-          expect(
-            $hook('my-radio-group-button-input', {value: value}).hasClass('frost-radio-button-input'),
-            'input hook is set'
-          ).to.equal(true)
-        })
-      })
-
-      describe('Size property', function () {
-        it('has small class set', function () {
-          const size = 'small'
-
-          this.set('size', size)
-
-          this.render(hbs`
-            {{#frost-radio-group hook='myRadioGroup' as |controls|}}
-              {{controls.button
-                size=size
-                value='testValue'
-              }}
-            {{/frost-radio-group}}
-          `)
-
-          expect(
-            this.$('.frost-radio-button').hasClass(size),
-            'small class is set'
-          ).to.equal(true)
-        })
-
-        it('has medium class set', function () {
-          const size = 'medium'
-
-          this.set('size', size)
-
-          this.render(hbs`
-            {{#frost-radio-group hook='myRadioGroup' as |controls|}}
-              {{controls.button
-                size=size
-                value='testValue'
-              }}
-            {{/frost-radio-group}}
-          `)
-
-          expect(
-            this.$('.frost-radio-button').hasClass(size),
-            'medium class is set'
-          ).to.equal(true)
-        })
-
-        it('has large class set', function () {
-          const size = 'large'
-
-          this.set('size', size)
-
-          this.render(hbs`
-            {{#frost-radio-group hook='myRadioGroup' as |controls|}}
-              {{controls.button
-                size=size
-                value='testValue'
-              }}
-            {{/frost-radio-group}}
-          `)
-
-          expect(
-            this.$('.frost-radio-button').hasClass(size),
-            'large class is set'
-          ).to.equal(true)
-        })
-      })
-
-      it('sets required property', function () {
-        this.render(hbs`
-          {{#frost-radio-group hook='myRadioGroup' as |controls|}}
-            {{controls.button
-              required=true
-              value='testValue'
-            }}
-          {{/frost-radio-group}}
-        `)
-
-        expect(
-          this.$('.frost-radio-button').hasClass('required'),
-          'required class is set'
-        ).to.equal(true)
-
-        expect(
-          this.$('.frost-radio-button-input').prop('required'),
-          'required class is set'
-        ).to.equal(true)
-      })
-
-      it('sets value property', function () {
-        const value = 'test value'
-
-        this.set('value', value)
-
-        this.render(hbs`
-          {{#frost-radio-group hook='myRadioGroup' as |controls|}}
-            {{controls.button
-              value=value
-            }}
-          {{/frost-radio-group}}
-        `)
-
-        expect(
-          this.$('.frost-radio-button-input').prop('value'),
-          'value is set'
-        ).to.eql(value)
-      })
-
-      describe('Label property', function () {
-        it('inline format', function () {
-          const text = 'my-text'
-
-          this.set('text', text)
-
-          this.render(hbs`
-            {{#frost-radio-group hook='myRadioGroup' as |controls|}}
-              {{controls.button
-                value='test value'
-                label=text
-              }}
-            {{/frost-radio-group}}
-          `)
-
-          expect(
-            this.$('.frost-radio-button').text().trim(),
-            'label is set'
-          ).to.eql(text)
-        })
-
-        it('block format', function () {
-          const text = 'my-text'
-
-          this.set('text', text)
-
-          this.render(hbs`
-            {{#frost-radio-group hook='myRadioGroup' as |controls|}}
-              {{#controls.button
-                value='test value'
-              }}
-                {{text}}
-              {{/controls.button}}
-            {{/frost-radio-group}}
-          `)
-
-          expect(
-            this.$('.frost-radio-button').text().trim(),
-            'label is set'
-          ).to.eql(text)
-        })
-      })
-
-      describe('onChange closure action', function () {
-        it('is called on click', function () {
-          const externalActionSpy = sinon.spy()
-
-          this.on('externalAction', externalActionSpy)
-
-          this.render(hbs`
-            {{frost-radio-button
-              hook='myRadioButton'
-              value='testValue'
-              onChange=(action 'externalAction')
-            }}
-          `)
-
-          this.$('input').trigger('click')
-
-          expect(
-            externalActionSpy.called,
-            'onChange closure action called on click'
-          ).to.equal(true)
-        })
-      })
-    })
-
     describe('onChange closure action', function () {
-      it('is called on keypress of "enter"', function () {
-        const externalActionSpy = sinon.spy()
-
-        this.on('externalAction', externalActionSpy)
-
-        this.render(hbs`
-          {{#frost-radio-group
-            hook='myRadioGroup'
-            id='groupId'
-            onChange=(action 'externalAction')
-            as |controls|
-          }}
-            {{controls.button value='testValue'}}
-          {{/frost-radio-group}}
-        `)
-
-        this.$('.frost-radio-button').trigger({type: 'keypress', keyCode: 13})
-
-        expect(
-          externalActionSpy.called,
-          'onChange closure action called on keypress "enter"'
-        ).to.equal(true)
-      })
-
-      it('is called on keypress of "spacebar"', function () {
-        const externalActionSpy = sinon.spy()
-
-        this.on('externalAction', externalActionSpy)
-
-        this.render(hbs`
-          {{#frost-radio-group
-            hook='myRadioGroup'
-            id='groupId'
-            onChange=(action 'externalAction')
-            as |controls|
-          }}
-            {{controls.button value='testValue'}}
-          {{/frost-radio-group}}
-        `)
-
-        this.$('.frost-radio-button').trigger({type: 'keypress', keyCode: 32})
-
-        expect(
-          externalActionSpy.called,
-          'onChange closure action called on keypress "spacebar"'
-        ).to.equal(true)
-      })
-
       it('is called on click', function () {
         const externalActionSpy = sinon.spy()
 
         this.on('externalAction', externalActionSpy)
 
         this.render(hbs`
-          {{#frost-radio-group
-            hook='myRadioGroup'
-            id='groupId'
+          {{frost-radio-button
+            hook='myRadioButton'
+            value='testValue'
             onChange=(action 'externalAction')
-            as |controls|
           }}
-            {{controls.button value='testValue'}}
-          {{/frost-radio-group}}
         `)
 
         this.$('input').trigger('click')
@@ -584,18 +507,66 @@ describeComponent(
         ).to.equal(true)
       })
     })
+  })
 
-    it('calls _createEvent() which sets the target id ', function () {
+  describe('onChange closure action', function () {
+    it('is called on keypress of "enter"', function () {
       const externalActionSpy = sinon.spy()
-      const id = 'myTestGroupId'
 
-      this.set('id', id)
       this.on('externalAction', externalActionSpy)
 
       this.render(hbs`
         {{#frost-radio-group
           hook='myRadioGroup'
-          id=id
+          id='groupId'
+          onChange=(action 'externalAction')
+          as |controls|
+        }}
+          {{controls.button value='testValue'}}
+        {{/frost-radio-group}}
+      `)
+
+      this.$('.frost-radio-button').trigger({type: 'keypress', keyCode: 13})
+
+      expect(
+        externalActionSpy.called,
+        'onChange closure action called on keypress "enter"'
+      ).to.equal(true)
+    })
+
+    it('is called on keypress of "spacebar"', function () {
+      const externalActionSpy = sinon.spy()
+
+      this.on('externalAction', externalActionSpy)
+
+      this.render(hbs`
+        {{#frost-radio-group
+          hook='myRadioGroup'
+          id='groupId'
+          onChange=(action 'externalAction')
+          as |controls|
+        }}
+          {{controls.button value='testValue'}}
+        {{/frost-radio-group}}
+      `)
+
+      this.$('.frost-radio-button').trigger({type: 'keypress', keyCode: 32})
+
+      expect(
+        externalActionSpy.called,
+        'onChange closure action called on keypress "spacebar"'
+      ).to.equal(true)
+    })
+
+    it('is called on click', function () {
+      const externalActionSpy = sinon.spy()
+
+      this.on('externalAction', externalActionSpy)
+
+      this.render(hbs`
+        {{#frost-radio-group
+          hook='myRadioGroup'
+          id='groupId'
           onChange=(action 'externalAction')
           as |controls|
         }}
@@ -606,31 +577,57 @@ describeComponent(
       this.$('input').trigger('click')
 
       expect(
-        externalActionSpy.args[0][0].target.id,
-        '_createEvent() added groupId'
-      ).to.eql(id)
-    })
-
-    it('renders using spread', function () {
-      this.render(hbs`
-        {{frost-radio-button
-          options=(hash
-            disabled=true
-            hook='myRadioButton'
-            value='testValue'
-          )
-        }}
-      `)
-
-      expect(
-        this.$('.frost-radio-button').hasClass('disabled'),
-        'disabled class is set'
-      ).to.equal(true)
-
-      expect(
-        this.$('.frost-radio-button-input').prop('disabled'),
-        'disabled class is set'
+        externalActionSpy.called,
+        'onChange closure action called on click'
       ).to.equal(true)
     })
-  }
-)
+  })
+
+  it('calls _createEvent() which sets the target id ', function () {
+    const externalActionSpy = sinon.spy()
+    const id = 'myTestGroupId'
+
+    this.set('id', id)
+    this.on('externalAction', externalActionSpy)
+
+    this.render(hbs`
+      {{#frost-radio-group
+        hook='myRadioGroup'
+        id=id
+        onChange=(action 'externalAction')
+        as |controls|
+      }}
+        {{controls.button value='testValue'}}
+      {{/frost-radio-group}}
+    `)
+
+    this.$('input').trigger('click')
+
+    expect(
+      externalActionSpy.args[0][0].target.id,
+      '_createEvent() added groupId'
+    ).to.eql(id)
+  })
+
+  it('renders using spread', function () {
+    this.render(hbs`
+      {{frost-radio-button
+        options=(hash
+          disabled=true
+          hook='myRadioButton'
+          value='testValue'
+        )
+      }}
+    `)
+
+    expect(
+      this.$('.frost-radio-button').hasClass('disabled'),
+      'disabled class is set'
+    ).to.equal(true)
+
+    expect(
+      this.$('.frost-radio-button-input').prop('disabled'),
+      'disabled class is set'
+    ).to.equal(true)
+  })
+})

--- a/tests/integration/components/frost-radio-group-test.js
+++ b/tests/integration/components/frost-radio-group-test.js
@@ -1,112 +1,110 @@
 import {expect} from 'chai'
 import {$hook} from 'ember-hook'
-import {describeComponent, it} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
+import {describe, it} from 'mocha'
 
-describeComponent(
-  'frost-radio-group',
-  'Integration: FrostRadioGroupComponent',
-  {
-    integration: true
-  },
-  function () {
-    it('block format', function () {
-      const label = 'b'
-      const value = 'a'
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
-      this.set('label', label)
-      this.set('value', value)
+const test = integration('frost-radio-group')
+describe(test.label, function () {
+  test.setup()
 
-      this.render(hbs`
-        {{#frost-radio-group hook='myRadioGroup' as |controls|}}
-          {{controls.button value=value label=label}}
-        {{/frost-radio-group}}
-      `)
+  it('block format', function () {
+    const label = 'b'
+    const value = 'a'
 
-      expect(
-        this.$('.frost-radio-button-input').first().prop('value'),
-        'value is set'
-      ).to.eql(value)
+    this.set('label', label)
+    this.set('value', value)
 
-      expect(
-        this.$('.frost-radio-button').first().text().trim(),
-        'label is set'
-      ).to.eql(label)
-    })
+    this.render(hbs`
+      {{#frost-radio-group hook='myRadioGroup' as |controls|}}
+        {{controls.button value=value label=label}}
+      {{/frost-radio-group}}
+    `)
 
-    it('inline format', function () {
-      const inputs = [
-        {value: 'a', label: 'b'}
-      ]
+    expect(
+      this.$('.frost-radio-button-input').first().prop('value'),
+      'value is set'
+    ).to.eql(value)
 
-      this.set('inputs', inputs)
+    expect(
+      this.$('.frost-radio-button').first().text().trim(),
+      'label is set'
+    ).to.eql(label)
+  })
 
-      this.render(hbs`
-        {{frost-radio-group hook='myRadioGroup' inputs=inputs}}
-      `)
+  it('inline format', function () {
+    const inputs = [
+      {value: 'a', label: 'b'}
+    ]
 
-      expect(
-        this.$('.frost-radio-button-input').first().prop('value'),
-        'value is set'
-      ).to.eql(inputs[0].value)
+    this.set('inputs', inputs)
 
-      expect(
-        this.$('.frost-radio-button').first().text().trim(),
-        'label is set'
-      ).to.eql(inputs[0].label)
-    })
+    this.render(hbs`
+      {{frost-radio-group hook='myRadioGroup' inputs=inputs}}
+    `)
 
-    it('set hook property', function () {
-      const hook = 'my-hook'
+    expect(
+      this.$('.frost-radio-button-input').first().prop('value'),
+      'value is set'
+    ).to.eql(inputs[0].value)
 
-      this.set('hook', hook)
+    expect(
+      this.$('.frost-radio-button').first().text().trim(),
+      'label is set'
+    ).to.eql(inputs[0].label)
+  })
 
-      this.render(hbs`
-        {{frost-radio-group hook=hook}}
-      `)
+  it('set hook property', function () {
+    const hook = 'my-hook'
 
-      expect(
-        $hook(`${hook}`).hasClass('frost-radio-group'),
-        'radio button group is set'
-      ).to.equal(true)
-    })
+    this.set('hook', hook)
 
-    it('renders using spread', function () {
-      const value = 'b'
-      const label = `Label for ${value}`
+    this.render(hbs`
+      {{frost-radio-group hook=hook}}
+    `)
 
-      this.set('value', value)
-      this.set('label', label)
+    expect(
+      $hook(`${hook}`).hasClass('frost-radio-group'),
+      'radio button group is set'
+    ).to.equal(true)
+  })
 
-      this.render(hbs`
-        {{#frost-radio-group
-          options=(hash
-            hook='myRadioGroup'
-            id='radioGroup7'
-            selectedValue=value
-          )
-          as |controls|
-        }}
-            {{#controls.button
-              options=(hash
-                size='medium'
-              )
-              value=value
-            }}
-              {{label}}
-            {{/controls.button}}
-        {{/frost-radio-group}}
-      `)
+  it('renders using spread', function () {
+    const value = 'b'
+    const label = `Label for ${value}`
 
-      expect(
-        this.$('.frost-radio-button-input').first().prop('value'),
-        'value is set'
-      ).to.eql(value)
+    this.set('value', value)
+    this.set('label', label)
 
-      expect(
-        this.$('.frost-radio-button').first().text().trim(),
-        'label is set'
-      ).to.eql(label)
-    })
-  }
-)
+    this.render(hbs`
+      {{#frost-radio-group
+        options=(hash
+          hook='myRadioGroup'
+          id='radioGroup7'
+          selectedValue=value
+        )
+        as |controls|
+      }}
+          {{#controls.button
+            options=(hash
+              size='medium'
+            )
+            value=value
+          }}
+            {{label}}
+          {{/controls.button}}
+      {{/frost-radio-group}}
+    `)
+
+    expect(
+      this.$('.frost-radio-button-input').first().prop('value'),
+      'value is set'
+    ).to.eql(value)
+
+    expect(
+      this.$('.frost-radio-button').first().text().trim(),
+      'label is set'
+    ).to.eql(label)
+  })
+})

--- a/tests/integration/components/frost-scroll-test.js
+++ b/tests/integration/components/frost-scroll-test.js
@@ -1,113 +1,111 @@
 import {expect} from 'chai'
 import {$hook} from 'ember-hook'
-import {describeComponent, it} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
+import {describe, it} from 'mocha'
 import sinon from 'sinon'
 
-describeComponent(
-  'frost-scroll',
-  'Integration: FrostScrollComponent',
-  {
-    integration: true
-  },
-  function () {
-    it('onScrollUp closure action is called', function () {
-      const externalActionSpy = sinon.spy()
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
-      this.on('externalAction', externalActionSpy)
+const test = integration('frost-scroll')
+describe(test.label, function () {
+  test.setup()
 
-      this.render(hbs`
-        {{frost-scroll
-          hook='myScroll'
-          onScrollUp=(action 'externalAction')
-        }}
-      `)
+  it('onScrollUp closure action is called', function () {
+    const externalActionSpy = sinon.spy()
 
-      this.$('.frost-scroll').trigger('ps-scroll-up')
+    this.on('externalAction', externalActionSpy)
 
-      expect(
-        externalActionSpy.called,
-        'onScrollUp closure action called on ps-scroll-up'
-      ).to.equal(true)
-    })
+    this.render(hbs`
+      {{frost-scroll
+        hook='myScroll'
+        onScrollUp=(action 'externalAction')
+      }}
+    `)
 
-    it('onScrollDown closure action is called', function () {
-      const externalActionSpy = sinon.spy()
+    this.$('.frost-scroll').trigger('ps-scroll-up')
 
-      this.on('externalAction', externalActionSpy)
+    expect(
+      externalActionSpy.called,
+      'onScrollUp closure action called on ps-scroll-up'
+    ).to.equal(true)
+  })
 
-      this.render(hbs`
-        {{frost-scroll
-          hook='myScroll'
-          onScrollDown=(action 'externalAction')
-        }}
-      `)
+  it('onScrollDown closure action is called', function () {
+    const externalActionSpy = sinon.spy()
 
-      this.$('.frost-scroll').trigger('ps-scroll-down')
+    this.on('externalAction', externalActionSpy)
 
-      expect(
-        externalActionSpy.called,
-        'onScrollDown closure action called on ps-scroll-down'
-      ).to.equal(true)
-    })
+    this.render(hbs`
+      {{frost-scroll
+        hook='myScroll'
+        onScrollDown=(action 'externalAction')
+      }}
+    `)
 
-    it('onScrollYStart closure action is called', function () {
-      const externalActionSpy = sinon.spy()
+    this.$('.frost-scroll').trigger('ps-scroll-down')
 
-      this.on('externalAction', externalActionSpy)
+    expect(
+      externalActionSpy.called,
+      'onScrollDown closure action called on ps-scroll-down'
+    ).to.equal(true)
+  })
 
-      this.render(hbs`
-        {{frost-scroll
-          hook='myScroll'
-          onScrollYStart=(action 'externalAction')
-        }}
-      `)
+  it('onScrollYStart closure action is called', function () {
+    const externalActionSpy = sinon.spy()
 
-      this.$('.frost-scroll').trigger('ps-y-reach-start')
+    this.on('externalAction', externalActionSpy)
 
-      expect(
-        externalActionSpy.called,
-        'onScrollYStart closure action called on ps-y-reach-start'
-      ).to.equal(true)
-    })
+    this.render(hbs`
+      {{frost-scroll
+        hook='myScroll'
+        onScrollYStart=(action 'externalAction')
+      }}
+    `)
 
-    it('onScrollYEnd closure action is called', function () {
-      const externalActionSpy = sinon.spy()
+    this.$('.frost-scroll').trigger('ps-y-reach-start')
 
-      this.on('externalAction', externalActionSpy)
+    expect(
+      externalActionSpy.called,
+      'onScrollYStart closure action called on ps-y-reach-start'
+    ).to.equal(true)
+  })
 
-      this.render(hbs`
-        {{frost-scroll
-          hook='myScroll'
-          onScrollYEnd=(action 'externalAction')
-        }}
-      `)
+  it('onScrollYEnd closure action is called', function () {
+    const externalActionSpy = sinon.spy()
 
-      this.$('.frost-scroll').trigger('ps-y-reach-end')
+    this.on('externalAction', externalActionSpy)
 
-      expect(
-        externalActionSpy.called,
-        'onScrollYEnd closure action called on ps-y-reach-end'
-      ).to.equal(true)
-    })
+    this.render(hbs`
+      {{frost-scroll
+        hook='myScroll'
+        onScrollYEnd=(action 'externalAction')
+      }}
+    `)
 
-    it('renders using spread', function () {
-      const hook = 'my-hook'
+    this.$('.frost-scroll').trigger('ps-y-reach-end')
 
-      this.set('hook', hook)
+    expect(
+      externalActionSpy.called,
+      'onScrollYEnd closure action called on ps-y-reach-end'
+    ).to.equal(true)
+  })
 
-      this.render(hbs`
-        {{frost-scroll
-          options=(hash
-            hook=hook
-          )
-        }}
-      `)
+  it('renders using spread', function () {
+    const hook = 'my-hook'
 
-      expect(
-        $hook(hook).hasClass('frost-scroll'),
-        'scroll has been rendered'
-      ).to.equal(true)
-    })
-  }
-)
+    this.set('hook', hook)
+
+    this.render(hbs`
+      {{frost-scroll
+        options=(hash
+          hook=hook
+        )
+      }}
+    `)
+
+    expect(
+      $hook(hook).hasClass('frost-scroll'),
+      'scroll has been rendered'
+    ).to.equal(true)
+  })
+})

--- a/tests/integration/components/frost-select-li-test.js
+++ b/tests/integration/components/frost-select-li-test.js
@@ -1,32 +1,30 @@
 import {expect} from 'chai'
-import {describeComponent, it} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
+import {describe, it} from 'mocha'
 
-describeComponent(
-  'frost-select-li',
-  'Integration: FrostSelectLiComponent',
-  {
-    integration: true
-  },
-  function () {
-    it('renders', function () {
-      this.setProperties({
-        data: {
-          label: 'Foo',
-          selected: false,
-          value: 'foo'
-        },
-        onItemOver () {},
-        onSelect () {}
-      })
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
-      this.render(hbs`{{frost-select-li
-        data=data
-        hook='mySelectListItem'
-        onItemOver=onItemOver
-        onSelect=onSelect
-      }}`)
-      expect(this.$()).to.have.length(1)
+const test = integration('frost-select-li')
+describe(test.label, function () {
+  test.setup()
+
+  it('renders', function () {
+    this.setProperties({
+      data: {
+        label: 'Foo',
+        selected: false,
+        value: 'foo'
+      },
+      onItemOver () {},
+      onSelect () {}
     })
-  }
-)
+
+    this.render(hbs`{{frost-select-li
+      data=data
+      hook='mySelectListItem'
+      onItemOver=onItemOver
+      onSelect=onSelect
+    }}`)
+    expect(this.$()).to.have.length(1)
+  })
+})

--- a/tests/integration/components/frost-select-outlet-test.js
+++ b/tests/integration/components/frost-select-outlet-test.js
@@ -1,17 +1,15 @@
 import {expect} from 'chai'
-import {describeComponent, it} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
+import {describe, it} from 'mocha'
 
-describeComponent(
-  'frost-select-outlet',
-  'Integration: FrostSelectOutletComponent',
-  {
-    integration: true
-  },
-  function () {
-    it('renders', function () {
-      this.render(hbs`{{frost-select-outlet hook='mySelectOutlet'}}`)
-      expect(this.$()).to.have.length(1)
-    })
-  }
-)
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
+
+const test = integration('frost-select-outlet')
+describe(test.label, function () {
+  test.setup()
+
+  it('renders', function () {
+    this.render(hbs`{{frost-select-outlet hook='mySelectOutlet'}}`)
+    expect(this.$()).to.have.length(1)
+  })
+})

--- a/tests/integration/components/frost-select-test.js
+++ b/tests/integration/components/frost-select-test.js
@@ -2,15 +2,14 @@ import {expect} from 'chai'
 import Ember from 'ember'
 const {$, run} = Ember
 import {$hook} from 'ember-hook'
-import {describeComponent, it} from 'ember-mocha'
 import wait from 'ember-test-helpers/wait'
 import hbs from 'htmlbars-inline-precompile'
-import {afterEach, beforeEach, describe} from 'mocha'
+import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
 
 import {expectSelectWithState, filterSelect} from 'dummy/tests/helpers/ember-frost-core'
 import {open, selectItemAtIndex} from 'dummy/tests/helpers/ember-frost-core/frost-select'
-import {integration} from 'dummy/tests/helpers/ember-test-utils/describe-component'
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 import {keyCodes} from 'ember-frost-core/utils'
 const {DOWN_ARROW, ENTER, ESCAPE, SPACE, TAB, UP_ARROW} = keyCodes
 
@@ -56,7 +55,10 @@ function getItemHtml (index) {
     .trim()
 }
 
-describeComponent(...integration('frost-select'), function () {
+const test = integration('frost-select')
+describe(test.label, function () {
+  test.setup()
+
   describe('renders', function () {
     let onBlur, onChange, onFocus, sandbox
 

--- a/tests/integration/components/frost-text-test.js
+++ b/tests/integration/components/frost-text-test.js
@@ -2,366 +2,363 @@ import {expect} from 'chai'
 import Ember from 'ember'
 const {run} = Ember
 import {$hook} from 'ember-hook'
-import {describeComponent, it} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
-import {beforeEach, describe} from 'mocha'
+import {beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
 
-describeComponent(
-  'frost-text',
-  'Integration: FrostTextComponent',
-  {
-    integration: true
-  },
-  function () {
-    describe('when type is set to "number"', function () {
-      beforeEach(function () {
-        this.render(hbs`
-          {{frost-text
-            hook='myTextInput'
-            type='number'
-          }}
-        `)
-      })
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
-      it('renders', function () {
-        expect(this.$('.frost-text')).to.have.length(1)
-      })
+const test = integration('frost-text')
+describe(test.label, function () {
+  test.setup()
+
+  describe('when type is set to "number"', function () {
+    beforeEach(function () {
+      this.render(hbs`
+        {{frost-text
+          hook='myTextInput'
+          type='number'
+        }}
+      `)
     })
 
     it('renders', function () {
-      this.render(hbs`
-          {{frost-text hook='myTextInput'}}
-      `)
+      expect(this.$('.frost-text')).to.have.length(1)
+    })
+  })
 
-      expect(
-        this.$('input').prop('tabindex'),
-        'tabindex is set'
-      ).to.eql(0)
+  it('renders', function () {
+    this.render(hbs`
+        {{frost-text hook='myTextInput'}}
+    `)
 
-      expect(
-        this.$('input').prop('type'),
-        'type is set'
-      ).to.eql('text')
+    expect(
+      this.$('input').prop('tabindex'),
+      'tabindex is set'
+    ).to.eql(0)
 
-      expect(
-        this.$('input').hasClass('frost-text-input'),
-        'class "frost-text-input" is set'
-      ).to.equal(true)
+    expect(
+      this.$('input').prop('type'),
+      'type is set'
+    ).to.eql('text')
 
-      expect(
-        this.$('input').hasClass('left'),
-        'class "left" is set'
-      ).to.equal(true)
+    expect(
+      this.$('input').hasClass('frost-text-input'),
+      'class "frost-text-input" is set'
+    ).to.equal(true)
 
-      expect(
-        this.$('.frost-text-clear'),
-        'class "frost-text-clear" is set'
-      ).to.have.length(1)
+    expect(
+      this.$('input').hasClass('left'),
+      'class "left" is set'
+    ).to.equal(true)
+
+    expect(
+      this.$('.frost-text-clear'),
+      'class "frost-text-clear" is set'
+    ).to.have.length(1)
+  })
+
+  it('sets align property', function () {
+    const align = 'right'
+
+    this.set('align', align)
+
+    this.render(hbs`
+        {{frost-text
+          align=align
+          hook='myTextInput'
+        }}
+    `)
+
+    expect(
+      this.$('input').hasClass(align),
+      'class "right" is set'
+    ).to.equal(true)
+  })
+
+  it('sets autofocus property', function () {
+    this.render(hbs`
+        {{frost-text
+          autofocus=true
+          hook='myTextInput'
+        }}
+    `)
+
+    expect(
+      this.$('input').prop('autofocus'),
+      'autofocus attribute is set'
+    ).to.equal(true)
+  })
+
+  it('set disabled property', function () {
+    this.render(hbs`
+      {{frost-text
+        disabled=true
+        hook='myTextInput'
+      }}
+    `)
+
+    expect(
+      this.$('input').prop('disabled'),
+      'disabled attribute is set'
+    ).to.equal(true)
+  })
+
+  it('sets maxlength property', function () {
+    const maxlength = 30
+
+    this.set('maxlength', maxlength)
+
+    this.render(hbs`
+      {{frost-text
+        hook='myTextInput'
+        maxlength=maxlength
+      }}
+   `)
+
+    expect(
+      this.$('input').prop('maxlength'),
+      'maxlength is set'
+    ).to.eql(maxlength)
+  })
+
+  it('sets placeholder property', function () {
+    const placeholder = 'Enter here'
+
+    this.set('placeholder', placeholder)
+
+    this.render(hbs`
+      {{frost-text
+        hook='myTextInput'
+        placeholder=placeholder
+      }}
+   `)
+
+    expect(
+      this.$('input').prop('placeholder'),
+      'placeholder is set'
+    ).to.eql(placeholder)
+  })
+
+  it('sets value property', function () {
+    const value = 'Testing'
+
+    this.set('value', value)
+
+    this.render(hbs`
+      {{frost-text
+        hook='myTextInput'
+        value=value
+      }}
+    `)
+
+    expect(
+      this.$('input').val(),
+      'value is set'
+    ).to.eql(value)
+  })
+
+  it('set readonly property', function () {
+    this.render(hbs`
+      {{frost-text
+        hook='myTextInput'
+        readonly=true
+      }}
+    `)
+
+    expect(
+      this.$('input').prop('readonly'),
+      'readonly attribute is set'
+    ).to.equal(true)
+  })
+
+  it('set required property', function () {
+    this.render(hbs`
+      {{frost-text
+        hook='myTextInput'
+        required=true
+      }}
+    `)
+
+    expect(
+      this.$('input').prop('required'),
+      'required attribute is set'
+    ).to.equal(true)
+  })
+
+  it('set spellcheck property', function () {
+    this.render(hbs`
+      {{frost-text
+        hook='myTextInput'
+        spellcheck=true
+      }}
+    `)
+
+    expect(
+      this.$('input').prop('spellcheck'),
+      'spellcheck attribute is set'
+    ).to.equal(true)
+  })
+
+  it('set tabindex property', function () {
+    const tabindex = -1
+
+    this.set('tabindex', tabindex)
+
+    this.render(hbs`
+      {{frost-text
+        hook='myTextInput'
+        tabindex=tabindex
+      }}
+    `)
+
+    expect(
+      this.$('input').prop('tabindex'),
+      'tabindex attribute is set'
+    ).to.eql(tabindex)
+  })
+
+  it('set title property', function () {
+    const title = 'title'
+
+    this.set('title', title)
+
+    this.render(hbs`
+      {{frost-text
+        hook='myTextInput'
+        title=title
+      }}
+    `)
+
+    expect(
+      this.$('input').prop('title'),
+      'title attribute is set'
+    ).to.eql(title)
+  })
+
+  it('only renders the clear icon in insert', function () {
+    this.render(hbs`
+      {{frost-text hook='myTextInput'}}
+    `)
+
+    expect(
+      this.$('.frost-text').hasClass('is-clear-visible'),
+      'class "is-clear-visible" is not set'
+    ).to.equal(false)
+
+    expect(
+      this.$('.frost-text').hasClass('is-clear-enabled'),
+      'class "is-clear-enabled" is not set'
+    ).to.equal(false)
+
+    run(() => this.$('input').val('Test').trigger('input'))
+
+    expect(
+      this.$('.frost-text').hasClass('is-clear-visible'),
+      'class "is-clear-visible" is set'
+    ).to.equal(true)
+
+    expect(
+      this.$('.frost-text').hasClass('is-clear-enabled'),
+      'class "is-clear-enabled" is set'
+    ).to.equal(true)
+  })
+
+  it('runs clear() which clears the input value', function () {
+    this.render(hbs`
+      {{frost-text hook='myTextInput'}}
+    `)
+
+    run(() => {
+      this.$('input').val('Test').trigger('input')
+      this.$('.frost-text-clear').trigger('click')
     })
 
-    it('sets align property', function () {
-      const align = 'right'
+    expect(
+      this.$('input').val(),
+      'input value cleared'
+    ).to.eql('')
+  })
 
-      this.set('align', align)
-
-      this.render(hbs`
-          {{frost-text
-            align=align
-            hook='myTextInput'
-          }}
-      `)
-
-      expect(
-        this.$('input').hasClass(align),
-        'class "right" is set'
-      ).to.equal(true)
-    })
-
-    it('sets autofocus property', function () {
-      this.render(hbs`
-          {{frost-text
-            autofocus=true
-            hook='myTextInput'
-          }}
-      `)
-
-      expect(
-        this.$('input').prop('autofocus'),
-        'autofocus attribute is set'
-      ).to.equal(true)
-    })
-
-    it('set disabled property', function () {
+  describe('when setting the hook property', function () {
+    beforeEach(function () {
       this.render(hbs`
         {{frost-text
+          hook='myText'
+        }}
+      `)
+    })
+
+    it('should set the clear hook', function () {
+      expect($hook('myText-clear')).to.have.class('frost-text-clear')
+    })
+
+    it('should set the input hook', function () {
+      expect($hook('myText-input')).to.have.class('frost-text-input')
+    })
+  })
+
+  it('calls onKeyUp closure action', function () {
+    const externalActionSpy = sinon.spy()
+
+    this.on('externalAction', externalActionSpy)
+
+    this.render(hbs`
+      {{frost-text
+        hook='myTextInput'
+        onKeyUp=(action 'externalAction')
+      }}
+    `)
+
+    this.$('input').trigger('keyup')
+
+    expect(
+      externalActionSpy.called,
+      'onKeyUp closure action called'
+    ).to.equal(true)
+  })
+
+  it('calls onInput closure action', function () {
+    const externalActionSpy = sinon.spy()
+    const testValue = 'Test'
+
+    this.set('value', testValue)
+    this.on('externalAction', externalActionSpy)
+
+    this.render(hbs`
+      {{frost-text
+        hook='myTextInput'
+        onInput=(action "externalAction")
+        value=value
+      }}
+    `)
+
+    this.$('input').trigger('input')
+
+    expect(
+      externalActionSpy.args[0][0].id,
+      'onInput closure action called with an object that contains the id'
+    ).to.eql(this.$('.frost-text').prop('id'))
+
+    expect(
+      externalActionSpy.args[0][0].value,
+      'onInput closure action called with an object that contains the value'
+    ).to.eql(testValue)
+  })
+
+  it('renders using spread', function () {
+    this.render(hbs`
+      {{frost-text
+        options=(hash
           disabled=true
           hook='myTextInput'
-        }}
-      `)
+        )
+      }}
+    `)
 
-      expect(
-        this.$('input').prop('disabled'),
-        'disabled attribute is set'
-      ).to.equal(true)
-    })
-
-    it('sets maxlength property', function () {
-      const maxlength = 30
-
-      this.set('maxlength', maxlength)
-
-      this.render(hbs`
-        {{frost-text
-          hook='myTextInput'
-          maxlength=maxlength
-        }}
-     `)
-
-      expect(
-        this.$('input').prop('maxlength'),
-        'maxlength is set'
-      ).to.eql(maxlength)
-    })
-
-    it('sets placeholder property', function () {
-      const placeholder = 'Enter here'
-
-      this.set('placeholder', placeholder)
-
-      this.render(hbs`
-        {{frost-text
-          hook='myTextInput'
-          placeholder=placeholder
-        }}
-     `)
-
-      expect(
-        this.$('input').prop('placeholder'),
-        'placeholder is set'
-      ).to.eql(placeholder)
-    })
-
-    it('sets value property', function () {
-      const value = 'Testing'
-
-      this.set('value', value)
-
-      this.render(hbs`
-        {{frost-text
-          hook='myTextInput'
-          value=value
-        }}
-      `)
-
-      expect(
-        this.$('input').val(),
-        'value is set'
-      ).to.eql(value)
-    })
-
-    it('set readonly property', function () {
-      this.render(hbs`
-        {{frost-text
-          hook='myTextInput'
-          readonly=true
-        }}
-      `)
-
-      expect(
-        this.$('input').prop('readonly'),
-        'readonly attribute is set'
-      ).to.equal(true)
-    })
-
-    it('set required property', function () {
-      this.render(hbs`
-        {{frost-text
-          hook='myTextInput'
-          required=true
-        }}
-      `)
-
-      expect(
-        this.$('input').prop('required'),
-        'required attribute is set'
-      ).to.equal(true)
-    })
-
-    it('set spellcheck property', function () {
-      this.render(hbs`
-        {{frost-text
-          hook='myTextInput'
-          spellcheck=true
-        }}
-      `)
-
-      expect(
-        this.$('input').prop('spellcheck'),
-        'spellcheck attribute is set'
-      ).to.equal(true)
-    })
-
-    it('set tabindex property', function () {
-      const tabindex = -1
-
-      this.set('tabindex', tabindex)
-
-      this.render(hbs`
-        {{frost-text
-          hook='myTextInput'
-          tabindex=tabindex
-        }}
-      `)
-
-      expect(
-        this.$('input').prop('tabindex'),
-        'tabindex attribute is set'
-      ).to.eql(tabindex)
-    })
-
-    it('set title property', function () {
-      const title = 'title'
-
-      this.set('title', title)
-
-      this.render(hbs`
-        {{frost-text
-          hook='myTextInput'
-          title=title
-        }}
-      `)
-
-      expect(
-        this.$('input').prop('title'),
-        'title attribute is set'
-      ).to.eql(title)
-    })
-
-    it('only renders the clear icon in insert', function () {
-      this.render(hbs`
-        {{frost-text hook='myTextInput'}}
-      `)
-
-      expect(
-        this.$('.frost-text').hasClass('is-clear-visible'),
-        'class "is-clear-visible" is not set'
-      ).to.equal(false)
-
-      expect(
-        this.$('.frost-text').hasClass('is-clear-enabled'),
-        'class "is-clear-enabled" is not set'
-      ).to.equal(false)
-
-      run(() => this.$('input').val('Test').trigger('input'))
-
-      expect(
-        this.$('.frost-text').hasClass('is-clear-visible'),
-        'class "is-clear-visible" is set'
-      ).to.equal(true)
-
-      expect(
-        this.$('.frost-text').hasClass('is-clear-enabled'),
-        'class "is-clear-enabled" is set'
-      ).to.equal(true)
-    })
-
-    it('runs clear() which clears the input value', function () {
-      this.render(hbs`
-        {{frost-text hook='myTextInput'}}
-      `)
-
-      run(() => {
-        this.$('input').val('Test').trigger('input')
-        this.$('.frost-text-clear').trigger('click')
-      })
-
-      expect(
-        this.$('input').val(),
-        'input value cleared'
-      ).to.eql('')
-    })
-
-    describe('when setting the hook property', function () {
-      beforeEach(function () {
-        this.render(hbs`
-          {{frost-text
-            hook='myText'
-          }}
-        `)
-      })
-
-      it('should set the clear hook', function () {
-        expect($hook('myText-clear')).to.have.class('frost-text-clear')
-      })
-
-      it('should set the input hook', function () {
-        expect($hook('myText-input')).to.have.class('frost-text-input')
-      })
-    })
-
-    it('calls onKeyUp closure action', function () {
-      const externalActionSpy = sinon.spy()
-
-      this.on('externalAction', externalActionSpy)
-
-      this.render(hbs`
-        {{frost-text
-          hook='myTextInput'
-          onKeyUp=(action 'externalAction')
-        }}
-      `)
-
-      this.$('input').trigger('keyup')
-
-      expect(
-        externalActionSpy.called,
-        'onKeyUp closure action called'
-      ).to.equal(true)
-    })
-
-    it('calls onInput closure action', function () {
-      const externalActionSpy = sinon.spy()
-      const testValue = 'Test'
-
-      this.set('value', testValue)
-      this.on('externalAction', externalActionSpy)
-
-      this.render(hbs`
-        {{frost-text
-          hook='myTextInput'
-          onInput=(action "externalAction")
-          value=value
-        }}
-      `)
-
-      this.$('input').trigger('input')
-
-      expect(
-        externalActionSpy.args[0][0].id,
-        'onInput closure action called with an object that contains the id'
-      ).to.eql(this.$('.frost-text').prop('id'))
-
-      expect(
-        externalActionSpy.args[0][0].value,
-        'onInput closure action called with an object that contains the value'
-      ).to.eql(testValue)
-    })
-
-    it('renders using spread', function () {
-      this.render(hbs`
-        {{frost-text
-          options=(hash
-            disabled=true
-            hook='myTextInput'
-          )
-        }}
-      `)
-
-      expect(
-        this.$('input').prop('disabled'),
-        'disabled attribute is set'
-      ).to.equal(true)
-    })
-  }
-)
+    expect(
+      this.$('input').prop('disabled'),
+      'disabled attribute is set'
+    ).to.equal(true)
+  })
+})

--- a/tests/integration/components/frost-textarea-test.js
+++ b/tests/integration/components/frost-textarea-test.js
@@ -2,381 +2,379 @@ import {expect} from 'chai'
 import Ember from 'ember'
 const {run} = Ember
 import {$hook} from 'ember-hook'
-import {describeComponent, it} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
+import {describe, it} from 'mocha'
 import sinon from 'sinon'
 
-describeComponent(
-  'frost-textarea',
-  'Integration: FrostTextAreaComponent',
-  {
-    integration: true
-  },
-  function () {
-    it('renders default values', function () {
-      this.render(hbs`
-        {{frost-textarea hook='myTextarea'}}
-      `)
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
-      expect(
-        this.$('textarea').prop('tabindex'),
-        'tabindex is set'
-      ).to.eql(0)
+const test = integration('frost-textarea')
+describe(test.label, function () {
+  test.setup()
 
-      expect(
-        this.$('textarea').hasClass('frost-textarea-input'),
-        'class "frost-textarea-input" is set'
-      ).to.equal(true)
+  it('renders default values', function () {
+    this.render(hbs`
+      {{frost-textarea hook='myTextarea'}}
+    `)
 
-      expect(
-        this.$('.frost-textarea-clear'),
-        'class "frost-textarea-clear" is set'
-      ).to.have.length(1)
+    expect(
+      this.$('textarea').prop('tabindex'),
+      'tabindex is set'
+    ).to.eql(0)
+
+    expect(
+      this.$('textarea').hasClass('frost-textarea-input'),
+      'class "frost-textarea-input" is set'
+    ).to.equal(true)
+
+    expect(
+      this.$('.frost-textarea-clear'),
+      'class "frost-textarea-clear" is set'
+    ).to.have.length(1)
+  })
+
+  it('sets autofocus property', function () {
+    this.render(hbs`
+      {{frost-textarea
+        autofocus=true
+        hook='myTextarea'
+      }}
+   `)
+
+    expect(
+      this.$('textarea').prop('autofocus'),
+      'autofocus attribute is set'
+    ).to.equal(true)
+  })
+
+  it('sets disabled property', function () {
+    this.render(hbs`
+      {{frost-textarea
+        disabled=true
+        hook='myTextarea'
+      }}
+   `)
+
+    expect(
+      this.$('textarea').prop('disabled'),
+      'disabled attribute is set'
+    ).to.equal(true)
+  })
+
+  it('sets readonly property', function () {
+    this.render(hbs`
+      {{frost-textarea
+        hook='myTextarea'
+        readonly=true
+      }}
+   `)
+
+    expect(
+      this.$('textarea').prop('readonly'),
+      'readonly attribute is set'
+    ).to.equal(true)
+  })
+
+  it('sets cols property', function () {
+    const cols = 20
+
+    this.set('cols', cols)
+
+    this.render(hbs`
+      {{frost-textarea
+        cols=cols
+        hook='myTextarea'
+      }}
+   `)
+
+    expect(
+      this.$('textarea').prop('cols'),
+      'cols attribute is set'
+    ).to.eql(cols)
+  })
+
+  it('sets tabindex', function () {
+    const tabindex = -1
+
+    this.set('tabindex', tabindex)
+
+    this.render(hbs`
+      {{frost-textarea
+        hook='myTextarea'
+        tabindex=tabindex
+      }}
+    `)
+
+    expect(
+      this.$('textarea').prop('tabindex'),
+      'tabindex is set'
+    ).to.eql(tabindex)
+  })
+
+  it('sets rows property', function () {
+    const rows = 20
+
+    this.set('rows', rows)
+
+    this.render(hbs`
+      {{frost-textarea
+        hook='myTextarea'
+        rows=rows
+      }}
+   `)
+
+    expect(
+      this.$('textarea').prop('rows'),
+      'rows attribute is set'
+    ).to.eql(rows)
+  })
+
+  it('sets placeholder property', function () {
+    const placeholder = 'placeholder'
+
+    this.set('placeholder', placeholder)
+
+    this.render(hbs`
+      {{frost-textarea
+        hook='myTextarea'
+        placeholder=placeholder
+      }}
+   `)
+
+    expect(
+      this.$('textarea').prop('placeholder'),
+      'placeholder attribute is set'
+    ).to.eql(placeholder)
+  })
+
+  it('sets value', function () {
+    const value = 'Test'
+
+    this.set('value', value)
+
+    this.render(hbs`
+      {{frost-textarea
+        hook='myTextarea'
+        value=value
+      }}
+   `)
+
+    expect(
+      this.$('textarea').val(),
+      'value is set'
+    ).to.eql(value)
+  })
+
+  it('calls onFocus closure action', function () {
+    const externalActionSpy = sinon.spy()
+
+    this.on('externalAction', externalActionSpy)
+
+    this.render(hbs`
+      {{frost-textarea
+        hook='myTextarea'
+        onFocus=(action 'externalAction')
+      }}
+    `)
+
+    this.$('textarea').trigger('focusin')
+
+    expect(
+      externalActionSpy.called,
+      'onFocus closure action called'
+    ).to.equal(true)
+  })
+
+  it('calls onInput closure action', function () {
+    const externalActionSpy = sinon.spy()
+
+    this.on('externalAction', externalActionSpy)
+
+    this.render(hbs`
+      {{frost-textarea
+        hook='myTextarea'
+        onInput=(action 'externalAction')
+      }}
+    `)
+
+    this.$('textarea').trigger('input')
+
+    expect(
+      externalActionSpy.called,
+      'onInput closure action called'
+    ).to.equal(true)
+  })
+
+  it('calls onBlur closure action', function () {
+    const externalActionSpy = sinon.spy()
+
+    this.on('externalAction', externalActionSpy)
+
+    this.render(hbs`
+      {{frost-textarea
+        hook='myTextarea'
+        onBlur=(action 'externalAction')
+      }}
+    `)
+
+    this.$('textarea').trigger('focusout')
+
+    expect(
+      externalActionSpy.called,
+      'onBlur closure action called'
+    ).to.equal(true)
+  })
+
+  it('hook attr grabs frost-textarea-input as expected', function () {
+    this.render(hbs`
+      {{frost-textarea
+        hook='myTextarea'
+      }}
+    `)
+
+    expect(
+      $hook('myTextarea-input').hasClass('ember-text-area'),
+      'input hook is set'
+    ).to.equal(true)
+  })
+
+  it('hook attr grabs frost-textarea-clear as expected', function () {
+    this.render(hbs`
+      {{frost-textarea
+        hook='myTextarea'
+        value='Test'
+      }}
+    `)
+
+    expect(
+      $hook('myTextarea-clear').hasClass('frost-textarea-clear'),
+      'clear hook is set'
+    ).to.equal(true)
+  })
+
+  it('only renders the clear icon in insert', function () {
+    this.render(hbs`
+      {{frost-textarea hook='myTextarea'}}
+    `)
+
+    expect(
+      this.$('.frost-textarea').hasClass('is-clear-visible'),
+      'class "is-clear-visible" is not set'
+    ).to.equal(false)
+
+    expect(
+      this.$('.frost-textarea').hasClass('is-clear-enabled'),
+      'class "is-clear-enabled" is not set'
+    ).to.equal(false)
+
+    run(() => this.$('textarea').val('Test').trigger('input'))
+
+    expect(
+      this.$('.frost-textarea').hasClass('is-clear-visible'),
+      'class "is-clear-visible" is set'
+    ).to.equal(true)
+
+    expect(
+      this.$('.frost-textarea').hasClass('is-clear-enabled'),
+      'class "is-clear-enabled" is set'
+    ).to.equal(true)
+  })
+
+  it('runs clear() which clears the input value', function () {
+    this.render(hbs`
+      {{frost-textarea hook='myTextarea'}}
+    `)
+
+    run(() => {
+      this.$('textarea').val('Test').trigger('input')
+      this.$('.frost-textarea-clear').trigger('click')
     })
 
-    it('sets autofocus property', function () {
-      this.render(hbs`
+    expect(
+      this.$('textarea').val(),
+      'input value cleared'
+    ).to.eql('')
+  })
+
+  it('hook attr grabs frost-textarea as expected', function () {
+    this.render(hbs`
         {{frost-textarea
-          autofocus=true
-          hook='myTextarea'
+          hook='my-text'
         }}
-     `)
+    `)
 
-      expect(
-        this.$('textarea').prop('autofocus'),
-        'autofocus attribute is set'
-      ).to.equal(true)
-    })
+    expect(
+      $hook('my-text-input').hasClass('frost-textarea-input'),
+      'input hook is set'
+    ).to.equal(true)
 
-    it('sets disabled property', function () {
-      this.render(hbs`
-        {{frost-textarea
+    expect(
+      $hook('my-text-clear').hasClass('frost-textarea-clear'),
+      'clear hook is set'
+    ).to.equal(true)
+  })
+
+  it('calls onKeyUp closure action', function () {
+    const externalActionSpy = sinon.spy()
+
+    this.on('externalAction', externalActionSpy)
+
+    this.render(hbs`
+      {{frost-textarea
+        hook='myTextarea'
+        onKeyUp=(action 'externalAction')
+      }}
+    `)
+
+    this.$('textarea').trigger('keyup')
+
+    expect(
+      externalActionSpy.called,
+      'onKeyUp closure action called'
+    ).to.equal(true)
+  })
+
+  it('calls onInput closure action', function () {
+    const externalActionSpy = sinon.spy()
+    const testValue = 'Test'
+
+    this.set('value', testValue)
+    this.on('externalAction', externalActionSpy)
+
+    this.render(hbs`
+      {{frost-textarea
+        hook='myTextarea'
+        onInput=(action "externalAction")
+        value=value
+      }}
+    `)
+
+    this.$('textarea').trigger('input')
+
+    expect(
+      externalActionSpy.args[0][0].id,
+      'onInput closure action called with an object that contains the id'
+    ).to.eql(this.$('.frost-textarea').prop('id'))
+
+    expect(
+      externalActionSpy.args[0][0].value,
+      'onInput closure action called with an object that contains the value'
+    ).to.eql(testValue)
+  })
+
+  it('renders using spread', function () {
+    this.render(hbs`
+      {{frost-textarea
+        options=(hash
           disabled=true
           hook='myTextarea'
-        }}
-     `)
-
-      expect(
-        this.$('textarea').prop('disabled'),
-        'disabled attribute is set'
-      ).to.equal(true)
-    })
-
-    it('sets readonly property', function () {
-      this.render(hbs`
-        {{frost-textarea
-          hook='myTextarea'
-          readonly=true
-        }}
-     `)
-
-      expect(
-        this.$('textarea').prop('readonly'),
-        'readonly attribute is set'
-      ).to.equal(true)
-    })
-
-    it('sets cols property', function () {
-      const cols = 20
-
-      this.set('cols', cols)
-
-      this.render(hbs`
-        {{frost-textarea
-          cols=cols
-          hook='myTextarea'
-        }}
-     `)
-
-      expect(
-        this.$('textarea').prop('cols'),
-        'cols attribute is set'
-      ).to.eql(cols)
-    })
-
-    it('sets tabindex', function () {
-      const tabindex = -1
-
-      this.set('tabindex', tabindex)
-
-      this.render(hbs`
-        {{frost-textarea
-          hook='myTextarea'
-          tabindex=tabindex
-        }}
-      `)
-
-      expect(
-        this.$('textarea').prop('tabindex'),
-        'tabindex is set'
-      ).to.eql(tabindex)
-    })
-
-    it('sets rows property', function () {
-      const rows = 20
-
-      this.set('rows', rows)
-
-      this.render(hbs`
-        {{frost-textarea
-          hook='myTextarea'
-          rows=rows
-        }}
-     `)
-
-      expect(
-        this.$('textarea').prop('rows'),
-        'rows attribute is set'
-      ).to.eql(rows)
-    })
-
-    it('sets placeholder property', function () {
-      const placeholder = 'placeholder'
-
-      this.set('placeholder', placeholder)
-
-      this.render(hbs`
-        {{frost-textarea
-          hook='myTextarea'
-          placeholder=placeholder
-        }}
-     `)
-
-      expect(
-        this.$('textarea').prop('placeholder'),
-        'placeholder attribute is set'
-      ).to.eql(placeholder)
-    })
-
-    it('sets value', function () {
-      const value = 'Test'
-
-      this.set('value', value)
-
-      this.render(hbs`
-        {{frost-textarea
-          hook='myTextarea'
-          value=value
-        }}
-     `)
-
-      expect(
-        this.$('textarea').val(),
-        'value is set'
-      ).to.eql(value)
-    })
-
-    it('calls onFocus closure action', function () {
-      const externalActionSpy = sinon.spy()
-
-      this.on('externalAction', externalActionSpy)
-
-      this.render(hbs`
-        {{frost-textarea
-          hook='myTextarea'
-          onFocus=(action 'externalAction')
-        }}
-      `)
-
-      this.$('textarea').trigger('focusin')
-
-      expect(
-        externalActionSpy.called,
-        'onFocus closure action called'
-      ).to.equal(true)
-    })
-
-    it('calls onInput closure action', function () {
-      const externalActionSpy = sinon.spy()
-
-      this.on('externalAction', externalActionSpy)
-
-      this.render(hbs`
-        {{frost-textarea
-          hook='myTextarea'
-          onInput=(action 'externalAction')
-        }}
-      `)
-
-      this.$('textarea').trigger('input')
-
-      expect(
-        externalActionSpy.called,
-        'onInput closure action called'
-      ).to.equal(true)
-    })
-
-    it('calls onBlur closure action', function () {
-      const externalActionSpy = sinon.spy()
-
-      this.on('externalAction', externalActionSpy)
-
-      this.render(hbs`
-        {{frost-textarea
-          hook='myTextarea'
-          onBlur=(action 'externalAction')
-        }}
-      `)
-
-      this.$('textarea').trigger('focusout')
-
-      expect(
-        externalActionSpy.called,
-        'onBlur closure action called'
-      ).to.equal(true)
-    })
-
-    it('hook attr grabs frost-textarea-input as expected', function () {
-      this.render(hbs`
-        {{frost-textarea
-          hook='myTextarea'
-        }}
-      `)
-
-      expect(
-        $hook('myTextarea-input').hasClass('ember-text-area'),
-        'input hook is set'
-      ).to.equal(true)
-    })
-
-    it('hook attr grabs frost-textarea-clear as expected', function () {
-      this.render(hbs`
-        {{frost-textarea
-          hook='myTextarea'
-          value='Test'
-        }}
-      `)
-
-      expect(
-        $hook('myTextarea-clear').hasClass('frost-textarea-clear'),
-        'clear hook is set'
-      ).to.equal(true)
-    })
-
-    it('only renders the clear icon in insert', function () {
-      this.render(hbs`
-        {{frost-textarea hook='myTextarea'}}
-      `)
-
-      expect(
-        this.$('.frost-textarea').hasClass('is-clear-visible'),
-        'class "is-clear-visible" is not set'
-      ).to.equal(false)
-
-      expect(
-        this.$('.frost-textarea').hasClass('is-clear-enabled'),
-        'class "is-clear-enabled" is not set'
-      ).to.equal(false)
-
-      run(() => this.$('textarea').val('Test').trigger('input'))
-
-      expect(
-        this.$('.frost-textarea').hasClass('is-clear-visible'),
-        'class "is-clear-visible" is set'
-      ).to.equal(true)
-
-      expect(
-        this.$('.frost-textarea').hasClass('is-clear-enabled'),
-        'class "is-clear-enabled" is set'
-      ).to.equal(true)
-    })
-
-    it('runs clear() which clears the input value', function () {
-      this.render(hbs`
-        {{frost-textarea hook='myTextarea'}}
-      `)
-
-      run(() => {
-        this.$('textarea').val('Test').trigger('input')
-        this.$('.frost-textarea-clear').trigger('click')
-      })
-
-      expect(
-        this.$('textarea').val(),
-        'input value cleared'
-      ).to.eql('')
-    })
-
-    it('hook attr grabs frost-textarea as expected', function () {
-      this.render(hbs`
-          {{frost-textarea
-            hook='my-text'
-          }}
-      `)
-
-      expect(
-        $hook('my-text-input').hasClass('frost-textarea-input'),
-        'input hook is set'
-      ).to.equal(true)
-
-      expect(
-        $hook('my-text-clear').hasClass('frost-textarea-clear'),
-        'clear hook is set'
-      ).to.equal(true)
-    })
-
-    it('calls onKeyUp closure action', function () {
-      const externalActionSpy = sinon.spy()
-
-      this.on('externalAction', externalActionSpy)
-
-      this.render(hbs`
-        {{frost-textarea
-          hook='myTextarea'
-          onKeyUp=(action 'externalAction')
-        }}
-      `)
-
-      this.$('textarea').trigger('keyup')
-
-      expect(
-        externalActionSpy.called,
-        'onKeyUp closure action called'
-      ).to.equal(true)
-    })
-
-    it('calls onInput closure action', function () {
-      const externalActionSpy = sinon.spy()
-      const testValue = 'Test'
-
-      this.set('value', testValue)
-      this.on('externalAction', externalActionSpy)
-
-      this.render(hbs`
-        {{frost-textarea
-          hook='myTextarea'
-          onInput=(action "externalAction")
-          value=value
-        }}
-      `)
-
-      this.$('textarea').trigger('input')
-
-      expect(
-        externalActionSpy.args[0][0].id,
-        'onInput closure action called with an object that contains the id'
-      ).to.eql(this.$('.frost-textarea').prop('id'))
-
-      expect(
-        externalActionSpy.args[0][0].value,
-        'onInput closure action called with an object that contains the value'
-      ).to.eql(testValue)
-    })
-
-    it('renders using spread', function () {
-      this.render(hbs`
-        {{frost-textarea
-          options=(hash
-            disabled=true
-            hook='myTextarea'
-          )
-        }}
-     `)
-
-      expect(
-        this.$('textarea').prop('disabled'),
-        'disabled attribute is set'
-      ).to.equal(true)
-    })
-  }
-)
+        )
+      }}
+   `)
+
+    expect(
+      this.$('textarea').prop('disabled'),
+      'disabled attribute is set'
+    ).to.equal(true)
+  })
+})

--- a/tests/integration/components/frost-toggle-test.js
+++ b/tests/integration/components/frost-toggle-test.js
@@ -1,249 +1,246 @@
 import {expect} from 'chai'
 import {$hook} from 'ember-hook'
-import {describeComponent, it} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
-import {describe} from 'mocha'
+import {describe, it} from 'mocha'
 import sinon from 'sinon'
 
-describeComponent(
-  'frost-toggle',
-  'Integration: FrostToggleComponent',
-  {
-    integration: true
-  },
-  function () {
-    it('renders default values', function () {
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
+
+const test = integration('frost-toggle')
+describe(test.label, function () {
+  test.setup()
+
+  it('renders default values', function () {
+    this.render(hbs`
+      {{frost-toggle hook='myToggle'}}
+    `)
+
+    expect(
+      this.$('.frost-toggle').find('input').prop('type'),
+      'type set to "checkbox"'
+    ).to.eql('checkbox')
+
+    expect(
+      this.$('.frost-toggle-input'),
+      'class frost-toggle-input is set'
+    ).to.have.length(1)
+
+    expect(
+      this.$('.frost-toggle').find('label').hasClass('frost-toggle-button'),
+      'label has class "frost-toggle-button"'
+    ).to.equal(true)
+
+    expect(
+      this.$('.frost-toggle').find('label').prop('for'),
+      '"label for" property has the correct value'
+    ).to.eql(
+      this.$('.frost-toggle').find('input').prop('id')
+    )
+  })
+
+  it('throws assertion error', function () {
+    expect(
+      () => {
+        this.render(hbs`
+          {{frost-toggle
+            hook='myToggle'
+            trueValue='testValue'
+            falseValue='testValue'
+          }}
+        `)
+      },
+      'assertion thrown when trueValue and falseValue are same value'
+    ).to.throw(/Same value has been assigned/)
+  })
+
+  it('sets disabled property', function () {
+    this.render(hbs`
+      {{frost-toggle
+        disabled=true
+        hook='myToggle'
+      }}
+   `)
+
+    expect(
+      this.$('.frost-toggle').find('input').prop('disabled'),
+      'disabled is set'
+    ).to.equal(true)
+  })
+
+  it('sets hook property', function () {
+    this.render(hbs`
+      {{frost-toggle
+        hook='my-test'
+      }}
+   `)
+
+    expect(
+      $hook('my-test-toggle-input').hasClass('frost-toggle-input'),
+      'input hook is set'
+    ).to.equal(true)
+
+    expect(
+      $hook('my-test-toggle-label').hasClass('frost-toggle-button'),
+      'label hook is set'
+    ).to.equal(true)
+
+    expect(
+      $hook('my-test-toggle-text-on').hasClass('frost-toggle-text on'),
+      'toggle text on hook is set'
+    ).to.equal(true)
+
+    expect(
+      $hook('my-test-toggle-text-off').hasClass('frost-toggle-text off'),
+      'toggle text off hook is set'
+    ).to.equal(true)
+  })
+
+  it('sets value property', function () {
+    const value = 'test value'
+
+    this.set('value', value)
+
+    this.render(hbs`
+      {{frost-toggle
+        hook='myToggle'
+        value=value
+      }}
+   `)
+
+    expect(
+      this.$('.frost-toggle').find('input').val(),
+      'value is set'
+    ).to.eql('on')
+  })
+
+  describe('label is set', function () {
+    it('uses trueLabel property', function () {
+      this.render(hbs`
+        {{frost-toggle
+          hook='myToggle'
+          trueLabel='Label On'
+          value='on'
+        }}
+     `)
+
+      expect(
+        this.$('.on').text().trim(),
+        'trueLabel is set'
+      ).to.eql('Label On')
+    })
+
+    it('uses default on label of "On"', function () {
+      this.render(hbs`
+        {{frost-toggle
+          hook='myToggle'
+          value='on'
+        }}
+     `)
+
+      expect(
+        this.$('.on').text().trim(),
+        'default on label is set'
+      ).to.eql('On')
+    })
+
+    it('uses falseLabel property', function () {
+      this.render(hbs`
+        {{frost-toggle
+          falseLabel='Label Off'
+          hook='myToggle'
+          value='on'
+        }}
+     `)
+
+      expect(
+        this.$('.off').text().trim(),
+        'falseLabel is set'
+      ).to.eql('Label Off')
+    })
+
+    it('uses default off label of "Off"', function () {
       this.render(hbs`
         {{frost-toggle hook='myToggle'}}
-      `)
+     `)
 
       expect(
-        this.$('.frost-toggle').find('input').prop('type'),
-        'type set to "checkbox"'
-      ).to.eql('checkbox')
-
-      expect(
-        this.$('.frost-toggle-input'),
-        'class frost-toggle-input is set'
-      ).to.have.length(1)
-
-      expect(
-        this.$('.frost-toggle').find('label').hasClass('frost-toggle-button'),
-        'label has class "frost-toggle-button"'
-      ).to.equal(true)
-
-      expect(
-        this.$('.frost-toggle').find('label').prop('for'),
-        '"label for" property has the correct value'
-      ).to.eql(
-        this.$('.frost-toggle').find('input').prop('id')
-      )
+        this.$('.off').text().trim(),
+        'default off label is set'
+      ).to.eql('Off')
     })
+  })
 
-    it('throws assertion error', function () {
-      expect(
-        () => {
-          this.render(hbs`
-            {{frost-toggle
-              hook='myToggle'
-              trueValue='testValue'
-              falseValue='testValue'
-            }}
-          `)
-        },
-        'assertion thrown when trueValue and falseValue are same value'
-      ).to.throw(/Same value has been assigned/)
-    })
+  it('uses trueValue property', function () {
+    this.set('testValue', 'enabled')
 
-    it('sets disabled property', function () {
-      this.render(hbs`
+    this.render(hbs`
         {{frost-toggle
+          hook='myToggle'
+          trueValue='enabled'
+          value=testValue
+        }}
+     `)
+
+    expect(
+      this.$('input').prop('checked'),
+      'toggle is in "On" state'
+    ).to.equal(true)
+  })
+
+  it('uses falseValue property', function () {
+    this.set('testValue', 'disabled')
+
+    this.render(hbs`
+        {{frost-toggle
+          falseValue='disabled'
+          hook='myToggle'
+          value=testValue
+        }}
+     `)
+
+    expect(
+      this.$('input').prop('checked'),
+      'toggle is in "Off" state'
+    ).to.equal(false)
+  })
+
+  it('fires onClick closure action', function () {
+    const externalActionSpy = sinon.spy()
+
+    this.on('externalAction', externalActionSpy)
+
+    this.set('testValue', 'disabled')
+
+    this.render(hbs`
+        {{frost-toggle
+          falseValue='disabled'
+          hook='myToggle'
+          value=testValue
+          onClick=(action 'externalAction')
+        }}
+     `)
+
+    this.$('label').click()
+
+    expect(
+      externalActionSpy.called,
+      'onClick closure action called'
+    ).to.equal(true)
+  })
+
+  it('renders using spread', function () {
+    this.render(hbs`
+      {{frost-toggle
+        options=(hash
           disabled=true
           hook='myToggle'
-        }}
-     `)
+        )
+      }}
+   `)
 
-      expect(
-        this.$('.frost-toggle').find('input').prop('disabled'),
-        'disabled is set'
-      ).to.equal(true)
-    })
-
-    it('sets hook property', function () {
-      this.render(hbs`
-        {{frost-toggle
-          hook='my-test'
-        }}
-     `)
-
-      expect(
-        $hook('my-test-toggle-input').hasClass('frost-toggle-input'),
-        'input hook is set'
-      ).to.equal(true)
-
-      expect(
-        $hook('my-test-toggle-label').hasClass('frost-toggle-button'),
-        'label hook is set'
-      ).to.equal(true)
-
-      expect(
-        $hook('my-test-toggle-text-on').hasClass('frost-toggle-text on'),
-        'toggle text on hook is set'
-      ).to.equal(true)
-
-      expect(
-        $hook('my-test-toggle-text-off').hasClass('frost-toggle-text off'),
-        'toggle text off hook is set'
-      ).to.equal(true)
-    })
-
-    it('sets value property', function () {
-      const value = 'test value'
-
-      this.set('value', value)
-
-      this.render(hbs`
-        {{frost-toggle
-          hook='myToggle'
-          value=value
-        }}
-     `)
-
-      expect(
-        this.$('.frost-toggle').find('input').val(),
-        'value is set'
-      ).to.eql('on')
-    })
-
-    describe('label is set', function () {
-      it('uses trueLabel property', function () {
-        this.render(hbs`
-          {{frost-toggle
-            hook='myToggle'
-            trueLabel='Label On'
-            value='on'
-          }}
-       `)
-
-        expect(
-          this.$('.on').text().trim(),
-          'trueLabel is set'
-        ).to.eql('Label On')
-      })
-
-      it('uses default on label of "On"', function () {
-        this.render(hbs`
-          {{frost-toggle
-            hook='myToggle'
-            value='on'
-          }}
-       `)
-
-        expect(
-          this.$('.on').text().trim(),
-          'default on label is set'
-        ).to.eql('On')
-      })
-
-      it('uses falseLabel property', function () {
-        this.render(hbs`
-          {{frost-toggle
-            falseLabel='Label Off'
-            hook='myToggle'
-            value='on'
-          }}
-       `)
-
-        expect(
-          this.$('.off').text().trim(),
-          'falseLabel is set'
-        ).to.eql('Label Off')
-      })
-
-      it('uses default off label of "Off"', function () {
-        this.render(hbs`
-          {{frost-toggle hook='myToggle'}}
-       `)
-
-        expect(
-          this.$('.off').text().trim(),
-          'default off label is set'
-        ).to.eql('Off')
-      })
-    })
-
-    it('uses trueValue property', function () {
-      this.set('testValue', 'enabled')
-
-      this.render(hbs`
-          {{frost-toggle
-            hook='myToggle'
-            trueValue='enabled'
-            value=testValue
-          }}
-       `)
-
-      expect(
-        this.$('input').prop('checked'),
-        'toggle is in "On" state'
-      ).to.equal(true)
-    })
-
-    it('uses falseValue property', function () {
-      this.set('testValue', 'disabled')
-
-      this.render(hbs`
-          {{frost-toggle
-            falseValue='disabled'
-            hook='myToggle'
-            value=testValue
-          }}
-       `)
-
-      expect(
-        this.$('input').prop('checked'),
-        'toggle is in "Off" state'
-      ).to.equal(false)
-    })
-
-    it('fires onClick closure action', function () {
-      const externalActionSpy = sinon.spy()
-
-      this.on('externalAction', externalActionSpy)
-
-      this.set('testValue', 'disabled')
-
-      this.render(hbs`
-          {{frost-toggle
-            falseValue='disabled'
-            hook='myToggle'
-            value=testValue
-            onClick=(action 'externalAction')
-          }}
-       `)
-
-      this.$('label').click()
-
-      expect(
-        externalActionSpy.called,
-        'onClick closure action called'
-      ).to.equal(true)
-    })
-
-    it('renders using spread', function () {
-      this.render(hbs`
-        {{frost-toggle
-          options=(hash
-            disabled=true
-            hook='myToggle'
-          )
-        }}
-     `)
-
-      expect(
-        this.$('.frost-toggle').find('input').prop('disabled'),
-        'disabled is set'
-      ).to.equal(true)
-    })
-  }
-)
+    expect(
+      this.$('.frost-toggle').find('input').prop('disabled'),
+      'disabled is set'
+    ).to.equal(true)
+  })
+})

--- a/tests/integration/helpers/array-test.js
+++ b/tests/integration/helpers/array-test.js
@@ -1,30 +1,27 @@
 import {expect} from 'chai'
-import {describeComponent, it} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
-import {beforeEach} from 'mocha'
+import {beforeEach, describe, it} from 'mocha'
 
-describeComponent(
-  'array',
-  'Integration: ArrayHelper',
-  {
-    integration: true
-  },
-  function () {
-    beforeEach(function () {
-      this.render(hbs`{{array 1 2 3}}`)
-    })
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
-    it('renders as expected', function () {
-      this.render(hbs`{{array 1 2 3}}`)
-      expect(this.$().text().trim()).to.be.equal('1,2,3')
-    })
+const test = integration('array')
+describe(test.label, function () {
+  test.setup()
 
-    it('use in loop', function () {
-      this.render(hbs`
-      {{#each (array 1 2 3) as |value|}}
-        <p class='value'>{{value}}</p>
-      {{/each}}`)
-      expect(this.$('.value')).to.have.length(3)
-    })
-  }
-)
+  beforeEach(function () {
+    this.render(hbs`{{array 1 2 3}}`)
+  })
+
+  it('renders as expected', function () {
+    this.render(hbs`{{array 1 2 3}}`)
+    expect(this.$().text().trim()).to.be.equal('1,2,3')
+  })
+
+  it('use in loop', function () {
+    this.render(hbs`
+    {{#each (array 1 2 3) as |value|}}
+      <p class='value'>{{value}}</p>
+    {{/each}}`)
+    expect(this.$('.value')).to.have.length(3)
+  })
+})

--- a/tests/unit/components/frost-checkbox-test.js
+++ b/tests/unit/components/frost-checkbox-test.js
@@ -1,174 +1,167 @@
 import {expect} from 'chai'
 import Ember from 'ember'
 const {$, run} = Ember
-import Component from 'ember-frost-core/components/frost-component'
-import {describeComponent} from 'ember-mocha'
 import {beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
 
-describeComponent(
-  'frost-checkbox',
-  'Unit: FrostCheckboxComponent',
-  {
-    needs: [
-      'helper:hook'
-    ],
+import {unit} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
+import Component from 'ember-frost-core/components/frost-component'
 
-    unit: true
-  },
-  function () {
-    let component
+const test = unit('frost-checkbox', ['helper:hook'])
+describe(test.label, function () {
+  test.setup()
+
+  let component
+
+  beforeEach(function () {
+    component = this.subject({
+      hook: 'myCheckbox'
+    })
+  })
+
+  it('sets default property values correctly', function () {
+    expect(
+      component.get('size'),
+      'size: "small"'
+    ).to.eql('small')
+
+    expect(
+      component.get('label'),
+      'label: ""'
+    ).to.eql('')
+
+    expect(
+      component.get('autofocus'),
+      'autofocus: "false"'
+    ).to.equal(false)
+
+    expect(
+      component.get('checked'),
+      'checked: "false"'
+    ).to.equal(false)
+
+    expect(
+      component.get('disabled'),
+      'disabled: "false"'
+    ).to.equal(false)
+
+    expect(
+      component.get('inputId'),
+      'inputId: "null"'
+    ).not.to.equal(null)
+  })
+
+  it('extends the base frost component', function () {
+    expect(
+      component instanceof Component,
+      'is instance of Frost Component'
+    ).to.equal(true)
+  })
+
+  it('_setInputId() concatenates elmenentId to "_input"', function () {
+    const testInputId = component.get('elementId')
+
+    component._setInputId()
+
+    expect(
+      component.get('inputId')
+    ).to.eql(`${testInputId}_input`)
+  })
+
+  describe('when onBlur property is omitted', function () {
+    beforeEach(function () {
+      run(() => component.set('onBlur', undefined))
+    })
+
+    it('does not throw an error when onBlur action is triggered', function () {
+      expect(function () {
+        component.get('actions.onBlur').call(component)
+      }).not.to.throw(Error)
+    })
+  })
+
+  describe('keyPress()', function () {
+    const preventDefaultSpy = sinon.spy()
+    const stopPropagationSpy = sinon.spy()
+
+    const eventTestObject = {
+      keyCode: 32,
+      preventDefault: preventDefaultSpy,
+      stopPropagation: stopPropagationSpy
+    }
 
     beforeEach(function () {
-      component = this.subject({
-        hook: 'myCheckbox'
-      })
+      preventDefaultSpy.reset()
+      stopPropagationSpy.reset()
     })
+    it('sets state to checked', function () {
+      this.render()
 
-    it('sets default property values correctly', function () {
-      expect(
-        component.get('size'),
-        'size: "small"'
-      ).to.eql('small')
+      component.keyPress(eventTestObject)
 
       expect(
-        component.get('label'),
-        'label: ""'
-      ).to.eql('')
-
-      expect(
-        component.get('autofocus'),
-        'autofocus: "false"'
-      ).to.equal(false)
-
-      expect(
-        component.get('checked'),
-        'checked: "false"'
-      ).to.equal(false)
-
-      expect(
-        component.get('disabled'),
-        'disabled: "false"'
-      ).to.equal(false)
-
-      expect(
-        component.get('inputId'),
-        'inputId: "null"'
-      ).not.to.equal(null)
-    })
-
-    it('extends the base frost component', function () {
-      expect(
-        component instanceof Component,
-        'is instance of Frost Component'
+        $('input').prop('checked'),
+        'keyPress() sets checked state'
       ).to.equal(true)
     })
 
-    it('_setInputId() concatenates elmenentId to "_input"', function () {
-      const testInputId = component.get('elementId')
+    it('does not set state to checked when disabled is true', function () {
+      const disabled = true
 
-      component._setInputId()
+      this.render()
+
+      run(() => component.set('disabled', disabled))
+
+      component.keyPress(eventTestObject)
 
       expect(
-        component.get('inputId')
-      ).to.eql(`${testInputId}_input`)
+        $('input').prop('checked'),
+        'keyPress() did not set checked state'
+      ).to.equal(false)
     })
 
-    describe('when onBlur property is omitted', function () {
-      beforeEach(function () {
-        run(() => component.set('onBlur', undefined))
-      })
+    it('calls preventDefault', function () {
+      this.render()
 
-      it('does not throw an error when onBlur action is triggered', function () {
-        expect(function () {
-          component.get('actions.onBlur').call(component)
-        }).not.to.throw(Error)
-      })
+      component.keyPress(eventTestObject)
+
+      expect(
+        preventDefaultSpy.called,
+        'preventDefault() was called'
+      ).to.equal(true)
     })
 
-    describe('keyPress()', function () {
-      const preventDefaultSpy = sinon.spy()
-      const stopPropagationSpy = sinon.spy()
+    it('calls stopPropogation', function () {
+      this.render()
 
-      const eventTestObject = {
-        keyCode: 32,
-        preventDefault: preventDefaultSpy,
-        stopPropagation: stopPropagationSpy
-      }
+      component.keyPress(eventTestObject)
 
-      beforeEach(function () {
-        preventDefaultSpy.reset()
-        stopPropagationSpy.reset()
-      })
-      it('sets state to checked', function () {
-        this.render()
-
-        component.keyPress(eventTestObject)
-
-        expect(
-          $('input').prop('checked'),
-          'keyPress() sets checked state'
-        ).to.equal(true)
-      })
-
-      it('does not set state to checked when disabled is true', function () {
-        const disabled = true
-
-        this.render()
-
-        run(() => component.set('disabled', disabled))
-
-        component.keyPress(eventTestObject)
-
-        expect(
-          $('input').prop('checked'),
-          'keyPress() did not set checked state'
-        ).to.equal(false)
-      })
-
-      it('calls preventDefault', function () {
-        this.render()
-
-        component.keyPress(eventTestObject)
-
-        expect(
-          preventDefaultSpy.called,
-          'preventDefault() was called'
-        ).to.equal(true)
-      })
-
-      it('calls stopPropogation', function () {
-        this.render()
-
-        component.keyPress(eventTestObject)
-
-        expect(
-          stopPropagationSpy.called,
-          'stopPropagation() was called'
-        ).to.equal(true)
-      })
-
-      it('returns false', function () {
-        this.render()
-
-        expect(
-          component.keyPress(eventTestObject),
-          'keyPress() returned false'
-        ).to.equal(false)
-      })
-
-      it('calls input() action', function () {
-        const spy = sinon.spy(component, 'send')
-
-        this.render()
-
-        component.keyPress(eventTestObject)
-
-        expect(
-          spy.args[0].join(),
-          'input() was called'
-        ).to.eql('input')
-      })
+      expect(
+        stopPropagationSpy.called,
+        'stopPropagation() was called'
+      ).to.equal(true)
     })
-  }
-)
+
+    it('returns false', function () {
+      this.render()
+
+      expect(
+        component.keyPress(eventTestObject),
+        'keyPress() returned false'
+      ).to.equal(false)
+    })
+
+    it('calls input() action', function () {
+      const spy = sinon.spy(component, 'send')
+
+      this.render()
+
+      component.keyPress(eventTestObject)
+
+      expect(
+        spy.args[0].join(),
+        'input() was called'
+      ).to.eql('input')
+    })
+  })
+})

--- a/tests/unit/components/frost-component-test.js
+++ b/tests/unit/components/frost-component-test.js
@@ -3,15 +3,17 @@
  */
 
 import {expect} from 'chai'
-import {unit} from 'dummy/tests/helpers/ember-test-utils/describe-component'
+import {unit} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 import CssMixin from 'ember-frost-core/mixins/css'
 import {HookMixin} from 'ember-hook'
-import {describeComponent, it} from 'ember-mocha'
 import PropTypesMixin from 'ember-prop-types'
 import SpreadMixin from 'ember-spread'
-import {beforeEach, describe} from 'mocha'
+import {beforeEach, describe, it} from 'mocha'
 
-describeComponent(...unit('frost-component'), function () {
+const test = unit('frost-component')
+describe(test.label, function () {
+  test.setup()
+
   let component
 
   describe('when created with only defaults', function () {

--- a/tests/unit/components/frost-icon-test.js
+++ b/tests/unit/components/frost-icon-test.js
@@ -1,86 +1,83 @@
 import {expect} from 'chai'
 import Ember from 'ember'
 const {run} = Ember
-import Component from 'ember-frost-core/components/frost-component'
-import {describeComponent} from 'ember-mocha'
 import PropTypeMixin from 'ember-prop-types'
 import SpreadMixin from 'ember-spread'
 import {beforeEach, describe, it} from 'mocha'
 
-describeComponent(
-  'frost-icon',
-  'Unit: FrostIconComponent',
-  {
-    unit: true
-  },
-  function () {
-    let component
+import {unit} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
+import Component from 'ember-frost-core/components/frost-component'
 
-    beforeEach(function () {
-      component = this.subject({
-        hook: 'myIcon',
-        icon: 'round-add'
+const test = unit('frost-icon')
+describe(test.label, function () {
+  test.setup()
+
+  let component
+
+  beforeEach(function () {
+    component = this.subject({
+      hook: 'myIcon',
+      icon: 'round-add'
+    })
+  })
+
+  it('sets default property values correctly', function () {
+    expect(
+      component.get('tagName'),
+      'tagName: "svg"'
+    ).to.equal('svg')
+
+    expect(
+      component.get('pack'),
+      'pack: "frost"'
+    ).to.eql('frost')
+  })
+
+  it('extends the base frost component', function () {
+    expect(
+      component instanceof Component,
+      'is instance of Frost Component'
+    ).to.equal(true)
+  })
+
+  it('sets dependent keys correctly', function () {
+    const iconClassDependentKeys = [
+      'icon',
+      'pack'
+    ]
+
+    expect(
+      component.iconClass._dependentKeys,
+      'Dependent keys are correct for iconClass()'
+    ).to.eql(iconClassDependentKeys)
+  })
+
+  it('has the expected Mixins', function () {
+    expect(
+      PropTypeMixin.detect(component),
+      'PropTypeMixin Mixin is present'
+    ).to.equal(true)
+
+    expect(
+      SpreadMixin.detect(component),
+      'SpreadMixin Mixin is present'
+    ).to.equal(true)
+  })
+
+  describe('"iconClass" computed property', function () {
+    it('is set correctly', function () {
+      const pack = 'frost'
+      const icon = 'add'
+
+      run(() => {
+        component.set('pack', pack)
+        component.set('icon', icon)
       })
-    })
-
-    it('sets default property values correctly', function () {
-      expect(
-        component.get('tagName'),
-        'tagName: "svg"'
-      ).to.equal('svg')
 
       expect(
-        component.get('pack'),
-        'pack: "frost"'
-      ).to.eql('frost')
+        component.get('iconClass'),
+        'iconClass: frost-icon-frost-add'
+      ).to.eql('frost-icon-frost-add')
     })
-
-    it('extends the base frost component', function () {
-      expect(
-        component instanceof Component,
-        'is instance of Frost Component'
-      ).to.equal(true)
-    })
-
-    it('sets dependent keys correctly', function () {
-      const iconClassDependentKeys = [
-        'icon',
-        'pack'
-      ]
-
-      expect(
-        component.iconClass._dependentKeys,
-        'Dependent keys are correct for iconClass()'
-      ).to.eql(iconClassDependentKeys)
-    })
-
-    it('has the expected Mixins', function () {
-      expect(
-        PropTypeMixin.detect(component),
-        'PropTypeMixin Mixin is present'
-      ).to.equal(true)
-
-      expect(
-        SpreadMixin.detect(component),
-        'SpreadMixin Mixin is present'
-      ).to.equal(true)
-    })
-
-    describe('"iconClass" computed property', function () {
-      it('is set correctly', function () {
-        const pack = 'frost'
-        const icon = 'add'
-
-        run(() => {
-          component.set('pack', pack)
-          component.set('icon', icon)
-        })
-
-        expect(
-          component.get('iconClass'),
-          'iconClass: frost-icon-frost-add'
-        ).to.eql('frost-icon-frost-add')
-      })
-    })
-  }
-)
+  })
+})

--- a/tests/unit/components/frost-loading-test.js
+++ b/tests/unit/components/frost-loading-test.js
@@ -1,35 +1,32 @@
 import {expect} from 'chai'
+import {beforeEach, describe, it} from 'mocha'
+
+import {unit} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 import Component from 'ember-frost-core/components/frost-component'
-import {describeComponent} from 'ember-mocha'
-import {beforeEach, it} from 'mocha'
 
-describeComponent(
-  'frost-loading',
-  'Unit: FrostLoadingComponent',
-  {
-    unit: true
-  },
-  function () {
-    let component
+const test = unit('frost-loading')
+describe(test.label, function () {
+  test.setup()
 
-    beforeEach(function () {
-      component = this.subject({
-        hook: 'myLoader'
-      })
+  let component
+
+  beforeEach(function () {
+    component = this.subject({
+      hook: 'myLoader'
     })
+  })
 
-    it('sets default property values correctly', function () {
-      expect(
-        component.get('type'),
-        'type: "ripple"'
-      ).to.eql('ripple')
-    })
+  it('sets default property values correctly', function () {
+    expect(
+      component.get('type'),
+      'type: "ripple"'
+    ).to.eql('ripple')
+  })
 
-    it('extends the commone frost component', function () {
-      expect(
-        component instanceof Component,
-        'is instance of Frost Component'
-      ).to.equal(true)
-    })
-  }
-)
+  it('extends the commone frost component', function () {
+    expect(
+      component instanceof Component,
+      'is instance of Frost Component'
+    ).to.equal(true)
+  })
+})

--- a/tests/unit/components/frost-password-test.js
+++ b/tests/unit/components/frost-password-test.js
@@ -1,156 +1,150 @@
 import {expect} from 'chai'
 import Ember from 'ember'
 const {run} = Ember
-import Component from 'ember-frost-core/components/frost-component'
-import FrostEventsProxy from 'ember-frost-core/mixins/frost-events-proxy'
-import {describeComponent} from 'ember-mocha'
 import {beforeEach, describe, it} from 'mocha'
 
-describeComponent(
-  'frost-password',
-  'Unit: FrostPasswordComponent',
-  {
-    needs: [
-      'component:frost-text'
-    ],
-    unit: true
-  },
-  function () {
-    let component
+import {unit} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
+import Component from 'ember-frost-core/components/frost-component'
+import FrostEventsProxy from 'ember-frost-core/mixins/frost-events-proxy'
 
-    beforeEach(function () {
-      component = this.subject({
-        hook: 'myPassword'
-      })
+const test = unit('frost-password')
+describe(test.label, function () {
+  test.setup()
+
+  let component
+
+  beforeEach(function () {
+    component = this.subject({
+      hook: 'myPassword'
+    })
+  })
+
+  it('sets default property values correctly', function () {
+    expect(
+      component.get('autofocus'),
+      'autofocus: false'
+    ).to.equal(false)
+
+    expect(
+      component.get('disabled'),
+      'disabled: "false"'
+    ).to.equal(false)
+
+    expect(
+      component.get('isRevealed'),
+      'isRevealed: false'
+    ).to.equal(false)
+
+    expect(
+      component.get('readonly'),
+      'readonly: false'
+    ).to.equal(false)
+
+    expect(
+      component.get('required'),
+      'required: false'
+    ).to.equal(false)
+
+    expect(
+      component.get('revealable'),
+      'revealable: false'
+    ).to.equal(false)
+
+    expect(
+      component.get('selectionDirection'),
+      'selectionDirection: "none"'
+    ).to.eql('none')
+
+    expect(
+      component.get('tabindex'),
+      'tabindex: 0'
+    ).to.eql(0)
+
+    expect(
+      component.get('type'),
+      'type: "password"'
+    ).to.eql('password')
+  })
+
+  it('extends the commone frost component', function () {
+    expect(
+      component instanceof Component,
+      'is instance of Frost Component'
+    ).to.equal(true)
+  })
+
+  it('has the expected Mixins', function () {
+    expect(
+      FrostEventsProxy.detect(component),
+      'FrostEventsProxy Mixin is present'
+    ).to.equal(true)
+  })
+
+  it('sets dependent keys correctly', function () {
+    const revealMessageDependentKeys = [
+      'isRevealed'
+    ]
+
+    const typeDependentKeys = [
+      'isRevealed'
+    ]
+
+    expect(
+      component.revealMessage._dependentKeys,
+      'Dependent keys are correct for revealMessage()'
+    ).to.eql(revealMessageDependentKeys)
+
+    expect(
+      component.type._dependentKeys,
+      'Dependent keys are correct for type()'
+    ).to.eql(typeDependentKeys)
+  })
+
+  describe('"revealMessage" computed property', function () {
+    it('is set to "Hide" when "isRevealed" is true', function () {
+      const isRevealed = true
+
+      run(() => component.set('isRevealed', isRevealed))
+
+      expect(
+        component.get('revealMessage'),
+        'revealMessage: "Hide"'
+      ).to.eql('Hide')
     })
 
-    it('sets default property values correctly', function () {
-      expect(
-        component.get('autofocus'),
-        'autofocus: false'
-      ).to.equal(false)
+    it('is set to "Show" when "isRevealed" is false', function () {
+      const isRevealed = false
+
+      run(() => component.set('isRevealed', isRevealed))
 
       expect(
-        component.get('disabled'),
-        'disabled: "false"'
-      ).to.equal(false)
+        component.get('revealMessage'),
+        'revealMessage: "Show"'
+      ).to.eql('Show')
+    })
+  })
+
+  describe('"type" computed property', function () {
+    it('is set to "text" when "isRevealed" is true', function () {
+      const isRevealed = true
+
+      run(() => component.set('isRevealed', isRevealed))
 
       expect(
-        component.get('isRevealed'),
-        'isRevealed: false'
-      ).to.equal(false)
+        component.get('type'),
+        'type: "text"'
+      ).to.eql('text')
+    })
 
-      expect(
-        component.get('readonly'),
-        'readonly: false'
-      ).to.equal(false)
+    it('is set to "password" when "isRevealed" is false', function () {
+      const isRevealed = false
 
-      expect(
-        component.get('required'),
-        'required: false'
-      ).to.equal(false)
-
-      expect(
-        component.get('revealable'),
-        'revealable: false'
-      ).to.equal(false)
-
-      expect(
-        component.get('selectionDirection'),
-        'selectionDirection: "none"'
-      ).to.eql('none')
-
-      expect(
-        component.get('tabindex'),
-        'tabindex: 0'
-      ).to.eql(0)
+      run(() => component.set('isRevealed', isRevealed))
 
       expect(
         component.get('type'),
         'type: "password"'
       ).to.eql('password')
     })
-
-    it('extends the commone frost component', function () {
-      expect(
-        component instanceof Component,
-        'is instance of Frost Component'
-      ).to.equal(true)
-    })
-
-    it('has the expected Mixins', function () {
-      expect(
-        FrostEventsProxy.detect(component),
-        'FrostEventsProxy Mixin is present'
-      ).to.equal(true)
-    })
-
-    it('sets dependent keys correctly', function () {
-      const revealMessageDependentKeys = [
-        'isRevealed'
-      ]
-
-      const typeDependentKeys = [
-        'isRevealed'
-      ]
-
-      expect(
-        component.revealMessage._dependentKeys,
-        'Dependent keys are correct for revealMessage()'
-      ).to.eql(revealMessageDependentKeys)
-
-      expect(
-        component.type._dependentKeys,
-        'Dependent keys are correct for type()'
-      ).to.eql(typeDependentKeys)
-    })
-
-    describe('"revealMessage" computed property', function () {
-      it('is set to "Hide" when "isRevealed" is true', function () {
-        const isRevealed = true
-
-        run(() => component.set('isRevealed', isRevealed))
-
-        expect(
-          component.get('revealMessage'),
-          'revealMessage: "Hide"'
-        ).to.eql('Hide')
-      })
-
-      it('is set to "Show" when "isRevealed" is false', function () {
-        const isRevealed = false
-
-        run(() => component.set('isRevealed', isRevealed))
-
-        expect(
-          component.get('revealMessage'),
-          'revealMessage: "Show"'
-        ).to.eql('Show')
-      })
-    })
-
-    describe('"type" computed property', function () {
-      it('is set to "text" when "isRevealed" is true', function () {
-        const isRevealed = true
-
-        run(() => component.set('isRevealed', isRevealed))
-
-        expect(
-          component.get('type'),
-          'type: "text"'
-        ).to.eql('text')
-      })
-
-      it('is set to "password" when "isRevealed" is false', function () {
-        const isRevealed = false
-
-        run(() => component.set('isRevealed', isRevealed))
-
-        expect(
-          component.get('type'),
-          'type: "password"'
-        ).to.eql('password')
-      })
-    })
-  }
-)
+  })
+})

--- a/tests/unit/components/frost-radio-button-test.js
+++ b/tests/unit/components/frost-radio-button-test.js
@@ -1,157 +1,154 @@
 import {expect} from 'chai'
 import Ember from 'ember'
 const {run} = Ember
-import Component from 'ember-frost-core/components/frost-component'
-import {describeComponent} from 'ember-mocha'
 import {beforeEach, describe, it} from 'mocha'
 
-describeComponent(
-  'frost-radio-button',
-  'Unit: FrostRadioButtonComponent',
-  {
-    unit: true
-  },
-  function () {
-    let component
+import {unit} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
+import Component from 'ember-frost-core/components/frost-component'
 
-    beforeEach(function () {
-      component = this.subject({
-        _setupAssertions: function () {
-          return
-        },
-        hook: 'myRadioButton',
-        value: 'testValue'
-      })
+const test = unit('frost-radio-button')
+describe(test.label, function () {
+  test.setup()
+
+  let component
+
+  beforeEach(function () {
+    component = this.subject({
+      _setupAssertions: function () {
+        return
+      },
+      hook: 'myRadioButton',
+      value: 'testValue'
+    })
+  })
+
+  it('sets default property values correctly', function () {
+    expect(
+      component.get('checked'),
+      'checked: false'
+    ).to.equal(false)
+
+    expect(
+      component.get('disabled'),
+      'disabled: false'
+    ).to.equal(false)
+
+    expect(
+      component.get('required'),
+      'required: false'
+    ).to.equal(false)
+
+    expect(
+      component.get('tabindex'),
+      'tabindex: 0'
+    ).to.eql(0)
+
+    expect(
+      component.get('size'),
+      'size: small'
+    ).to.eql('small')
+  })
+
+  it('extends the commone frost component', function () {
+    expect(
+      component instanceof Component,
+      'is instance of Frost Component'
+    ).to.equal(true)
+  })
+
+  it('sets dependent keys correctly', function () {
+    const checkedDependentKeys = [
+      'selectedValue',
+      'value'
+    ]
+
+    const tabindexDependentKeys = [
+      'disabled'
+    ]
+
+    expect(
+      component.checked._dependentKeys,
+      'Dependent keys are correct for checked()'
+    ).to.eql(checkedDependentKeys)
+
+    expect(
+      component.tabindex._dependentKeys,
+      'Dependent keys are correct for tabindex()'
+    ).to.eql(tabindexDependentKeys)
+  })
+
+  describe('"checked" computed property', function () {
+    const selectedValue = 'testValue'
+
+    it('is set to true when "selectedValue" is equal to "value"', function () {
+      run(() => component.set('selectedValue', selectedValue))
+
+      expect(
+        component.get('checked'),
+        'checked: true'
+      ).to.equal(true)
     })
 
-    it('sets default property values correctly', function () {
+    it('is set to false when "selectedValue" is NOT equal to "value"', function () {
+      run(() => {
+        component.set('selectedValue', selectedValue)
+        component.set('value', 'newTestValue')
+      })
+
       expect(
         component.get('checked'),
         'checked: false'
       ).to.equal(false)
-
-      expect(
-        component.get('disabled'),
-        'disabled: false'
-      ).to.equal(false)
-
-      expect(
-        component.get('required'),
-        'required: false'
-      ).to.equal(false)
-
-      expect(
-        component.get('tabindex'),
-        'tabindex: 0'
-      ).to.eql(0)
-
-      expect(
-        component.get('size'),
-        'size: small'
-      ).to.eql('small')
     })
+  })
 
-    it('extends the commone frost component', function () {
+  it('"tabindex" set to "-1" when "disabled" is set to true', function () {
+    run(() => component.set('disabled', true))
+
+    expect(
+      component.get('tabindex'),
+      'tabindex: -1'
+    ).to.eql(-1)
+  })
+
+  describe('"hookQualifiers" computed property', function () {
+    it('is set when "value" is set', function () {
+      const value = 'my-value'
+
+      run(() => component.set('value', value))
+
       expect(
-        component instanceof Component,
-        'is instance of Frost Component'
-      ).to.equal(true)
+        component.get('hookQualifiers').value,
+        `hookQualifiers: {value: ${value}}`
+      ).to.eql(value)
     })
+  })
 
-    it('sets dependent keys correctly', function () {
-      const checkedDependentKeys = [
-        'selectedValue',
-        'value'
-      ]
-
-      const tabindexDependentKeys = [
-        'disabled'
-      ]
-
-      expect(
-        component.checked._dependentKeys,
-        'Dependent keys are correct for checked()'
-      ).to.eql(checkedDependentKeys)
-
-      expect(
-        component.tabindex._dependentKeys,
-        'Dependent keys are correct for tabindex()'
-      ).to.eql(tabindexDependentKeys)
-    })
-
-    describe('"checked" computed property', function () {
-      const selectedValue = 'testValue'
-
-      it('is set to true when "selectedValue" is equal to "value"', function () {
-        run(() => component.set('selectedValue', selectedValue))
-
-        expect(
-          component.get('checked'),
-          'checked: true'
-        ).to.equal(true)
+  describe('keyPress', function () {
+    it('"onChange" not called when "disabled" is set', function () {
+      run(() => {
+        component.set('disabled', true)
       })
 
-      it('is set to false when "selectedValue" is NOT equal to "value"', function () {
-        run(() => {
-          component.set('selectedValue', selectedValue)
-          component.set('value', 'newTestValue')
-        })
-
-        expect(
-          component.get('checked'),
-          'checked: false'
-        ).to.equal(false)
-      })
-    })
-
-    it('"tabindex" set to "-1" when "disabled" is set to true', function () {
-      run(() => component.set('disabled', true))
+      const keyPressed = component.keyPress({keyCode: 13})
 
       expect(
-        component.get('tabindex'),
-        'tabindex: -1'
-      ).to.eql(-1)
+        keyPressed,
+        'onChange not called'
+      ).to.equal(undefined)
     })
 
-    describe('"hookQualifiers" computed property', function () {
-      it('is set when "value" is set', function () {
-        const value = 'my-value'
-
-        run(() => component.set('value', value))
-
-        expect(
-          component.get('hookQualifiers').value,
-          `hookQualifiers: {value: ${value}}`
-        ).to.eql(value)
+    it('"onChange" not called when "checked" is set', function () {
+      run(() => {
+        component.set('checked', true)
       })
+
+      const keyPressed = component.keyPress({keyCode: 13})
+
+      expect(
+        keyPressed,
+        'onChange not called'
+      ).to.equal(undefined)
     })
-
-    describe('keyPress', function () {
-      it('"onChange" not called when "disabled" is set', function () {
-        run(() => {
-          component.set('disabled', true)
-        })
-
-        const keyPressed = component.keyPress({keyCode: 13})
-
-        expect(
-          keyPressed,
-          'onChange not called'
-        ).to.equal(undefined)
-      })
-
-      it('"onChange" not called when "checked" is set', function () {
-        run(() => {
-          component.set('checked', true)
-        })
-
-        const keyPressed = component.keyPress({keyCode: 13})
-
-        expect(
-          keyPressed,
-          'onChange not called'
-        ).to.equal(undefined)
-      })
-    })
-  }
-)
+  })
+})

--- a/tests/unit/components/frost-radio-group-test.js
+++ b/tests/unit/components/frost-radio-group-test.js
@@ -1,64 +1,61 @@
 import {expect} from 'chai'
 import Ember from 'ember'
 const {run} = Ember
-import Component from 'ember-frost-core/components/frost-component'
-import {describeComponent} from 'ember-mocha'
 import {beforeEach, describe, it} from 'mocha'
 
-describeComponent(
-  'frost-radio-group',
-  'Unit: FrostRadioGroupComponent',
-  {
-    unit: true
-  },
-  function () {
-    let component
+import {unit} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
+import Component from 'ember-frost-core/components/frost-component'
 
-    beforeEach(function () {
-      component = this.subject({
-        hook: 'myRadioGroup'
-      })
+const test = unit('frost-radio-group')
+describe(test.label, function () {
+  test.setup()
+
+  let component
+
+  beforeEach(function () {
+    component = this.subject({
+      hook: 'myRadioGroup'
     })
+  })
 
-    it('sets default property values correctly', function () {
+  it('sets default property values correctly', function () {
+    expect(
+      component.get('inputs'),
+      'inputs: []'
+    ).to.be.eql([])
+
+    expect(
+      component.get('value'),
+      'value: null'
+    ).to.equal(null)
+  })
+
+  it('extends the commone frost component', function () {
+    expect(
+      component instanceof Component,
+      'is instance of Frost Component'
+    ).to.equal(true)
+  })
+
+  describe('"meshedInputs" computed property', function () {
+    it('is not set when inputs is not set', function () {
       expect(
-        component.get('inputs'),
-        'inputs: []'
-      ).to.be.eql([])
+        component.get('meshedInputs'),
+        '"meshedInputs" is returning an empty list'
+      ).to.eql([])
+    })
+
+    it('is set when inputs is set', function () {
+      const inputs = [{
+        value: 'test', label: 'test'
+      }]
+
+      run(() => component.set('inputs', inputs))
 
       expect(
-        component.get('value'),
-        'value: null'
-      ).to.equal(null)
+        component.get('meshedInputs')[0].size,
+        'default size is set in "meshedInputs"'
+      ).to.eq('small')
     })
-
-    it('extends the commone frost component', function () {
-      expect(
-        component instanceof Component,
-        'is instance of Frost Component'
-      ).to.equal(true)
-    })
-
-    describe('"meshedInputs" computed property', function () {
-      it('is not set when inputs is not set', function () {
-        expect(
-          component.get('meshedInputs'),
-          '"meshedInputs" is returning an empty list'
-        ).to.eql([])
-      })
-
-      it('is set when inputs is set', function () {
-        const inputs = [{
-          value: 'test', label: 'test'
-        }]
-
-        run(() => component.set('inputs', inputs))
-
-        expect(
-          component.get('meshedInputs')[0].size,
-          'default size is set in "meshedInputs"'
-        ).to.eq('small')
-      })
-    })
-  }
-)
+  })
+})

--- a/tests/unit/components/frost-scroll-test.js
+++ b/tests/unit/components/frost-scroll-test.js
@@ -1,151 +1,148 @@
 import {expect} from 'chai'
 import Ember from 'ember'
 const {$} = Ember
-import Component from 'ember-frost-core/components/frost-component'
-import {describeComponent} from 'ember-mocha'
-import {beforeEach, it} from 'mocha'
+import {beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
 
-describeComponent(
-  'frost-scroll',
-  'Unit: FrostScrollComponent',
-  {
-    unit: true
-  },
-  function () {
-    let component
+import {unit} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
+import Component from 'ember-frost-core/components/frost-component'
 
-    beforeEach(function () {
-      component = this.subject({
-        hook: 'myScroll'
-      })
+const test = unit('frost-scroll')
+describe(test.label, function () {
+  test.setup()
+
+  let component
+
+  beforeEach(function () {
+    component = this.subject({
+      hook: 'myScroll'
     })
+  })
 
-    it('extends the commone frost component', function () {
-      expect(
-        component instanceof Component,
-        'is instance of Frost Component'
-      ).to.equal(true)
-    })
+  it('extends the commone frost component', function () {
+    expect(
+      component instanceof Component,
+      'is instance of Frost Component'
+    ).to.equal(true)
+  })
 
-    it('registers and unregisters "ps-scroll-up" event handlers', function () {
-      const spyOn = sinon.spy($.fn, 'on')
-      const spyOff = sinon.spy($.fn, 'off')
+  it('registers and unregisters "ps-scroll-up" event handlers', function () {
+    const spyOn = sinon.spy($.fn, 'on')
+    const spyOff = sinon.spy($.fn, 'off')
 
-      component.set('onScrollUp', function () { return })
+    component.set('onScrollUp', function () { return })
 
-      this.render()
+    this.render()
 
-      spyOn.reset()
+    spyOn.reset()
 
-      component.trigger('didInsertElement')
+    component.trigger('didInsertElement')
 
-      expect(
-        spyOn.calledWith("ps-scroll-up"), // eslint-disable-line
-        'on() was called with "ps-scroll-up" event'
-      ).to.equal(true)
+    expect(
+      spyOn.calledWith("ps-scroll-up"), // eslint-disable-line
+      'on() was called with "ps-scroll-up" event'
+    ).to.equal(true)
 
-      spyOff.reset()
+    spyOff.reset()
 
-      component.trigger('willDestroyElement')
+    component.trigger('willDestroyElement')
 
-      expect(
-        spyOff.calledWith("ps-scroll-up"), // eslint-disable-line
-        'off() was called with "ps-scroll-up" event'
-      ).to.equal(true)
+    expect(
+      spyOff.calledWith("ps-scroll-up"), // eslint-disable-line
+      'off() was called with "ps-scroll-up" event'
+    ).to.equal(true)
 
-      $.fn.on.restore()
-      $.fn.off.restore()
-    })
+    $.fn.on.restore()
+    $.fn.off.restore()
+  })
 
-    it('registers and unregisters "ps-scroll-down" event handlers', function () {
-      const spyOn = sinon.spy($.fn, 'on')
-      const spyOff = sinon.spy($.fn, 'off')
+  it('registers and unregisters "ps-scroll-down" event handlers', function () {
+    const spyOn = sinon.spy($.fn, 'on')
+    const spyOff = sinon.spy($.fn, 'off')
 
-      component.set('onScrollDown', function () { return })
+    component.set('onScrollDown', function () { return })
 
-      this.render()
+    this.render()
 
-      spyOn.reset()
+    spyOn.reset()
 
-      component.trigger('didInsertElement')
+    component.trigger('didInsertElement')
 
-      expect(
-        spyOn.calledWith("ps-scroll-down"), // eslint-disable-line
-        'on() was called with "ps-scroll-down" event'
-      ).to.equal(true)
+    expect(
+      spyOn.calledWith("ps-scroll-down"), // eslint-disable-line
+      'on() was called with "ps-scroll-down" event'
+    ).to.equal(true)
 
-      spyOff.reset()
+    spyOff.reset()
 
-      component.trigger('willDestroyElement')
+    component.trigger('willDestroyElement')
 
-      expect(
-        spyOff.calledWith("ps-scroll-down"), // eslint-disable-line
-        'off() was called with "ps-scroll-down" event'
-      ).to.equal(true)
+    expect(
+      spyOff.calledWith("ps-scroll-down"), // eslint-disable-line
+      'off() was called with "ps-scroll-down" event'
+    ).to.equal(true)
 
-      $.fn.on.restore()
-      $.fn.off.restore()
-    })
+    $.fn.on.restore()
+    $.fn.off.restore()
+  })
 
-    it('registers and unregisters "ps-y-reach-start" event handlers', function () {
-      const spyOn = sinon.spy($.fn, 'on')
-      const spyOff = sinon.spy($.fn, 'off')
+  it('registers and unregisters "ps-y-reach-start" event handlers', function () {
+    const spyOn = sinon.spy($.fn, 'on')
+    const spyOff = sinon.spy($.fn, 'off')
 
-      component.set('onScrollYStart', function () { return })
+    component.set('onScrollYStart', function () { return })
 
-      this.render()
+    this.render()
 
-      spyOn.reset()
+    spyOn.reset()
 
-      component.trigger('didInsertElement')
+    component.trigger('didInsertElement')
 
-      expect(
-        spyOn.calledWith("ps-y-reach-start"), // eslint-disable-line
-        'on() was called with "ps-y-reach-start" event'
-      ).to.equal(true)
+    expect(
+      spyOn.calledWith("ps-y-reach-start"), // eslint-disable-line
+      'on() was called with "ps-y-reach-start" event'
+    ).to.equal(true)
 
-      spyOff.reset()
+    spyOff.reset()
 
-      component.trigger('willDestroyElement')
+    component.trigger('willDestroyElement')
 
-      expect(
-        spyOff.calledWith("ps-y-reach-start"), // eslint-disable-line
-        'off() was called with "ps-y-reach-start" event'
-      ).to.equal(true)
+    expect(
+      spyOff.calledWith("ps-y-reach-start"), // eslint-disable-line
+      'off() was called with "ps-y-reach-start" event'
+    ).to.equal(true)
 
-      $.fn.on.restore()
-      $.fn.off.restore()
-    })
+    $.fn.on.restore()
+    $.fn.off.restore()
+  })
 
-    it('registers and unregisters "ps-y-reach-end" event handlers', function () {
-      const spyOn = sinon.spy($.fn, 'on')
-      const spyOff = sinon.spy($.fn, 'off')
+  it('registers and unregisters "ps-y-reach-end" event handlers', function () {
+    const spyOn = sinon.spy($.fn, 'on')
+    const spyOff = sinon.spy($.fn, 'off')
 
-      component.set('onScrollYEnd', function () { return })
+    component.set('onScrollYEnd', function () { return })
 
-      this.render()
+    this.render()
 
-      spyOn.reset()
+    spyOn.reset()
 
-      component.trigger('didInsertElement')
+    component.trigger('didInsertElement')
 
-      expect(
-        spyOn.calledWith("ps-y-reach-end"), // eslint-disable-line
-        'on() was called with "ps-y-reach-end" event'
-      ).to.equal(true)
+    expect(
+      spyOn.calledWith("ps-y-reach-end"), // eslint-disable-line
+      'on() was called with "ps-y-reach-end" event'
+    ).to.equal(true)
 
-      spyOff.reset()
+    spyOff.reset()
 
-      component.trigger('willDestroyElement')
+    component.trigger('willDestroyElement')
 
-      expect(
-        spyOff.calledWith("ps-y-reach-end"), // eslint-disable-line
-        'off() was called with "ps-y-reach-end" event'
-      ).to.equal(true)
+    expect(
+      spyOff.calledWith("ps-y-reach-end"), // eslint-disable-line
+      'off() was called with "ps-y-reach-end" event'
+    ).to.equal(true)
 
-      $.fn.on.restore()
-      $.fn.off.restore()
-    })
-  }
-)
+    $.fn.on.restore()
+    $.fn.off.restore()
+  })
+})

--- a/tests/unit/components/frost-text-test.js
+++ b/tests/unit/components/frost-text-test.js
@@ -1,119 +1,117 @@
 import {expect} from 'chai'
 import Ember from 'ember'
 const {run} = Ember
-import Component from 'ember-frost-core/components/frost-component'
-import FrostEventsProxy from 'ember-frost-core/mixins/frost-events-proxy'
-import {describeComponent} from 'ember-mocha'
 import {beforeEach, describe, it} from 'mocha'
 
-describeComponent(
-  'frost-text',
-  'Unit: FrostTextComponent', {
-    unit: true
-  },
-  function () {
-    let component
+import {unit} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
+import Component from 'ember-frost-core/components/frost-component'
+import FrostEventsProxy from 'ember-frost-core/mixins/frost-events-proxy'
 
+const test = unit('frost-text')
+describe(test.label, function () {
+  test.setup()
+
+  let component
+
+  beforeEach(function () {
+    component = this.subject({
+      hook: 'myTextInput'
+    })
+  })
+
+  it('sets default property values correctly', function () {
+    expect(
+      component.get('align'),
+      'align: left'
+    ).to.be.eql('left')
+
+    expect(
+      component.get('autocapitalize'),
+      'autocapitalize: off'
+    ).to.be.eql('off')
+
+    expect(
+      component.get('autocorrect'),
+      'autocorrect: off'
+    ).to.be.eql('off')
+
+    expect(
+      component.get('autofocus'),
+      'autofocus: false'
+    ).to.equal(false)
+
+    expect(
+      component.get('isClearEnabled'),
+      'isClearEnabled: false'
+    ).to.equal(false)
+
+    expect(
+      component.get('isClearVisible'),
+      'isClearVisible: false'
+    ).to.equal(false)
+
+    expect(
+      component.get('isHookEmbedded'),
+      'isHookEmbedded: false'
+    ).to.equal(false)
+
+    expect(
+      component.get('readonly'),
+      'readonly: false'
+    ).to.equal(false)
+
+    expect(
+      component.get('required'),
+      'required: false'
+    ).to.equal(false)
+
+    expect(
+      component.get('spellcheck'),
+      'spellcheck: false'
+    ).to.equal(false)
+
+    expect(
+      component.get('tabindex'),
+      'tabindex: 0'
+    ).to.be.eql(0)
+
+    expect(
+      component.get('type'),
+      'type: text'
+    ).to.be.eql('text')
+
+    expect(
+      component.get('maxlength'),
+      'maxlength: undefined'
+    ).to.equal(undefined)
+  })
+
+  it('extends the commone frost component', function () {
+    expect(
+      component instanceof Component,
+      'is instance of Frost Component'
+    ).to.equal(true)
+  })
+
+  it('has the expect Mixins', function () {
+    expect(
+      FrostEventsProxy.detect(component),
+      'FrostEventsProxy is present'
+    ).to.equal(true)
+  })
+
+  describe('when keyUp property is omitted', function () {
     beforeEach(function () {
-      component = this.subject({
-        hook: 'myTextInput'
-      })
+      run(() => component.set('keyUp', undefined))
     })
 
-    it('sets default property values correctly', function () {
+    it('does not throw an error when keyUp action is triggered', function () {
       expect(
-        component.get('align'),
-        'align: left'
-      ).to.be.eql('left')
-
-      expect(
-        component.get('autocapitalize'),
-        'autocapitalize: off'
-      ).to.be.eql('off')
-
-      expect(
-        component.get('autocorrect'),
-        'autocorrect: off'
-      ).to.be.eql('off')
-
-      expect(
-        component.get('autofocus'),
-        'autofocus: false'
-      ).to.equal(false)
-
-      expect(
-        component.get('isClearEnabled'),
-        'isClearEnabled: false'
-      ).to.equal(false)
-
-      expect(
-        component.get('isClearVisible'),
-        'isClearVisible: false'
-      ).to.equal(false)
-
-      expect(
-        component.get('isHookEmbedded'),
-        'isHookEmbedded: false'
-      ).to.equal(false)
-
-      expect(
-        component.get('readonly'),
-        'readonly: false'
-      ).to.equal(false)
-
-      expect(
-        component.get('required'),
-        'required: false'
-      ).to.equal(false)
-
-      expect(
-        component.get('spellcheck'),
-        'spellcheck: false'
-      ).to.equal(false)
-
-      expect(
-        component.get('tabindex'),
-        'tabindex: 0'
-      ).to.be.eql(0)
-
-      expect(
-        component.get('type'),
-        'type: text'
-      ).to.be.eql('text')
-
-      expect(
-        component.get('maxlength'),
-        'maxlength: undefined'
-      ).to.equal(undefined)
+        function () {
+          component.get('actions.keyUp').call(component)
+        },
+        'error not triggered by keyup()'
+      ).not.to.throw(Error)
     })
-
-    it('extends the commone frost component', function () {
-      expect(
-        component instanceof Component,
-        'is instance of Frost Component'
-      ).to.equal(true)
-    })
-
-    it('has the expect Mixins', function () {
-      expect(
-        FrostEventsProxy.detect(component),
-        'FrostEventsProxy is present'
-      ).to.equal(true)
-    })
-
-    describe('when keyUp property is omitted', function () {
-      beforeEach(function () {
-        run(() => component.set('keyUp', undefined))
-      })
-
-      it('does not throw an error when keyUp action is triggered', function () {
-        expect(
-          function () {
-            component.get('actions.keyUp').call(component)
-          },
-          'error not triggered by keyup()'
-        ).not.to.throw(Error)
-      })
-    })
-  }
-)
+  })
+})

--- a/tests/unit/components/frost-textarea-test.js
+++ b/tests/unit/components/frost-textarea-test.js
@@ -1,116 +1,112 @@
 import {expect} from 'chai'
 import Ember from 'ember'
-import Component from 'ember-frost-core/components/frost-component'
-import FrostEventsProxy from 'ember-frost-core/mixins/frost-events-proxy'
-import {describeComponent} from 'ember-mocha'
+const {run} = Ember
 import {beforeEach, describe, it} from 'mocha'
 
-const {run} = Ember
+import {unit} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
+import Component from 'ember-frost-core/components/frost-component'
+import FrostEventsProxy from 'ember-frost-core/mixins/frost-events-proxy'
 
-describeComponent(
-  'frost-textarea',
-  'Unit: FrostTextAreaComponent',
-  {
-    unit: true
-  },
-  function () {
-    let component
+const test = unit('frost-textarea')
+describe(test.label, function () {
+  test.setup()
 
+  let component
+
+  beforeEach(function () {
+    component = this.subject({
+      hook: 'myTextarea'
+    })
+  })
+
+  it('sets default property values correctly', function () {
+    expect(
+      component.get('autofocus'),
+      'autofocus: false'
+    ).to.equal(false)
+
+    expect(
+      component.get('cols'),
+      'cols: null'
+    ).to.equal(null)
+
+    expect(
+      component.get('disabled'),
+      'disabled: false'
+    ).to.equal(false)
+
+    expect(
+      component.get('form'),
+      'form: null'
+    ).to.equal(null)
+
+    expect(
+      component.get('isClearEnabled'),
+      'isClearEnabled: false'
+    ).to.equal(false)
+
+    expect(
+      component.get('isClearVisible'),
+      'isClearVisible: false'
+    ).to.equal(false)
+
+    expect(
+      component.get('placeholder'),
+      'placeholder: null'
+    ).to.equal(null)
+
+    expect(
+      component.get('readonly'),
+      'readonly: false'
+    ).to.equal(false)
+
+    expect(
+      component.get('rows'),
+      'rows: null'
+    ).to.equal(null)
+
+    expect(
+      component.get('tabindex'),
+      'tabindex: 0'
+    ).to.be.eql(0)
+
+    expect(
+      component.get('value'),
+      'value: null'
+    ).to.equal(null)
+
+    expect(
+      component.get('wrap'),
+      'wrap: soft'
+    ).to.be.eql('soft')
+  })
+
+  it('extends the commone frost component', function () {
+    expect(
+      component instanceof Component,
+      'is instance of Frost Component'
+    ).to.equal(true)
+  })
+
+  it('has the expect Mixins', function () {
+    expect(
+      FrostEventsProxy.detect(component),
+      'FrostEventsProxy is present'
+    ).to.equal(true)
+  })
+
+  describe('when keyUp property is omitted', function () {
     beforeEach(function () {
-      component = this.subject({
-        hook: 'myTextarea'
-      })
+      run(() => component.set('keyUp', undefined))
     })
 
-    it('sets default property values correctly', function () {
+    it('does not throw an error when keyUp action is triggered', function () {
       expect(
-        component.get('autofocus'),
-        'autofocus: false'
-      ).to.equal(false)
-
-      expect(
-        component.get('cols'),
-        'cols: null'
-      ).to.equal(null)
-
-      expect(
-        component.get('disabled'),
-        'disabled: false'
-      ).to.equal(false)
-
-      expect(
-        component.get('form'),
-        'form: null'
-      ).to.equal(null)
-
-      expect(
-        component.get('isClearEnabled'),
-        'isClearEnabled: false'
-      ).to.equal(false)
-
-      expect(
-        component.get('isClearVisible'),
-        'isClearVisible: false'
-      ).to.equal(false)
-
-      expect(
-        component.get('placeholder'),
-        'placeholder: null'
-      ).to.equal(null)
-
-      expect(
-        component.get('readonly'),
-        'readonly: false'
-      ).to.equal(false)
-
-      expect(
-        component.get('rows'),
-        'rows: null'
-      ).to.equal(null)
-
-      expect(
-        component.get('tabindex'),
-        'tabindex: 0'
-      ).to.be.eql(0)
-
-      expect(
-        component.get('value'),
-        'value: null'
-      ).to.equal(null)
-
-      expect(
-        component.get('wrap'),
-        'wrap: soft'
-      ).to.be.eql('soft')
+        function () {
+          component.get('actions.keyUp').call(component)
+        },
+        'error not triggered by keyup()'
+      ).not.to.throw(Error)
     })
-
-    it('extends the commone frost component', function () {
-      expect(
-        component instanceof Component,
-        'is instance of Frost Component'
-      ).to.equal(true)
-    })
-
-    it('has the expect Mixins', function () {
-      expect(
-        FrostEventsProxy.detect(component),
-        'FrostEventsProxy is present'
-      ).to.equal(true)
-    })
-
-    describe('when keyUp property is omitted', function () {
-      beforeEach(function () {
-        run(() => component.set('keyUp', undefined))
-      })
-
-      it('does not throw an error when keyUp action is triggered', function () {
-        expect(
-          function () {
-            component.get('actions.keyUp').call(component)
-          },
-          'error not triggered by keyup()'
-        ).not.to.throw(Error)
-      })
-    })
-  }
-)
+  })
+})

--- a/tests/unit/components/frost-toggle-test.js
+++ b/tests/unit/components/frost-toggle-test.js
@@ -1,237 +1,234 @@
 import {expect} from 'chai'
 import Ember from 'ember'
 const {run} = Ember
-import Component from 'ember-frost-core/components/frost-component'
-import FrostEventsProxy from 'ember-frost-core/mixins/frost-events-proxy'
-import * as utils from 'ember-frost-core/utils'
-import {describeComponent} from 'ember-mocha'
 import {beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
 
-describeComponent(
-  'frost-toggle',
-  'Unit: FrostToggleComponent',
-  {
-    unit: true
-  },
-  function () {
-    let component
+import {unit} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
+import Component from 'ember-frost-core/components/frost-component'
+import FrostEventsProxy from 'ember-frost-core/mixins/frost-events-proxy'
+import * as utils from 'ember-frost-core/utils'
 
-    beforeEach(function () {
-      component = this.subject({
-        _setupAssertion: function () {},
-        hook: 'myToggle'
-      })
+const test = unit('frost-toggle')
+describe(test.label, function () {
+  test.setup()
+
+  let component
+
+  beforeEach(function () {
+    component = this.subject({
+      _setupAssertion: function () {},
+      hook: 'myToggle'
+    })
+  })
+
+  it('sets default property values correctly', function () {
+    expect(
+      component.get('disabled'),
+      'disabled: false'
+    ).to.equal(false)
+
+    expect(
+      component.get('_trueLabel'),
+      '_trueLabel: true'
+    ).to.equal(true)
+
+    expect(
+      component.get('_falseLabel'),
+      '_falseLabel: false'
+    ).to.equal(false)
+
+    expect(
+      component.get('size'),
+      'size: "undefined"'
+    ).to.eql('medium')
+  })
+
+  it('sets dependent keys correctly', function () {
+    const _trueValueDependentKeys = [
+      'trueValue',
+      '_trueLabel'
+    ]
+
+    const _falseValueDependentKeys = [
+      'falseValue',
+      '_falseLabel'
+    ]
+
+    const _isToggledDependentKeys = [
+      'value'
+    ]
+
+    expect(
+      component._trueValue._dependentKeys,
+      'Dependent keys are correct for _trueValue()'
+    ).to.eql(_trueValueDependentKeys)
+
+    expect(
+      component._falseValue._dependentKeys,
+      'Dependent keys are correct for _falseValue()'
+    ).to.eql(_falseValueDependentKeys)
+
+    expect(
+      component._isToggled._dependentKeys,
+      'Dependent keys are correct for _isToggled()'
+    ).to.eql(_isToggledDependentKeys)
+  })
+
+  it('extends the commone frost component', function () {
+    expect(
+      component instanceof Component,
+      'is instance of Frost Component'
+    ).to.equal(true)
+  })
+
+  it('has the expected Mixins', function () {
+    expect(
+      FrostEventsProxy.detect(component),
+      'FrostEventsProxy Mixin is present'
+    ).to.equal(true)
+  })
+
+  describe('_preferBoolean()', function () {
+    it('returns boolean true when passed string "true"', function () {
+      expect(
+        component._preferBoolean('true'),
+        'returned boolean true'
+      ).to.equal(true)
     })
 
-    it('sets default property values correctly', function () {
+    it('returns boolean false when passed string "false"', function () {
       expect(
-        component.get('disabled'),
-        'disabled: false'
+        component._preferBoolean('false'),
+        'returned boolean false'
       ).to.equal(false)
+    })
+
+    it('returns value passed when not string "false" or "true"', function () {
+      expect(
+        component._preferBoolean('test'),
+        'passed value is returned'
+      ).to.eql('test')
+    })
+  })
+
+  describe('_trueValue computed property', function () {
+    it('returns "trueValue" when set', function () {
+      run(() => component.set('trueValue', 'testValue'))
+
+      expect(
+        component.get('_trueValue'),
+        '_trueValue successfully set to trueValue'
+      ).to.eql('testValue')
+    })
+
+    it('returns "_trueLabel" when set', function () {
+      run(() => component.set('_trueLabel', 'testLabel'))
 
       expect(
         component.get('_trueLabel'),
-        '_trueLabel: true'
-      ).to.equal(true)
+        '_trueValue successfully set to _trueLabel'
+      ).to.eql('testLabel')
+    })
+  })
+
+  describe('_falseValue computed property', function () {
+    it('returns "falseValue" when set', function () {
+      run(() => component.set('falseValue', 'testValue'))
 
       expect(
-        component.get('_falseLabel'),
-        '_falseLabel: false'
+        component.get('_falseValue'),
+        '_falseValue successfully set to falseValue'
+      ).to.eql('testValue')
+    })
+
+    it('returns "_falseLabel" when set', function () {
+      run(() => component.set('_falseLabel', 'testLabel'))
+
+      expect(
+        component.get('_falseValue'),
+        '_falseValue successfully set to _falseLabel'
+      ).to.eql('testLabel')
+    })
+  })
+
+  describe('_isToggled computed property', function () {
+    it('returns true when value is toggled on', function () {
+      run(() => {
+        component.set('_trueValue', 'testValueOn')
+        component.set('value', 'testValueOn')
+      })
+
+      expect(
+        component.get('_isToggled'),
+        '_isToggled returns true'
+      ).to.equal(true)
+    })
+
+    it('returns false when value is toggled off', function () {
+      run(() => {
+        component.set('_trueValue', 'testValueOn')
+        component.set('value', 'testValueOff')
+      })
+
+      expect(
+        component.get('_isToggled'),
+        '_isToggled returns false'
       ).to.equal(false)
-
-      expect(
-        component.get('size'),
-        'size: "undefined"'
-      ).to.eql('medium')
     })
+  })
 
-    it('sets dependent keys correctly', function () {
-      const _trueValueDependentKeys = [
-        'trueValue',
-        '_trueLabel'
-      ]
+  describe('_changeTarget()', function () {
+    it('sets toggled state to "false"', function () {
+      const cloneEventStub = sinon.stub(utils, 'cloneEvent').returns({
+        target: {value: null}
+      })
 
-      const _falseValueDependentKeys = [
-        'falseValue',
-        '_falseLabel'
-      ]
-
-      const _isToggledDependentKeys = [
-        'value'
-      ]
+      run(() => {
+        component.set('_trueValue', 'testValueOn')
+        component.set('value', 'testValueOn')
+        component.set('_falseValue', 'testValueOff')
+      })
 
       expect(
-        component._trueValue._dependentKeys,
-        'Dependent keys are correct for _trueValue()'
-      ).to.eql(_trueValueDependentKeys)
+        component._changeTarget({}, {}),
+        'target object is set to "false" toggled state'
+      ).to.eql({
+        target: {
+          state: false,
+          value: 'testValueOff'
+        }
+      })
 
       expect(
-        component._falseValue._dependentKeys,
-        'Dependent keys are correct for _falseValue()'
-      ).to.eql(_falseValueDependentKeys)
-
-      expect(
-        component._isToggled._dependentKeys,
-        'Dependent keys are correct for _isToggled()'
-      ).to.eql(_isToggledDependentKeys)
-    })
-
-    it('extends the commone frost component', function () {
-      expect(
-        component instanceof Component,
-        'is instance of Frost Component'
+        cloneEventStub.called,
+        'cloneEvent() method is called'
       ).to.equal(true)
+
+      utils.cloneEvent.restore()
     })
 
-    it('has the expected Mixins', function () {
+    it('sets toggled state to "true"', function () {
+      sinon.stub(utils, 'cloneEvent').returns({
+        target: {value: null}
+      })
+
+      run(() => {
+        component.set('_trueValue', 'testValueOn')
+        component.set('value', 'testValueOff')
+        component.set('_falseValue', 'testValueOff')
+      })
+
       expect(
-        FrostEventsProxy.detect(component),
-        'FrostEventsProxy Mixin is present'
-      ).to.equal(true)
+        component._changeTarget({}, {}),
+        'target object is set to "true" toggled state'
+      ).to.eql({
+        target: {
+          state: true,
+          value: 'testValueOn'
+        }
+      })
+      utils.cloneEvent.restore()
     })
-
-    describe('_preferBoolean()', function () {
-      it('returns boolean true when passed string "true"', function () {
-        expect(
-          component._preferBoolean('true'),
-          'returned boolean true'
-        ).to.equal(true)
-      })
-
-      it('returns boolean false when passed string "false"', function () {
-        expect(
-          component._preferBoolean('false'),
-          'returned boolean false'
-        ).to.equal(false)
-      })
-
-      it('returns value passed when not string "false" or "true"', function () {
-        expect(
-          component._preferBoolean('test'),
-          'passed value is returned'
-        ).to.eql('test')
-      })
-    })
-
-    describe('_trueValue computed property', function () {
-      it('returns "trueValue" when set', function () {
-        run(() => component.set('trueValue', 'testValue'))
-
-        expect(
-          component.get('_trueValue'),
-          '_trueValue successfully set to trueValue'
-        ).to.eql('testValue')
-      })
-
-      it('returns "_trueLabel" when set', function () {
-        run(() => component.set('_trueLabel', 'testLabel'))
-
-        expect(
-          component.get('_trueLabel'),
-          '_trueValue successfully set to _trueLabel'
-        ).to.eql('testLabel')
-      })
-    })
-
-    describe('_falseValue computed property', function () {
-      it('returns "falseValue" when set', function () {
-        run(() => component.set('falseValue', 'testValue'))
-
-        expect(
-          component.get('_falseValue'),
-          '_falseValue successfully set to falseValue'
-        ).to.eql('testValue')
-      })
-
-      it('returns "_falseLabel" when set', function () {
-        run(() => component.set('_falseLabel', 'testLabel'))
-
-        expect(
-          component.get('_falseValue'),
-          '_falseValue successfully set to _falseLabel'
-        ).to.eql('testLabel')
-      })
-    })
-
-    describe('_isToggled computed property', function () {
-      it('returns true when value is toggled on', function () {
-        run(() => {
-          component.set('_trueValue', 'testValueOn')
-          component.set('value', 'testValueOn')
-        })
-
-        expect(
-          component.get('_isToggled'),
-          '_isToggled returns true'
-        ).to.equal(true)
-      })
-
-      it('returns false when value is toggled off', function () {
-        run(() => {
-          component.set('_trueValue', 'testValueOn')
-          component.set('value', 'testValueOff')
-        })
-
-        expect(
-          component.get('_isToggled'),
-          '_isToggled returns false'
-        ).to.equal(false)
-      })
-    })
-
-    describe('_changeTarget()', function () {
-      it('sets toggled state to "false"', function () {
-        const cloneEventStub = sinon.stub(utils, 'cloneEvent').returns({
-          target: {value: null}
-        })
-
-        run(() => {
-          component.set('_trueValue', 'testValueOn')
-          component.set('value', 'testValueOn')
-          component.set('_falseValue', 'testValueOff')
-        })
-
-        expect(
-          component._changeTarget({}, {}),
-          'target object is set to "false" toggled state'
-        ).to.eql({
-          target: {
-            state: false,
-            value: 'testValueOff'
-          }
-        })
-
-        expect(
-          cloneEventStub.called,
-          'cloneEvent() method is called'
-        ).to.equal(true)
-
-        utils.cloneEvent.restore()
-      })
-
-      it('sets toggled state to "true"', function () {
-        sinon.stub(utils, 'cloneEvent').returns({
-          target: {value: null}
-        })
-
-        run(() => {
-          component.set('_trueValue', 'testValueOn')
-          component.set('value', 'testValueOff')
-          component.set('_falseValue', 'testValueOff')
-        })
-
-        expect(
-          component._changeTarget({}, {}),
-          'target object is set to "true" toggled state'
-        ).to.eql({
-          target: {
-            state: true,
-            value: 'testValueOn'
-          }
-        })
-        utils.cloneEvent.restore()
-      })
-    })
-  }
-)
+  })
+})

--- a/tests/unit/components/hookable-input-test.js
+++ b/tests/unit/components/hookable-input-test.js
@@ -3,12 +3,15 @@
  */
 
 import {expect} from 'chai'
-import {unit} from 'dummy/tests/helpers/ember-test-utils/describe-component'
 import {HookMixin} from 'ember-hook'
-import {describeComponent, it} from 'ember-mocha'
-import {beforeEach} from 'mocha'
+import {beforeEach, describe, it} from 'mocha'
 
-describeComponent(...unit('hookable-input'), function () {
+import {unit} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
+
+const test = unit('hookable-input')
+describe(test.label, function () {
+  test.setup()
+
   let component
 
   beforeEach(function () {

--- a/tests/unit/components/hookable-textarea-test.js
+++ b/tests/unit/components/hookable-textarea-test.js
@@ -3,12 +3,15 @@
  */
 
 import {expect} from 'chai'
-import {unit} from 'dummy/tests/helpers/ember-test-utils/describe-component'
 import {HookMixin} from 'ember-hook'
-import {describeComponent, it} from 'ember-mocha'
-import {beforeEach} from 'mocha'
+import {beforeEach, describe, it} from 'mocha'
 
-describeComponent(...unit('hookable-textarea'), function () {
+import {unit} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
+
+const test = unit('hookable-textarea')
+describe(test.label, function () {
+  test.setup()
+
   let component
 
   beforeEach(function () {

--- a/tests/unit/helpers/array-test.js
+++ b/tests/unit/helpers/array-test.js
@@ -4,7 +4,7 @@ import {describe, it} from 'mocha'
 
 const data = [42, 1, 2]
 
-describe('ArrayHelper', function () {
+describe('Unit / Helper / array', function () {
   it('works', function () {
     let result = array(data)
     expect(result).to.have.length(data.length)

--- a/tests/unit/utils/key-codes-test.js
+++ b/tests/unit/utils/key-codes-test.js
@@ -2,7 +2,7 @@ import {expect} from 'chai'
 import keycodes from 'ember-frost-core/utils/key-codes'
 import {describe, it} from 'mocha'
 
-describe('keycodes', function () {
+describe('Unit / Utility / keycodes', function () {
   // Replace this with your real tests.
   it('works', function () {
     let result = keycodes

--- a/tests/unit/utils/utils-test.js
+++ b/tests/unit/utils/utils-test.js
@@ -4,7 +4,7 @@ const {$} = Ember
 import {cloneEvent} from 'ember-frost-core/utils'
 import {describe, it} from 'mocha'
 
-describe('cloneEvent', function () {
+describe('Unit / Utility / cloneEvent', function () {
   it('target cloned and original target unchanged', function () {
     const eventText = 'my-original-target'
     const clonedEventText = 'cloned-target'


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

Closes: https://github.com/ciena-frost/ember-frost-core/issues/389

# CHANGELOG

* **Updated** integration and unit tests to remove the deprecated use of `describeComponent()`
