### PR TITLE
Adding x-axis scroll handlers to frost-scroll

### DIFF
--- a/addon/components/frost-scroll.js
+++ b/addon/components/frost-scroll.js
@@ -53,6 +53,18 @@ export default Component.extend({
       run.debounce(this, this.onScrollYStart, debouncePeriod, true)
     }
 
+    this._scrollXHandler = () => {
+      run.debounce(this, this.onScrollX, debouncePeriod, true)
+    }
+
+    this._scrollRightHandler = () => {
+      run.debounce(this, this.onScrollRight, debouncePeriod, true)
+    }
+
+    this._scrollLeftHandler = () => {
+      run.debounce(this, this.onScrollLeft, debouncePeriod, true)
+    }
+
     if (typeOf(this.onScrollUp) === 'function') {
       this.$().on('ps-scroll-up', this._scrollUpHandler)
     }
@@ -67,6 +79,18 @@ export default Component.extend({
 
     if (typeOf(this.onScrollYEnd) === 'function') {
       this.$().on('ps-y-reach-end', this._scrollYEndHandler)
+    }
+
+    if (typeOf(this.onScrollX) === 'function') {
+      this.$().on('ps-scroll-x', this._scrollXHandler)
+    }
+
+    if (typeOf(this.onScrollRight) === 'function') {
+      this.$().on('ps-scroll-right', this._scrollRightHandler)
+    }
+
+    if (typeOf(this.onScrollLeft) === 'function') {
+      this.$().on('ps-scroll-left', this._scrollLeftHandler)
     }
 
     if (typeOf(this['on-scroll-y-end']) === 'function') {
@@ -104,6 +128,18 @@ export default Component.extend({
 
     if (typeOf(this.onScrollYEnd) === 'function') {
       this.$().off('ps-y-reach-end', this._scrollYEndHandler)
+    }
+
+    if (typeOf(this.onScrollX) === 'function') {
+      this.$().off('ps-scroll-x', this._scrollXHandler)
+    }
+
+    if (typeOf(this.onScrollRight) === 'function') {
+      this.$().off('ps-scroll-right', this._scrollRightHandler)
+    }
+
+    if (typeOf(this.onScrollLeft) === 'function') {
+      this.$().off('ps-scroll-left', this._scrollLeftHandler)
     }
   },
   /* eslint-enable complexity */

--- a/tests/dummy/app/pods/scroll/controller.js
+++ b/tests/dummy/app/pods/scroll/controller.js
@@ -34,6 +34,27 @@ export default Controller.extend({
       })
     },
 
+    onScrollX () {
+      this.get('notifications').success('Scrolled x axis', {
+        autoClear: true,
+        clearDuration: 2000
+      })
+    },
+
+    onScrollRight () {
+      this.get('notifications').success('Scrolled right', {
+        autoClear: true,
+        clearDuration: 2000
+      })
+    },
+
+    onScrollLeft () {
+      this.get('notifications').success('Scrolled left', {
+        autoClear: true,
+        clearDuration: 2000
+      })
+    },
+
     yEndReached () {
       this.get('notifications').success('Scroll reached end of y axis', {
         autoClear: true,
@@ -43,4 +64,3 @@ export default Controller.extend({
   }
 })
 // END-SNIPPET scroll-controller
-

--- a/tests/dummy/app/pods/scroll/template.hbs
+++ b/tests/dummy/app/pods/scroll/template.hbs
@@ -36,6 +36,9 @@
           onScrollDown=(action 'onScrollDown')
           onScrollYStart=(action 'onScrollYStart')
           onScrollYEnd=(action 'onScrollYEnd')
+          onScrollX=(action 'onScrollX')
+          onScrollRight=(action 'onScrollRight')
+          onScrollLeft=(action 'onScrollLeft')
           on-scroll-y-end=(action 'yEndReached')
         }}
           {{frost-icon

--- a/tests/integration/components/frost-scroll-test.js
+++ b/tests/integration/components/frost-scroll-test.js
@@ -89,6 +89,66 @@ describe(test.label, function () {
     ).to.equal(true)
   })
 
+  it('onScrollX closure action is called', function () {
+    const externalActionSpy = sinon.spy()
+
+    this.on('externalAction', externalActionSpy)
+
+    this.render(hbs`
+      {{frost-scroll
+        hook='myScroll'
+        onScrollX=(action 'externalAction')
+      }}
+    `)
+
+    this.$('.frost-scroll').trigger('ps-scroll-x')
+
+    expect(
+      externalActionSpy.called,
+      'onScrollX closure action called on ps-scroll-x'
+    ).to.equal(true)
+  })
+
+  it('onScrollRight closure action is called', function () {
+    const externalActionSpy = sinon.spy()
+
+    this.on('externalAction', externalActionSpy)
+
+    this.render(hbs`
+      {{frost-scroll
+        hook='myScroll'
+        onScrollRight=(action 'externalAction')
+      }}
+    `)
+
+    this.$('.frost-scroll').trigger('ps-scroll-right')
+
+    expect(
+      externalActionSpy.called,
+      'onScrollRight closure action called on ps-scroll-right'
+    ).to.equal(true)
+  })
+
+  it('onScrollLeft closure action is called', function () {
+    const externalActionSpy = sinon.spy()
+
+    this.on('externalAction', externalActionSpy)
+
+    this.render(hbs`
+      {{frost-scroll
+        hook='myScroll'
+        onScrollLeft=(action 'externalAction')
+      }}
+    `)
+
+    this.$('.frost-scroll').trigger('ps-scroll-left')
+
+    expect(
+      externalActionSpy.called,
+      'onScrollLeft closure action called on ps-scroll-left'
+    ).to.equal(true)
+  })
+
   it('renders using spread', function () {
     const hook = 'my-hook'
 

--- a/tests/unit/components/frost-scroll-test.js
+++ b/tests/unit/components/frost-scroll-test.js
@@ -19,7 +19,7 @@ describe(test.label, function () {
     })
   })
 
-  it('extends the commone frost component', function () {
+  it('extends the common frost component', function () {
     expect(
       component instanceof Component,
       'is instance of Frost Component'
@@ -140,6 +140,96 @@ describe(test.label, function () {
     expect(
       spyOff.calledWith("ps-y-reach-end"), // eslint-disable-line
       'off() was called with "ps-y-reach-end" event'
+    ).to.equal(true)
+
+    $.fn.on.restore()
+    $.fn.off.restore()
+  })
+
+  it('registers and unregisters "ps-scroll-x" event handlers', function () {
+    const spyOn = sinon.spy($.fn, 'on')
+    const spyOff = sinon.spy($.fn, 'off')
+
+    component.set('onScrollX', function () { return })
+
+    this.render()
+
+    spyOn.reset()
+
+    component.trigger('didInsertElement')
+
+    expect(
+      spyOn.calledWith("ps-scroll-x"), // eslint-disable-line
+      'on() was called with "ps-scroll-x" event'
+    ).to.equal(true)
+
+    spyOff.reset()
+
+    component.trigger('willDestroyElement')
+
+    expect(
+      spyOff.calledWith("ps-scroll-x"), // eslint-disable-line
+      'off() was called with "ps-scroll-x" event'
+    ).to.equal(true)
+
+    $.fn.on.restore()
+    $.fn.off.restore()
+  })
+
+  it('registers and unregisters "ps-scroll-right" event handlers', function () {
+    const spyOn = sinon.spy($.fn, 'on')
+    const spyOff = sinon.spy($.fn, 'off')
+
+    component.set('onScrollRight', function () { return })
+
+    this.render()
+
+    spyOn.reset()
+
+    component.trigger('didInsertElement')
+
+    expect(
+      spyOn.calledWith("ps-scroll-right"), // eslint-disable-line
+      'on() was called with "ps-scroll-right" event'
+    ).to.equal(true)
+
+    spyOff.reset()
+
+    component.trigger('willDestroyElement')
+
+    expect(
+      spyOff.calledWith("ps-scroll-right"), // eslint-disable-line
+      'off() was called with "ps-scroll-right" event'
+    ).to.equal(true)
+
+    $.fn.on.restore()
+    $.fn.off.restore()
+  })
+
+  it('registers and unregisters "ps-scroll-left" event handlers', function () {
+    const spyOn = sinon.spy($.fn, 'on')
+    const spyOff = sinon.spy($.fn, 'off')
+
+    component.set('onScrollLeft', function () { return })
+
+    this.render()
+
+    spyOn.reset()
+
+    component.trigger('didInsertElement')
+
+    expect(
+      spyOn.calledWith("ps-scroll-left"), // eslint-disable-line
+      'on() was called with "ps-scroll-left" event'
+    ).to.equal(true)
+
+    spyOff.reset()
+
+    component.trigger('willDestroyElement')
+
+    expect(
+      spyOff.calledWith("ps-scroll-left"), // eslint-disable-line
+      'off() was called with "ps-scroll-left" event'
     ).to.equal(true)
 
     $.fn.on.restore()


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* Added x-axis scroll event handlers to frost-scroll
* Added tests for new scroll events