### PR TITLE
feature(icon-fingerprinting): Scaffolding for iconAsset fp

### DIFF
--- a/addon/components/frost-icon.js
+++ b/addon/components/frost-icon.js
@@ -6,14 +6,13 @@ import Component from './frost-component'
 import Ember from 'ember'
 import computed, {readOnly} from 'ember-computed-decorators'
 import {PropTypes} from 'ember-prop-types'
-const {deprecate, inject, get} = Ember
+const {deprecate, get} = Ember
 
 export default Component.extend({
 
   // == Dependencies ==========================================================
 
   // == Keyword Properties ====================================================
-
   classNameBindings: ['iconClass'],
   layout,
   tagName: 'svg',
@@ -54,7 +53,7 @@ export default Component.extend({
   @readOnly
   @computed('pack')
   pathToIconPack (pack) {
-    return this.get('iconAssets')[`assets/icon-packs/${pack}.svg`]
+    return this._iconAssets[`assets/icon-packs/${pack}.svg`]
   },
 
   // == Functions =============================================================

--- a/addon/components/frost-icon.js
+++ b/addon/components/frost-icon.js
@@ -6,7 +6,7 @@ import Component from './frost-component'
 import Ember from 'ember'
 import computed, {readOnly} from 'ember-computed-decorators'
 import {PropTypes} from 'ember-prop-types'
-const {deprecate, get} = Ember
+const {deprecate, inject, get} = Ember
 
 export default Component.extend({
 
@@ -49,6 +49,12 @@ export default Component.extend({
    */
   iconClass (icon, pack) {
     return `frost-icon-${pack}-${icon}`
+  },
+
+  @readOnly
+  @computed('pack')
+  pathToIconPack (pack) {
+    return this.get('iconAssets')[`assets/icon-packs/${pack}.svg`]
   },
 
   // == Functions =============================================================

--- a/addon/initializers/icon-assets.js
+++ b/addon/initializers/icon-assets.js
@@ -1,0 +1,14 @@
+export function initialize (application) {
+  application.deferReadiness()
+
+  return $.get('assets/assetMap.json').then((assetMap) => {
+    application.register('icon-assets:main', Ember.Object.extend(assetMap.assets))
+    application.inject('component', 'iconAssets', 'icon-assets:main');
+    application.advanceReadiness()
+  })
+}
+
+export default {
+  name: 'icon-assets',
+  initialize
+};

--- a/addon/initializers/icon-assets.js
+++ b/addon/initializers/icon-assets.js
@@ -1,14 +1,16 @@
+import Ember from 'ember'
+
 export function initialize (application) {
   application.deferReadiness()
 
-  return $.get('assets/assetMap.json').then((assetMap) => {
-    application.register('icon-assets:main', Ember.Object.extend(assetMap.assets))
-    application.inject('component', 'iconAssets', 'icon-assets:main');
-    application.advanceReadiness()
-  })
+  return Ember.$.get('assets/assetMap.json')
+    .then((assetMap) => {
+      application.register('icon-assets:main', Ember.Object.extend(assetMap.assets))
+      application.inject('component:frost-icon', '_iconAssets', 'icon-assets:main')
+    }).always(() => application.advanceReadiness())
 }
 
 export default {
   name: 'icon-assets',
   initialize
-};
+}

--- a/addon/templates/components/frost-icon.hbs
+++ b/addon/templates/components/frost-icon.hbs
@@ -1,2 +1,2 @@
 {{! Template for the frost-icon component }}
-<use xlink:href="assets/icon-packs/{{pack}}.svg#{{icon}}" />
+<use xlink:href="{{pathToIconPack}}#{{icon}}"/>

--- a/app/initializers/icon-assets.js
+++ b/app/initializers/icon-assets.js
@@ -1,0 +1,1 @@
+export { default, initialize } from 'ember-frost-core/initializers/icon-assets';

--- a/app/initializers/icon-assets.js
+++ b/app/initializers/icon-assets.js
@@ -1,1 +1,1 @@
-export { default, initialize } from 'ember-frost-core/initializers/icon-assets';
+export { default, initialize } from 'ember-frost-core/initializers/icon-assets'

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 // 'use strict'
 
+const AssetRev = require('broccoli-asset-rev')
 const writeFile = require('broccoli-file-creator')
 const Funnel = require('broccoli-funnel')
 const mergeTrees = require('broccoli-merge-trees')
@@ -169,16 +170,22 @@ module.exports = {
 
     return mergeTrees([addonTree, iconNameTree], {overwrite: true})
   },
-  /* eslint-enable complexity */
-
-  treeForPublic: function (tree) {
+  /**
+   * Override of `treeForPublic` is to merge the
+   * existing tree for public files with the set of
+   * svg assets, supplied in the `svg` directory
+   * @param  {[type]} treeForPublic [description]
+   * @return {[type]}               [description]
+   */
+   /* eslint-enable complexity */
+  treeForPublic: function (treeForPublic) {
     const isAddon = this.project.isEmberCLIAddon()
 
     const addonPackages = pickBy(this.project.addonPackages, (addonPackage) => {
       return has(addonPackage.pkg, 'ember-frost-icon-pack')
     })
 
-    const iconPacks = Object.keys(addonPackages).map((addonName) => {
+    let iconPacks = Object.keys(addonPackages).map((addonName) => {
       const addonPackage = addonPackages[addonName]
       const iconPack = addonPackage.pkg['ember-frost-icon-pack']
       const iconPackPath = iconPack.path || 'svgs'
@@ -209,6 +216,13 @@ module.exports = {
       }))
     }
 
-    return mergeTrees(iconPacks, {overwrite: true})
+    const mergedIconPacks = mergeTrees(iconPacks, {overwrite: true})
+
+    const assetRevisedIconPacks = new AssetRev(mergedIconPacks, {
+      enabled: true,
+      extensions: ['svg'],
+      generateAssetMap: true
+    })
+    return mergeTrees([assetRevisedIconPacks, treeForPublic], {overwrite: true})
   }
 }

--- a/tests/unit/initializers/icon-assets-test.js
+++ b/tests/unit/initializers/icon-assets-test.js
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+import { describe, it, beforeEach } from 'mocha';
+import Ember from 'ember';
+import { initialize } from 'dummy/initializers/icon-assets';
+import destroyApp from '../../helpers/destroy-app';
+
+describe('Unit | Initializer | icon assets', function() {
+  let application;
+
+  beforeEach(function() {
+    Ember.run(function() {
+      application = Ember.Application.create();
+      application.deferReadiness();
+    });
+  });
+
+  afterEach(function() {
+    destroyApp(application);
+  });
+
+  // Replace this with your real tests.
+  it('works', function() {
+    initialize(application);
+
+    // you would normally confirm the results of the initializer here
+    expect(true).to.be.ok;
+  });
+});

--- a/tests/unit/initializers/icon-assets-test.js
+++ b/tests/unit/initializers/icon-assets-test.js
@@ -1,28 +1,26 @@
-import { expect } from 'chai';
-import { describe, it, beforeEach } from 'mocha';
-import Ember from 'ember';
-import { initialize } from 'dummy/initializers/icon-assets';
-import destroyApp from '../../helpers/destroy-app';
+import { expect } from 'chai'
+import Ember from 'ember'
+import { describe, it, beforeEach, afterEach } from 'mocha'
+import destroyApp from '../../helpers/destroy-app'
+import { initialize } from 'dummy/initializers/icon-assets'
 
-describe('Unit | Initializer | icon assets', function() {
-  let application;
+describe('Unit | Initializer | icon assets', function () {
+  let application
 
-  beforeEach(function() {
-    Ember.run(function() {
-      application = Ember.Application.create();
-      application.deferReadiness();
-    });
-  });
+  beforeEach(function () {
+    Ember.run(function () {
+      application = Ember.Application.create()
+      application.deferReadiness()
+    })
+  })
 
-  afterEach(function() {
-    destroyApp(application);
-  });
+  afterEach(function () {
+    destroyApp(application)
+  })
 
-  // Replace this with your real tests.
-  it('works', function() {
-    initialize(application);
-
-    // you would normally confirm the results of the initializer here
-    expect(true).to.be.ok;
-  });
-});
+  // TODO: Add real tests
+  it('works', function () {
+    initialize(application)
+    expect(true).to.equal(true)
+  })
+})


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

For now this intends to be a proof of concept, and should not be merged.

### How it works
- Use broccoli-asset-rev to wrap pre-existing `treeForPublic`
    - By default b-a-r will ignore svg files
- Generate asset map
- Create an application initializer that defers app readiness state and injects assetMap
- Frost icon refers to the icon pack through a CP

# CHANGELOG
- Icon packs are now fingerprinted

Closes #424 