### PR TITLE
Fixed bug with multiple onSelect calls after filtering

### DIFF
--- a/addon/components/frost-select-dropdown.js
+++ b/addon/components/frost-select-dropdown.js
@@ -296,6 +296,20 @@ export default Component.extend({
     }
   },
 
+  /**
+   * Unbind event listeners to items in dropdown
+   * @param {HTMLElement} dropdownListElement - dropdown list element (ul)
+   */
+  _removeListItemEventListeners (dropdownListElement) {
+    const listItemElements = dropdownListElement.querySelectorAll('li')
+
+    Array.from(listItemElements).forEach((li, index) => {
+      $(li)
+        .off('mousedown')
+        .off('mouseenter')
+    })
+  },
+
   /* eslint-disable complexity */
   // FIXME: jsdoc
   _updatePosition ($element) {
@@ -328,6 +342,8 @@ export default Component.extend({
     const clonedTextElements = clonedDropdownListElement.querySelectorAll('.frost-select-list-item-text')
     const textElements = dropdownListElement.querySelectorAll('.frost-select-list-item-text')
     const scrollTop = dropdownListElement.scrollTop
+
+    this._removeListItemEventListeners(dropdownListElement)
 
     dropdownListElement.replaceWith(clonedDropdownListElement)
 

--- a/tests/integration/components/frost-select-test.js
+++ b/tests/integration/components/frost-select-test.js
@@ -1043,6 +1043,38 @@ describe(test.label, function () {
               expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
             })
           })
+
+          describe('when filter is applied and selection is made', function () {
+            beforeEach(function (done) {
+              onChange.reset()
+              filterSelect('b')
+              wait().then(() => {
+                filterSelect('ba')
+                wait().then(() => {
+                  filterSelect('bar')
+                  wait().then(() => {
+                    selectItemAtIndex('select', 0, done)
+                  })
+                })
+              })
+            })
+
+            it('renders as expected', function () {
+              expectSelectWithState('select', {
+                focused: true,
+                opened: false,
+                text: 'Bar'
+              })
+            })
+
+            it('should call onChange once', function () {
+              expect(onChange).to.have.callCount(1)
+            })
+
+            it('should call onChange with the correct value', function () {
+              expect(onChange).to.have.been.calledWith(['bar'])
+            })
+          })
         })
 
         describe('when down arrow pressed', function () {


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** a bug causing frost-select's onSelect callback to trigger multiple times after filtering