### PR TITLE
added 'width' property to 'frost-select' interface

### DIFF
--- a/addon/components/frost-select.js
+++ b/addon/components/frost-select.js
@@ -237,7 +237,7 @@ export default Component.extend({
   /**
    * Get a style string based on the presence of some properties
    * @param {String} width the width property specified
-   * @return {String} the completed style string
+   * @returns {String} the completed style string
    */
   style (width) {
     let styles = ''

--- a/addon/components/frost-select.js
+++ b/addon/components/frost-select.js
@@ -54,7 +54,8 @@ export default Component.extend({
     'ariaLabel:aria-label',
     'computedTabIndex:tabIndex',
     'opened:aria-pressed',
-    'role'
+    'role',
+    'style'
   ],
 
   classNameBindings: [
@@ -95,6 +96,7 @@ export default Component.extend({
       PropTypes.string
     ]),
     tabIndex: PropTypes.number,
+    width: PropTypes.oneOfType([PropTypes.number, PropTypes.null]),
     wrapLabels: PropTypes.bool,
 
     // state
@@ -227,6 +229,24 @@ export default Component.extend({
     }
 
     return `${selectedItems.length} items selected`
+  },
+
+  @readOnly
+  @computed('width')
+
+  /**
+   * Get a style string based on the presence of some properties
+   * @param {String} width the width property specified
+   * @return {String} the completed style string
+   */
+  style (width) {
+    let styles = ''
+
+    // if a property is not falsy, append it to the style string
+    // note that in the width case, we want the component interface to have absolute power over the width
+    // so it will override any max or win widths to ensure ultimate control
+    if (width) styles += `width: ${width}px; max-width: initial; min-width:initial; `
+    return Ember.String.htmlSafe(styles)
   },
   // == Tasks =================================================================
 

--- a/tests/dummy/app/pods/select/controller.js
+++ b/tests/dummy/app/pods/select/controller.js
@@ -26,6 +26,7 @@ export default Controller.extend({
   preSelectedValueForClearing: 'Arthur Curry',
   selectedValues: ['Arthur Curry', 'Ray Palmer'],
   clearSelectedValue: false,
+  width: 500,
   actions: {
     onBlurHandler () {
       this.get('notifications').success('blur event', {

--- a/tests/dummy/app/pods/select/template.hbs
+++ b/tests/dummy/app/pods/select/template.hbs
@@ -178,6 +178,28 @@
 ```"}}
       </div>
     </div>
+
+    <div class="example">
+      <div class="title">width</div>
+      <div class="demo">
+        {{frost-select
+          data=data
+          hook='mySelect'
+          label='superhero'
+          width=width
+        }}
+      </div>
+      <div class="snippet">
+        {{format-markdown "```handlebars
+{{frost-select
+  data=data
+  hook='mySelect'
+  label='superhero'
+  width=width
+}}
+```"}}
+      </div>
+    </div>
   </div>
 
   <div class="section-title">State</div>

--- a/tests/integration/components/frost-select-test.js
+++ b/tests/integration/components/frost-select-test.js
@@ -8,7 +8,7 @@ import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
 
 import {expectSelectWithState, filterSelect} from 'dummy/tests/helpers/ember-frost-core'
-import {open, close, selectItemAtIndex} from 'dummy/tests/helpers/ember-frost-core/frost-select'
+import {close, open, selectItemAtIndex} from 'dummy/tests/helpers/ember-frost-core/frost-select'
 import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 import {keyCodes} from 'ember-frost-core/utils'
 const {DOWN_ARROW, ENTER, ESCAPE, SPACE, TAB, UP_ARROW} = keyCodes
@@ -89,6 +89,7 @@ describe(test.label, function () {
           onChange=onChange
           onFocus=onFocus
           tabIndex=tabIndex
+          width=width
           wrapLabels=wrapLabels
         }}
         {{input hook='post'}}
@@ -97,6 +98,45 @@ describe(test.label, function () {
 
     afterEach(function () {
       sandbox.restore()
+    })
+
+    describe('at correct width', function () {
+      const maximumWidth = 330
+      const minimumWidth = 175
+      const specifiedWidth = 500
+
+      it('if no width is specified, and container is small', function () {
+        this.$().css('width', '100px')
+        const actual = this.$('.frost-select')[0].getBoundingClientRect().width
+        expect(actual, 'it has the minimum width').to.equal(minimumWidth)
+      })
+
+      it('if no width is specified, and container is large', function () {
+        // simulate some app setting a max-width on .frost-select via CSS (as the dummy demo does)
+        this.$('.frost-select').css('max-width', `${maximumWidth}px`)
+
+        // set the container to some large width
+        this.$().css('width', `${specifiedWidth}px`)
+
+        // get the actual, factual horizontal space reserved in the layout for this element
+        const actual = this.$('.frost-select')[0].getBoundingClientRect().width
+
+        expect(actual, 'it respects max-width being set').to.equal(maximumWidth)
+      })
+
+      describe('when width is set as property', function () {
+        beforeEach(function () {
+          return this.set('width', specifiedWidth)
+        })
+
+        it('it has the specified width regardless of container size', function () {
+          // let's check both the element's style attr and what the browser layed out
+          const actualCSSValue = this.$('.frost-select').css('width')
+          const actualRenderedWidth = this.$('.frost-select')[0].getBoundingClientRect().width
+          expect(parseInt(actualCSSValue, 10), 'in the element\'s style attr').to.equal(specifiedWidth)
+          expect(parseInt(actualRenderedWidth, 10), 'and in the actual layout').to.equal(specifiedWidth)
+        })
+      })
     })
 
     describe('when data not present', function () {


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* adds `width` property to the `frost-select` component interface.  works by explicitly overriding any width/min/max width on that `frost-select` instance to explicitly set a desired width.
