### PR TITLE
Frost select wrapping

### DIFF
--- a/addon/components/frost-select-dropdown.js
+++ b/addon/components/frost-select-dropdown.js
@@ -82,6 +82,11 @@ export default Component.extend({
 
   @readOnly
   @computed('wrapOptionText')
+  /**
+   * The class names for the frost-select drop down
+   * @param {Boolean} wrapOptionText - whether or not select option text should wrap
+   * @returns {string} the class names for the frost-select drop down
+   */
   dropdownClassNames (wrapOptionText) {
     let classNames = 'frost-select-dropdown'
     if (wrapOptionText) {
@@ -92,6 +97,11 @@ export default Component.extend({
 
   @readOnly
   @computed('multiselect')
+  /**
+   * The class names for the frost select dropdown options
+   * @param {Boolean} multiSelect - whether or not this is a multiselect
+   * @returns {string} the class names for the frost select dropdown options
+   */
   dropdownTextClassNames (multiSelect) {
     let classNames = 'frost-select-list-item-text'
     if (multiSelect) {

--- a/addon/components/frost-select-dropdown.js
+++ b/addon/components/frost-select-dropdown.js
@@ -47,7 +47,7 @@ export default Component.extend({
     onSelect: PropTypes.func.isRequired,
     receivedHook: PropTypes.string,
     selectedItems: PropTypes.arrayOf(PropTypes.object),
-    wrapOptionText: PropTypes.bool,
+    wrapLabels: PropTypes.bool,
 
     // state
     bottom: PropTypes.oneOfType([
@@ -81,18 +81,18 @@ export default Component.extend({
   // == Computed Properties ===================================================
 
   @readOnly
-  @computed('wrapOptionText')
+  @computed('wrapLabels')
   /**
    * The class names for the frost-select drop down
-   * @param {Boolean} wrapOptionText - whether or not select option text should wrap
+   * @param {Boolean} wrapLabels - whether or not select option text should wrap
    * @returns {string} the class names for the frost-select drop down
    */
-  dropdownClassNames (wrapOptionText) {
-    let classNames = 'frost-select-dropdown'
-    if (wrapOptionText) {
-      classNames += ' frost-select-dropdown-wrap-option-text'
+  dropdownClassNames (wrapLabels) {
+    const classNames = ['frost-select-dropdown']
+    if (wrapLabels) {
+      classNames.push('frost-select-dropdown-wrap-labels')
     }
-    return classNames
+    return classNames.join(' ')
   },
 
   @readOnly
@@ -103,11 +103,11 @@ export default Component.extend({
    * @returns {string} the class names for the frost select dropdown options
    */
   dropdownTextClassNames (multiSelect) {
-    let classNames = 'frost-select-list-item-text'
+    const classNames = ['frost-select-list-item-text']
     if (multiSelect) {
-      classNames += ' frost-multi-select-list-item-text'
+      classNames.push('frost-multi-select-list-item-text')
     }
-    return classNames
+    return classNames.join(' ')
   },
 
   @readOnly
@@ -373,14 +373,14 @@ export default Component.extend({
     const clonedTextElements = clonedDropdownListElement.querySelectorAll('.frost-select-list-item-text')
     const textElements = dropdownListElement.querySelectorAll('.frost-select-list-item-text')
     const scrollTop = dropdownListElement.scrollTop
-    const wrapOptionText = this.get('wrapOptionText')
+    const wrapLabels = this.get('wrapLabels')
 
     this._removeListItemEventListeners(dropdownListElement)
 
     dropdownListElement.replaceWith(clonedDropdownListElement)
 
     Array.from(textElements).forEach((textElement, index) => {
-      if (!wrapOptionText) {
+      if (!wrapLabels) {
         const clonedTextElement = clonedTextElements[index]
         const updatedData = trimLongDataInElement(clonedTextElement)
 

--- a/addon/components/frost-select-dropdown.js
+++ b/addon/components/frost-select-dropdown.js
@@ -47,6 +47,7 @@ export default Component.extend({
     onSelect: PropTypes.func.isRequired,
     receivedHook: PropTypes.string,
     selectedItems: PropTypes.arrayOf(PropTypes.object),
+    wrapOptionText: PropTypes.bool,
 
     // state
     bottom: PropTypes.oneOfType([
@@ -78,6 +79,26 @@ export default Component.extend({
   },
 
   // == Computed Properties ===================================================
+
+  @readOnly
+  @computed('wrapOptionText')
+  dropdownClassNames (wrapOptionText) {
+    let classNames = 'frost-select-dropdown'
+    if (wrapOptionText) {
+      classNames += ' frost-select-dropdown-wrap-option-text'
+    }
+    return classNames
+  },
+
+  @readOnly
+  @computed('multiselect')
+  dropdownTextClassNames (multiSelect) {
+    let classNames = 'frost-select-list-item-text'
+    if (multiSelect) {
+      classNames += ' frost-multi-select-list-item-text'
+    }
+    return classNames
+  },
 
   @readOnly
   @computed('bottom', 'left', 'maxHeight', 'top', 'width')
@@ -342,18 +363,21 @@ export default Component.extend({
     const clonedTextElements = clonedDropdownListElement.querySelectorAll('.frost-select-list-item-text')
     const textElements = dropdownListElement.querySelectorAll('.frost-select-list-item-text')
     const scrollTop = dropdownListElement.scrollTop
+    const wrapOptionText = this.get('wrapOptionText')
 
     this._removeListItemEventListeners(dropdownListElement)
 
     dropdownListElement.replaceWith(clonedDropdownListElement)
 
     Array.from(textElements).forEach((textElement, index) => {
-      const clonedTextElement = clonedTextElements[index]
-      const updatedData = trimLongDataInElement(clonedTextElement)
+      if (!wrapOptionText) {
+        const clonedTextElement = clonedTextElements[index]
+        const updatedData = trimLongDataInElement(clonedTextElement)
 
-      if (updatedData) {
-        textElement.textContent = updatedData.text
-        textElement.setAttribute('title', updatedData.tooltip)
+        if (updatedData) {
+          textElement.textContent = updatedData.text
+          textElement.setAttribute('title', updatedData.tooltip)
+        }
       }
 
       if (filter) {

--- a/addon/components/frost-select.js
+++ b/addon/components/frost-select.js
@@ -93,6 +93,7 @@ export default Component.extend({
       PropTypes.string
     ]),
     tabIndex: PropTypes.number,
+    wrapOptionText: PropTypes.bool,
 
     // state
     $element: PropTypes.object,

--- a/addon/components/frost-select.js
+++ b/addon/components/frost-select.js
@@ -93,7 +93,7 @@ export default Component.extend({
       PropTypes.string
     ]),
     tabIndex: PropTypes.number,
-    wrapOptionText: PropTypes.bool,
+    wrapLabels: PropTypes.bool,
 
     // state
     $element: PropTypes.object,

--- a/addon/styles/_frost-select.scss
+++ b/addon/styles/_frost-select.scss
@@ -214,13 +214,14 @@ $frost-select-list-item-horizontal-padding: 10px;
 
 .frost-select-list-item-text {
   flex: 1 0 auto;
+
   &:not(.frost-multi-select-list-item-text) {
     max-width: calc(100% - #{$frost-select-list-item-horizontal-padding});
   }
 }
 
 .frost-multi-select-list-item-text {
-  max-width: calc(100% - #{$frost-checkbox-medium-width} - #{$frost-select-list-item-horizontal-padding})
+  max-width: calc(100% - #{$frost-checkbox-medium-width} - #{$frost-select-list-item-horizontal-padding});
 }
 
 .frost-select-overlay {

--- a/addon/styles/_frost-select.scss
+++ b/addon/styles/_frost-select.scss
@@ -9,6 +9,8 @@ $frost-select-focused-border-color: $frost-color-blue-1;
 $frost-select-height: 35px;
 $frost-select-normal-border-color: $frost-color-grey-7;
 $frost-select-placeholder-color: $frost-color-grey-6;
+$frost-checkbox-medium-width: 32px;
+$frost-select-list-item-horizontal-padding: 10px;
 
 @mixin triangle-down($color, $size) {
   width: 25px;
@@ -157,6 +159,14 @@ $frost-select-placeholder-color: $frost-color-grey-6;
       color: $frost-color-grey-5;
     }
   }
+
+  &-wrap-option-text {
+    .frost-select-list-item {
+      height: auto;
+      min-height: $frost-input-select-option-row-height;
+      white-space: normal;
+    }
+  }
 }
 
 .frost-select-list-item {
@@ -204,6 +214,13 @@ $frost-select-placeholder-color: $frost-color-grey-6;
 
 .frost-select-list-item-text {
   flex: 1 0 auto;
+  &:not(.frost-multi-select-list-item-text) {
+    max-width: calc(100% - #{$frost-select-list-item-horizontal-padding});
+  }
+}
+
+.frost-multi-select-list-item-text {
+  max-width: calc(100% - #{$frost-checkbox-medium-width} - #{$frost-select-list-item-horizontal-padding})
 }
 
 .frost-select-overlay {

--- a/addon/styles/_frost-select.scss
+++ b/addon/styles/_frost-select.scss
@@ -160,7 +160,7 @@ $frost-select-list-item-horizontal-padding: 10px;
     }
   }
 
-  &-wrap-option-text {
+  &-wrap-labels {
     .frost-select-list-item {
       height: auto;
       min-height: $frost-input-select-option-row-height;

--- a/addon/templates/components/frost-select-dropdown.hbs
+++ b/addon/templates/components/frost-select-dropdown.hbs
@@ -9,7 +9,7 @@
   style={{arrowStyle}}
 />
 <div
-  class='frost-select-dropdown'
+  class={{dropdownClassNames}}
   data-test={{hook (concat hook '-list')}}
   onmousedown={{action 'mouseDown'}}
   style={{listStyle}}
@@ -64,7 +64,7 @@
           }}
         {{/if}}
         <span
-          class="frost-select-list-item-text"
+          class={{dropdownTextClassNames}}
           data-text={{item.label}}
         >
           {{item.label}}

--- a/addon/templates/components/frost-select.hbs
+++ b/addon/templates/components/frost-select.hbs
@@ -20,7 +20,7 @@
       onFilterInput=(action 'filterInput')
       onSelect=(action 'selectItem')
       selectedItems=selectedItems
-      wrapOptionText=wrapOptionText
+      wrapLabels=wrapLabels
     )
   }}
 {{/if}}

--- a/addon/templates/components/frost-select.hbs
+++ b/addon/templates/components/frost-select.hbs
@@ -20,6 +20,7 @@
       onFilterInput=(action 'filterInput')
       onSelect=(action 'selectItem')
       selectedItems=selectedItems
+      wrapOptionText=wrapOptionText
     )
   }}
 {{/if}}

--- a/docs/frost-select.md
+++ b/docs/frost-select.md
@@ -18,6 +18,8 @@
 | `placeholder` | `string` | | Placeholder text for when nothing is selected. |
 | `selected`      | `number` or `array` | `1` or `[1, 2]` | The indices of the pre-selected values corresponding to values in the passed-in data. Passing negative values (e.g. `-1` or `[-1]`) to a single select will clear the current select state.|
 | `selectedValue` | `any`, `array` if using multi-select, `null` or `''` (empty string) to clear | `'bar'` or `['bar', 'buzz']` | A value to choose in the drop down programmatically, or an array of values if using multi-select. Takes precedence over `selected` attribute. Passing `null` or `''` (empty string) will clear the selected state. |
+| `wrapOptionText` | `boolean` | `false` | **default** - trim text to fit without wrapping |
+| | | `true` | Allow select option text to wrap |
 
 ## Testing with ember-hook
 The select component is accessible using ember-hook with the top level hook name or you can access the internal components as well -

--- a/docs/frost-select.md
+++ b/docs/frost-select.md
@@ -18,7 +18,7 @@
 | `placeholder` | `string` | | Placeholder text for when nothing is selected. |
 | `selected`      | `number` or `array` | `1` or `[1, 2]` | The indices of the pre-selected values corresponding to values in the passed-in data. Passing negative values (e.g. `-1` or `[-1]`) to a single select will clear the current select state.|
 | `selectedValue` | `any`, `array` if using multi-select, `null` or `''` (empty string) to clear | `'bar'` or `['bar', 'buzz']` | A value to choose in the drop down programmatically, or an array of values if using multi-select. Takes precedence over `selected` attribute. Passing `null` or `''` (empty string) will clear the selected state. |
-| `wrapOptionText` | `boolean` | `false` | **default** - trim text to fit without wrapping |
+| `wrapLabels` | `boolean` | `false` | **default** - trim label text to fit without wrapping |
 | | | `true` | Allow select option text to wrap |
 
 ## Testing with ember-hook

--- a/test-support/helpers/ember-frost-core/frost-select.js
+++ b/test-support/helpers/ember-frost-core/frost-select.js
@@ -14,6 +14,7 @@ import {expect} from 'chai'
 import Ember from 'ember'
 const {$, RSVP, run, typeOf} = Ember // eslint-disable-line
 import {$hook} from 'ember-hook'
+import wait from 'ember-test-helpers/wait'
 
 import {expectToggleClass} from './utils'
 
@@ -96,14 +97,15 @@ export function filter (filter) {
 
 /**
  * Open frost-select dropdown
- * @param {String} hook - frost-select hook
+ * @param {String} [hook='select'] - frost-select hook
  */
-export function open (hook) {
+export function open (hook='select') {
   // In a real browser when you click on the select with your mouse a
   // focusin event is fired on the component. However when using jQuery's
   // click() method the focusin is not fired so we are programitcally
   // triggering that in this test.
-  $hook('select').click().trigger('focusin')
+  $hook(hook).click().trigger('focusin')
+  return wait()
 }
 
 /**

--- a/test-support/helpers/ember-frost-core/frost-select.js
+++ b/test-support/helpers/ember-frost-core/frost-select.js
@@ -98,8 +98,9 @@ export function filter (filter) {
 /**
  * Open frost-select dropdown
  * @param {String} [hook='select'] - frost-select hook
+ * @returns {Promise} the resolved promise from ember-test-helpers/wait
  */
-export function open (hook='select') {
+export function open (hook = 'select') {
   // In a real browser when you click on the select with your mouse a
   // focusin event is fired on the component. However when using jQuery's
   // click() method the focusin is not fired so we are programitcally

--- a/tests/dummy/app/pods/select/template.hbs
+++ b/tests/dummy/app/pods/select/template.hbs
@@ -329,6 +329,21 @@
         {{code-snippet name='select-other-spread.hbs'}}
       </div>
     </div>
+    <div class='example'>
+      <div class='title'>wrapOptionText</div>
+      <div class='demo'>
+        {{! BEGIN-SNIPPET select-other-wrap-option-text }}
+        {{frost-select
+          data=data
+          hook='myMultiSelect'
+          wrapOptionText=true
+        }}
+        {{! END-SNIPPET }}
+      </div>
+      <div class='snippet'>
+        {{code-snippet name='select-other-wrap-option-text.hbs'}}
+      </div>
+    </div>
   </div>
 </div>
 
@@ -578,6 +593,21 @@
       </div>
       <div class='snippet'>
         {{code-snippet name='multi-select-other-spread.hbs'}}
+      </div>
+    </div>
+    <div class='example'>
+      <div class='title'>wrapOptionText</div>
+      <div class='demo'>
+        {{! BEGIN-SNIPPET multi-select-other-wrap-option-text }}
+        {{frost-multi-select
+          data=data
+          hook='myMultiSelect'
+          wrapOptionText=true
+        }}
+        {{! END-SNIPPET }}
+      </div>
+      <div class='snippet'>
+        {{code-snippet name='multi-select-other-wrap-option-text.hbs'}}
       </div>
     </div>
   </div>

--- a/tests/dummy/app/pods/select/template.hbs
+++ b/tests/dummy/app/pods/select/template.hbs
@@ -330,18 +330,18 @@
       </div>
     </div>
     <div class='example'>
-      <div class='title'>wrapOptionText</div>
+      <div class='title'>wrapLabels</div>
       <div class='demo'>
-        {{! BEGIN-SNIPPET select-other-wrap-option-text }}
+        {{! BEGIN-SNIPPET select-other-wrap-labels }}
         {{frost-select
           data=data
           hook='myMultiSelect'
-          wrapOptionText=true
+          wrapLabels=true
         }}
         {{! END-SNIPPET }}
       </div>
       <div class='snippet'>
-        {{code-snippet name='select-other-wrap-option-text.hbs'}}
+        {{code-snippet name='select-other-wrap-labels.hbs'}}
       </div>
     </div>
   </div>
@@ -596,18 +596,18 @@
       </div>
     </div>
     <div class='example'>
-      <div class='title'>wrapOptionText</div>
+      <div class='title'>wrapLabels</div>
       <div class='demo'>
-        {{! BEGIN-SNIPPET multi-select-other-wrap-option-text }}
+        {{! BEGIN-SNIPPET multi-select-other-wrap-labels }}
         {{frost-multi-select
           data=data
           hook='myMultiSelect'
-          wrapOptionText=true
+          wrapLabels=true
         }}
         {{! END-SNIPPET }}
       </div>
       <div class='snippet'>
-        {{code-snippet name='multi-select-other-wrap-option-text.hbs'}}
+        {{code-snippet name='multi-select-other-wrap-labels.hbs'}}
       </div>
     </div>
   </div>

--- a/tests/dummy/app/styles/_select.scss
+++ b/tests/dummy/app/styles/_select.scss
@@ -1,0 +1,3 @@
+.frost-select {
+  max-width: 330px;
+}

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -5,6 +5,7 @@
 @import 'highlight';
 @import 'button';
 @import 'helpers';
+@import 'select';
 
 .dummy-notification-container {
   position: fixed;

--- a/tests/dummy/mirage/fixtures/nodes.js
+++ b/tests/dummy/mirage/fixtures/nodes.js
@@ -3,8 +3,8 @@ export default [
     type: 'nodes',
     id: '1',
     attributes: {
-      'value': 'Clark Kent',
-      'label': 'Superman'
+      'value': 'Super hero',
+      'label': 'My really really really really really really really really really really long label'
     }
   },
   {

--- a/tests/integration/components/frost-select-test.js
+++ b/tests/integration/components/frost-select-test.js
@@ -89,6 +89,7 @@ describe(test.label, function () {
           onChange=onChange
           onFocus=onFocus
           tabIndex=tabIndex
+          wrapOptionText=wrapOptionText
         }}
         {{input hook='post'}}
       `)
@@ -1241,6 +1242,34 @@ describe(test.label, function () {
           expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
           expect(onChange.callCount, 'onChange is not called').to.equal(0)
           expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
+        })
+      })
+
+      describe('when wrapOptionText is true and data includes a long label', function () {
+        let longLabel
+        beforeEach(function () {
+          longLabel = 'Very very very very very very very very very very very very very very long label'
+          this.setProperties({
+            data: [
+              {label: 'Short Label', value: 'foo'},
+              {label: longLabel, value: 'bar'},
+              {label: 'Baz', value: 'baz'},
+              {label: 'Ba ba black sheep', value: 'sheep'}
+            ],
+            wrapOptionText: true
+          })
+
+          return open('select')
+        })
+
+        it('should show the entire label', function () {
+          expect($hook('select-item', {index: 1}).text().trim()).to.have.equal(longLabel)
+        })
+
+        it('should give that list item a larger height', function () {
+          const regularItemHeight = $hook('select-item', {index: 0}).height()
+          const wrappedItemHeight = $hook('select-item', {index: 1}).height()
+          expect(wrappedItemHeight).to.be.greaterThan(regularItemHeight)
         })
       })
     })

--- a/tests/integration/components/frost-select-test.js
+++ b/tests/integration/components/frost-select-test.js
@@ -89,7 +89,7 @@ describe(test.label, function () {
           onChange=onChange
           onFocus=onFocus
           tabIndex=tabIndex
-          wrapOptionText=wrapOptionText
+          wrapLabels=wrapLabels
         }}
         {{input hook='post'}}
       `)
@@ -1245,7 +1245,7 @@ describe(test.label, function () {
         })
       })
 
-      describe('when wrapOptionText is true and data includes a long label', function () {
+      describe('when wrapLabels is true and data includes a long label', function () {
         let longLabel
         beforeEach(function () {
           longLabel = 'Very very very very very very very very very very very very very very long label'
@@ -1256,7 +1256,7 @@ describe(test.label, function () {
               {label: 'Baz', value: 'baz'},
               {label: 'Ba ba black sheep', value: 'sheep'}
             ],
-            wrapOptionText: true
+            wrapLabels: true
           })
 
           return open('select')


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Added** wrapLabels attribute to frost-select, which disables the text trimming for frost-select option labels and allows them to wrap
