### PR TITLE
fix(toggle): Fix css for toggle in firefox

### DIFF
--- a/addon/components/frost-toggle.js
+++ b/addon/components/frost-toggle.js
@@ -17,11 +17,11 @@ export default Component.extend(SpreadMixin, PropTypeMixin, FrostEventsProxyMixi
   // == Keyword Properties ====================================================
 
   attributeBindings: [
-    '_isToggled:toggled',
     'disabled'
   ],
 
   classNameBindings: [
+    '_isToggled:toggled',
     'disabled'
   ],
 

--- a/addon/styles/_frost-toggle.scss
+++ b/addon/styles/_frost-toggle.scss
@@ -1,3 +1,6 @@
+$frost-toggle-button-height: 35px;
+$frost-toggle-button-switch-height: 27px;
+
 
 $frost-toggle-off-color: #000;
 $frost-toggle-on-color: #fff;
@@ -43,7 +46,7 @@ $frost-toggle-on-color: #fff;
 
     &.medium {
       width: 115px;
-      height: 35px;
+      height: $frost-toggle-button-height;
       padding: 3px;
       border-radius: 3px;
     }
@@ -53,12 +56,13 @@ $frost-toggle-on-color: #fff;
       display: block;
       position: absolute;
       width: 40px;
-      height: 27px;
+      height: $frost-toggle-button-switch-height;
       margin: 0 10px 0 0;
       content: '';
     }
 
     &:after {
+      top: calc(50% - (#{$frost-toggle-button-switch-height} / 2));
       right: 0;
       transition: right .2s;
       border-radius: 3px;


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
- Fix positioning of `:after` selector in firefox

### Chrome
![screen shot 2017-03-30 at 5 15 54 pm](https://cloud.githubusercontent.com/assets/7063255/24526565/9803c9d0-156c-11e7-84cd-2ce7456a3e0b.png)

![screen shot 2017-03-30 at 5 16 31 pm](https://cloud.githubusercontent.com/assets/7063255/24526576/a393fb6c-156c-11e7-8e5e-4c4ed4d9fc58.png)

### Firefox

<img width="138" alt="screen shot 2017-03-30 at 5 16 52 pm" src="https://cloud.githubusercontent.com/assets/7063255/24526606/b49b185a-156c-11e7-9ddc-0ca8d5f2b097.png">
<img width="144" alt="screen shot 2017-03-30 at 5 16 56 pm" src="https://cloud.githubusercontent.com/assets/7063255/24526605/b49a95f6-156c-11e7-9502-cd1db080b2d1.png">

Closes #224 