### PR TITLE
chore(dependencies): Bump ember-elsewhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.14.5 (2017-04-21)
+
+* **Fixed** a typo that was introducing exponents in an if statement for no good reason.
+
+
 # 1.14.4 (2017-04-20)
 
 * **Fixed** a typo that was introducing exponents in an if statement for no good reason.

--- a/blueprints/ember-frost-core/index.js
+++ b/blueprints/ember-frost-core/index.js
@@ -5,7 +5,7 @@ module.exports = {
     const addonsToAdd = [
       {name: 'ember-computed-decorators', target: '~0.2.0'},
       {name: 'ember-concurrency', target: '~0.7.15'},
-      {name: 'ember-elsewhere', target: '~0.4.1'},
+      {name: 'ember-elsewhere', target: '~1.0.1'},
       {name: 'ember-hook', target: '^1.4.1'},
       {name: 'ember-prop-types', target: '^3.0.0'},
       {name: 'ember-spread', target: '^1.1.1'},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-frost-core",
-  "version": "1.14.4",
+  "version": "1.14.5",
   "description": "The library of core frost components",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

https://github.com/ef4/ember-elsewhere/pull/15

This is to address teardown issues for acceptance tests

# CHANGELOG
- Bumped ember-elsewhere version