### PR TITLE
Migrate ember-spread from devDependency to dependency

### DIFF
--- a/blueprints/ember-frost-core/index.js
+++ b/blueprints/ember-frost-core/index.js
@@ -26,7 +26,6 @@ module.exports = {
             {name: 'ember-elsewhere', target: '~0.4.1'},
             {name: 'ember-frost-test', target: '^1.0.0'},
             {name: 'ember-prop-types', target: '^3.0.0'},
-            {name: 'ember-spread', target: '^1.0.0'},
             {name: 'ember-truth-helpers', target: '^1.2.0'}
           ]
         })

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "ember-prop-types": "^3.10.2",
     "ember-resolver": "^2.1.1",
     "ember-sinon": "0.6.0",
-    "ember-spread": "^1.1.1",
     "ember-test-utils": "^1.6.1",
     "ember-truth-helpers": "^1.3.0",
     "eslint": "^3.13.1",
@@ -104,6 +103,7 @@
     "ember-cli-sass": "^5.6.0",
     "ember-cli-string-utils": "^1.0.0",
     "ember-cli-valid-component-name": "^1.0.0",
+    "ember-spread": "^1.1.1",
     "fs-extra-promise": "^0.4.0",
     "npm-install-security-check": "^1.0.0"
   }


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [X] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

Closes: https://github.com/ciena-frost/ember-frost-core/issues/391
# CHANGELOG
* **Updated** `ember-spread` from devDependency to a dependency
* **Removed** `ember-spread` from the blueprint
