### PR TITLE
Improve frost-select performance

### DIFF
--- a/addon/utils/text.js
+++ b/addon/utils/text.js
@@ -1,3 +1,4 @@
+/* global jQuery */
 import Ember from 'ember'
 const {$} = Ember
 
@@ -71,8 +72,9 @@ export function trimDataToFit (text, width, font) {
  * Note: expects data-text attribute to be on element with full text
  *
  * @param {HTMLElement} element - HTML element to trim data within
+ * @param {jQuery} [$] - jQuery selector, can be stubbed for testing
  */
-export function trimLongDataInElement (element) {
+export function trimLongDataInElement (element, $ = jQuery) {
   let text = element.textContent
   let $element = $(element)
   let tooltip = ''
@@ -89,9 +91,8 @@ export function trimLongDataInElement (element) {
   if (textWidth > width) {
     text = trimDataToFit(text, width)
     tooltip = $(element).data('text')
+    $element
+      .text(text)
+      .prop('title', tooltip)
   }
-
-  $element
-    .text(text)
-    .prop('title', tooltip)
 }

--- a/tests/integration/components/frost-select-test.js
+++ b/tests/integration/components/frost-select-test.js
@@ -1213,6 +1213,48 @@ describe(test.label, function () {
       })
     })
 
+    describe('When label is too long to fit', function () {
+      beforeEach(function () {
+        this.set('data', [
+          {label: 'Baaaaaaaaaa baaaaaaaaaaaaaaa black sheep', value: 'sheep'}
+        ])
+        this.$('.frost-select').width(175)
+      })
+
+      describe('when select is opened', function () {
+        beforeEach(function () {
+          this.$('.frost-select').click()
+          return wait()
+        })
+
+        it('should truncate label but leave beginning and end', function () {
+          const indexOfElipsis = $hook('select-item', {index: 0}).text().indexOf('\u2026')
+          expect(indexOfElipsis).to.be.greaterThan(3).and.lessThan(this.get('data.0.label.length') - 3)
+        })
+
+        describe('when select is closed and made wide enough', function () {
+          beforeEach(function () {
+            this.$('.frost-select').click()
+            return wait().then(() => {
+              this.$('.frost-select').width(600)
+              return wait()
+            })
+          })
+
+          describe('when select is re-opened', function () {
+            beforeEach(function () {
+              this.$('.frost-select').click()
+              return wait()
+            })
+
+            it('should no longer truncate text', function () {
+              expect($hook('select-item', {index: 0}).text().trim()).to.equal(this.get('data.0.label'))
+            })
+          })
+        })
+      })
+    })
+
     describe('ember-hook selectors', function () {
       describe('when dropdown is open', function () {
         beforeEach(function () {

--- a/tests/unit/utils/text-test.js
+++ b/tests/unit/utils/text-test.js
@@ -2,10 +2,21 @@ import {expect} from 'chai'
 import Ember from 'ember'
 const {$} = Ember
 import {afterEach, beforeEach, describe, it} from 'mocha'
+import sinon from 'sinon'
 
 import {trimDataToFit, trimLongDataInElement} from 'ember-frost-core/utils/text'
 
 describe('Unit / Utils / text', () => {
+  let sandbox
+
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create()
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
   describe('.trimDataToFit()', () => {
     it('does not throw an error when text is undefined', () => {
       expect(() => {
@@ -34,6 +45,7 @@ describe('Unit / Utils / text', () => {
       $element.css({
         font: 'normal normal normal 10px/14px Arial'
       })
+      $element.text(text)
     })
 
     afterEach(() => {
@@ -42,8 +54,11 @@ describe('Unit / Utils / text', () => {
 
     describe('when text fits within element', () => {
       beforeEach(() => {
+        sandbox.spy($element, 'text')
+        sandbox.spy($element, 'prop')
+        sandbox.stub(Ember, '$').withArgs($element.get(0)).returns($element)
         $element.width(200)
-        trimLongDataInElement($element.get(0))
+        trimLongDataInElement($element.get(0), Ember.$) // eslint-disable-line ember-standard/destructure
       })
 
       it('does not trim text', () => {
@@ -52,6 +67,16 @@ describe('Unit / Utils / text', () => {
 
       it('does not set title', () => {
         expect($element).to.have.prop('title', '')
+      })
+
+      it('should not call $element.text', function () {
+        // Make sure to avoid unnecessary performance penalty
+        expect($element.text).to.have.callCount(0)
+      })
+
+      it('should not call $element.prop', function () {
+        // Make sure to avoid unnecessary performance penalty
+        expect($element.prop).to.have.callCount(0)
       })
     })
 


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

Resolves #398 

Setting the text and title on the `frost-select-li` approximately tripled its rendering time (at least in Chrome with Ember 2.8.3). With this fix, my frost-selects are performing nearly as well as they did pre `1.8.0`. 

# CHANGELOG

* **Improved** frost-select performance
