### PR TITLE
fix(icon-assets): Bug fixes not accounted for when consuming

### DIFF
--- a/addon/services/icon-assets.js
+++ b/addon/services/icon-assets.js
@@ -23,7 +23,10 @@ export default Service.extend({
         return result
       })
       .then(iconMap => { this._assets = iconMap.assets || {} })
-      .finally(() => this._loadIcons())
+      .finally(() => {
+        this._requestResolved = true
+        this._loadIcons()
+      })
   },
   register (element) {
     return new RSVP.Promise(resolve => {
@@ -34,16 +37,15 @@ export default Service.extend({
         path
       }
 
-      if (this._icons !== undefined) { // assets have yet to resolve
-        this._icons.push(icon)
-      } else { // load immediately
+      if (this._requestResolved) {
         this._load(icon)
+      } else {
+        this._icons.push(icon)
       }
     })
   },
   _loadIcons () {
     this._icons.forEach(el => this._load(el))
-    delete this._icons
   },
   _load (icon) {
     const path = icon.path

--- a/index.js
+++ b/index.js
@@ -185,7 +185,7 @@ module.exports = {
       return has(addonPackage.pkg, 'ember-frost-icon-pack')
     })
 
-    let iconPacks = Object.keys(addonPackages).map((addonName) => {
+    const iconPacks = Object.keys(addonPackages).map((addonName) => {
       const addonPackage = addonPackages[addonName]
       const iconPack = addonPackage.pkg['ember-frost-icon-pack']
       const iconPackPath = iconPack.path || 'svgs'
@@ -223,6 +223,12 @@ module.exports = {
       extensions: ['svg'],
       assetMapPath: 'assets/icon-assets.json'
     })
-    return mergeTrees([assetRevisedIconPacks, treeForPublic], {overwrite: true})
+    const treesToMerge = [assetRevisedIconPacks]
+
+    if (treeForPublic) {
+      treesToMerge.push(treeForPublic)
+    }
+
+    return mergeTrees(treesToMerge, { overwrite: true })
   }
 }


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
- treeForPublic might not exist, check if it is there before attempting to merge
- Fix logic surrounding fetch request resolved, so load icons based on cached asset map