### PR TITLE
getComponentName returns clean className in nested component

### DIFF
--- a/addon/mixins/css.js
+++ b/addon/mixins/css.js
@@ -38,9 +38,11 @@ export default Mixin.create({
    * NOTE: This function relies on the speicifc format of the value from `toString()` which may change in future
    * @returns {String} the name of the component, parsed out of the toString() result
    */
-  getComponentName () {
-    return this.toString().replace(/^.+:(.+)::.+$/, '$1')
-  },
+   getComponentName () {
+     return this.toString()
+       .replace(/^.+:(.+)::.+$/, '$1')
+       .match(/(?!.*\/).+/)[0]
+   },
 
   /**
    * This function is really only here because we can't stub this._super

--- a/addon/mixins/css.js
+++ b/addon/mixins/css.js
@@ -38,11 +38,11 @@ export default Mixin.create({
    * NOTE: This function relies on the speicifc format of the value from `toString()` which may change in future
    * @returns {String} the name of the component, parsed out of the toString() result
    */
-   getComponentName () {
-     return this.toString()
-       .replace(/^.+:(.+)::.+$/, '$1')
-       .match(/(?!.*\/).+/)[0]
-   },
+  getComponentName () {
+    return this.toString()
+      .replace(/^.+:(.+)::.+$/, '$1')
+      .match(/(?!.*\/).+/)[0]
+  },
 
   /**
    * This function is really only here because we can't stub this._super

--- a/tests/dummy/app/pods/components/baz/foo-bar/component.js
+++ b/tests/dummy/app/pods/components/baz/foo-bar/component.js
@@ -1,0 +1,6 @@
+import Ember from 'ember'
+const {Component} = Ember
+
+import CssMixin from 'ember-frost-core/mixins/css'
+
+export default Component.extend(CssMixin)

--- a/tests/unit/mixins/css-nested-test.js
+++ b/tests/unit/mixins/css-nested-test.js
@@ -1,0 +1,41 @@
+/**
+ * Unit test for the CssMixin
+ */
+import {expect} from 'chai'
+import {setupComponentTest} from 'ember-mocha'
+import {afterEach, beforeEach, describe, it} from 'mocha'
+import sinon from 'sinon'
+
+describe('Unit / Mixin / css-nested', function () {
+  let component, sandbox
+  const expectedName = 'foo-bar'
+  setupComponentTest('baz/foo-bar')
+
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create()
+    component = this.subject()
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  it('has classNameBindings set to include "css"', function () {
+    expect(component.get('classNameBindings')).to.include('css')
+  })
+
+  it('defaults "css" to the component name', function () {
+    expect(component.get('css')).to.equal(expectedName)
+  })
+
+  describe('.getComponentName()', function () {
+    let componentName
+    beforeEach(function () {
+      componentName = component.getComponentName()
+    })
+
+    it('should extract a className from a nested component', function () {
+      expect(componentName).to.equal(expectedName)
+    })
+  })
+})

--- a/tests/unit/mixins/css-test.js
+++ b/tests/unit/mixins/css-test.js
@@ -37,6 +37,13 @@ describe('Unit / Mixin / css', function () {
     it('should strip the junk from toString()', function () {
       expect(componentName).to.equal('css-component')
     })
+    it('should extract a className from a nested component', function () {
+      component.toString = function () {
+        return '<baz@component:deep/nested/component/foo-bar::id>'
+      }
+      const nestedComponentName = component.getComponentName()
+      expect(nestedComponentName).to.equal('foo-bar')
+    })
   })
 
   describe('.init()', function () {

--- a/tests/unit/mixins/css-test.js
+++ b/tests/unit/mixins/css-test.js
@@ -37,13 +37,6 @@ describe('Unit / Mixin / css', function () {
     it('should strip the junk from toString()', function () {
       expect(componentName).to.equal('css-component')
     })
-    it('should extract a className from a nested component', function () {
-      component.toString = function () {
-        return '<baz@component:deep/nested/component/foo-bar::id>'
-      }
-      const nestedComponentName = component.getComponentName()
-      expect(nestedComponentName).to.equal('foo-bar')
-    })
   })
 
   describe('.init()', function () {


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

I wanted to iterate on how `getComponentName` would set classNames because nested components were getting pretty messy.

classname which would currently be `baz/foo-bar` becomes `foo-bar`

# CHANGELOG
- css mixin `getComponentName` returns clean className for nested components
