### PR TITLE
Add style rules for hover state of frost-toggle switch

### DIFF
--- a/addon/styles/_frost-toggle.scss
+++ b/addon/styles/_frost-toggle.scss
@@ -5,6 +5,9 @@ $frost-toggle-button-switch-height: 27px;
 $frost-toggle-off-color: #000;
 $frost-toggle-on-color: #fff;
 
+$frost-toggle-button-hover-color: #c6eafc;
+$frost-toggle-button-hover-shadow: rgba(0, 0, 0, .2);
+
 .frost-toggle {
   display: inline-flex;
   align-items: center;
@@ -59,6 +62,16 @@ $frost-toggle-on-color: #fff;
       height: $frost-toggle-button-switch-height;
       margin: 0 10px 0 0;
       content: '';
+    }
+
+    &:hover {
+      &:not(.disabled) {
+        &:before,
+        &:after {
+          background-color: $frost-toggle-button-hover-color;
+          box-shadow: 0 2px 4px $frost-toggle-button-hover-shadow;
+        }
+      }
     }
 
     &:after {

--- a/addon/styles/_frost-toggle.scss
+++ b/addon/styles/_frost-toggle.scss
@@ -1,10 +1,6 @@
 $frost-toggle-button-height: 35px;
 $frost-toggle-button-switch-height: 27px;
 
-
-$frost-toggle-off-color: #000;
-$frost-toggle-on-color: #fff;
-
 $frost-toggle-button-hover-color: #c6eafc;
 $frost-toggle-button-hover-shadow: rgba(0, 0, 0, .2);
 
@@ -58,9 +54,8 @@ $frost-toggle-button-hover-shadow: rgba(0, 0, 0, .2);
     &:after {
       display: block;
       position: absolute;
-      width: 40px;
+      width: 45%;
       height: $frost-toggle-button-switch-height;
-      margin: 0 10px 0 0;
       content: '';
     }
 
@@ -76,9 +71,9 @@ $frost-toggle-button-hover-shadow: rgba(0, 0, 0, .2);
 
     &:after {
       top: calc(50% - (#{$frost-toggle-button-switch-height} / 2));
-      right: 0;
+      right: 5px;
       transition: right .2s;
-      border-radius: 3px;
+      border-radius: 2px;
       background-color: $frost-color-white;
     }
 
@@ -91,11 +86,11 @@ $frost-toggle-button-hover-shadow: rgba(0, 0, 0, .2);
       text-align: center;
 
       &.off {
-        color: $frost-toggle-off-color;
+        color: $frost-color-grey-4;
       }
 
       &.on {
-        color: $frost-toggle-on-color;
+        color: $frost-color-white;
       }
     }
   }


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

Added style rules for the hover state of the frost-toggle button switch. The switch will now turn a light blue color when the user mouses over the toggle. If the toggle is disabled, the switch will not change color. 