### PR TITLE
Added onClick callback for frost-select

### DIFF
--- a/addon/components/frost-select.js
+++ b/addon/components/frost-select.js
@@ -275,9 +275,12 @@ export default Component.extend({
 
   // == DOM Events ============================================================
 
-  _onClick: on('click', function () {
+  _onClick: on('click', function (e) {
     if (!this.get('disabled')) {
       this.toggleProperty('opened')
+    }
+    if (this.onClick) {
+      this.onClick(e)
     }
   }),
 

--- a/docs/frost-select.md
+++ b/docs/frost-select.md
@@ -13,6 +13,7 @@
 |    | | `true` | sets select component to error state |
 | `hook` | `string` | `<unique-name>` | name used for testing with ember-hook |
 | `onChange`     | `string` | `<action-name>` | The action callback to call when the value of the select component changes |
+| `onClick`      | `string` | `<action-name>` | The action callback to call when the select component is clicked. Fires even if select is disabled. |
 | `onInput`      | `string` | `<action-name>` | The action callback to call when the value of the filter changes as the user types |
 | `options` | `object` | `{<attributes>}` | property object used to spread the attributes to the top level of the component with ember-spread. |
 | `placeholder` | `string` | | Placeholder text for when nothing is selected. |

--- a/tests/integration/components/frost-select-test.js
+++ b/tests/integration/components/frost-select-test.js
@@ -72,13 +72,14 @@ describe(test.label, function () {
   test.setup()
 
   describe('renders', function () {
-    let onBlur, onChange, onFocus, sandbox
+    let onBlur, onChange, onClick, onFocus, sandbox
 
     beforeEach(function () {
       sandbox = sinon.sandbox.create()
 
       onBlur = sandbox.spy()
       onChange = sandbox.spy()
+      onClick = sandbox.stub()
       onFocus = sandbox.spy()
 
       this.setProperties({
@@ -86,6 +87,7 @@ describe(test.label, function () {
         onBlur,
         onFocus,
         onChange,
+        onClick,
         tabIndex: 0 // This is the default
       })
 
@@ -99,6 +101,7 @@ describe(test.label, function () {
           hook=hook
           onBlur=onBlur
           onChange=onChange
+          onClick=onClick
           onFocus=onFocus
           tabIndex=tabIndex
           width=width
@@ -176,6 +179,7 @@ describe(test.label, function () {
 
           expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
           expect(onChange.callCount, 'onChange is not called').to.equal(0)
+          expect(onClick.callCount, 'onClick is called').to.equal(1)
           expect(onFocus.callCount, 'onFocus is called').to.equal(1)
         })
 
@@ -444,6 +448,7 @@ describe(test.label, function () {
 
             expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
             expect(onChange.callCount, 'onChange is not called').to.equal(0)
+            expect(onClick.callCount, 'onClick is called').to.equal(1)
             expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
           })
         })
@@ -1494,6 +1499,7 @@ describe(test.label, function () {
 
             expect(onBlur.callCount, 'onBlur is not called').to.equal(0)
             expect(onChange.callCount, 'onChange is not called').to.equal(0)
+            expect(onClick.callCount, 'onClick is called').to.equal(1)
             expect(onFocus.callCount, 'onFocus is not called').to.equal(0)
           })
         })
@@ -1737,6 +1743,33 @@ describe(test.label, function () {
             done()
           }, 100)
         }, 50)
+      })
+    })
+  })
+
+  describe('when onClick is not defined and select is opened', function () {
+    beforeEach(function () {
+      this.setProperties({
+        data: [],
+        hook: 'select'
+      })
+
+      this.render(hbs`
+        {{frost-select-outlet hook='eventSelectOutlet'}}
+        {{frost-select
+          data=data
+          hook=hook
+        }}
+      `)
+
+      return open('select')
+    })
+
+    it('renders as expected', function () {
+      expectSelectWithState('select', {
+        focused: true,
+        items: [],
+        opened: true
       })
     })
   })


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

This callback might be useful if you want to `stopPropagation` of the click event.

# CHANGELOG

* **Added** onClick callback for frost-select
