### PR TITLE
Move notification z-index above modal z-index

### DIFF
--- a/addon/styles/_z-index.scss
+++ b/addon/styles/_z-index.scss
@@ -4,7 +4,8 @@
 
 // TODO Proper aliases - the following are samples
 $frost-z-index-application-bar: 9000;
-$frost-z-index-notification: 8000;
-$frost-z-index-modal: 7000;
-$frost-z-index-navigation: 6000;
+$frost-z-index-navigation: 8000;
+$frost-z-index-notification: 7000;
+$frost-z-index-modal: 6000;
+
 

--- a/addon/styles/_z-index.scss
+++ b/addon/styles/_z-index.scss
@@ -4,6 +4,7 @@
 
 // TODO Proper aliases - the following are samples
 $frost-z-index-application-bar: 9000;
-$frost-z-index-modal: 8000;
-$frost-z-index-navigation: 7000;
-$frost-z-index-notification: 6000;
+$frost-z-index-notification: 8000;
+$frost-z-index-modal: 7000;
+$frost-z-index-navigation: 6000;
+


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* Set notification z-index to appear above modals
