### PR TITLE
fix frost-scroll content size being reduced

### DIFF
--- a/addon/components/frost-scroll.js
+++ b/addon/components/frost-scroll.js
@@ -121,7 +121,9 @@ export default Component.extend({
     this._super(...arguments)
     this._unregisterEvents()
   },
-
+  didRender () {
+    window.Ps.update(this.$()[0])
+  },
   // == Actions ===============================================================
 
   actions: {


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
## Without Fix
![no-fix](https://user-images.githubusercontent.com/9057680/27596624-18c6aa40-5b2e-11e7-8412-5fbaffcdaf41.gif)
## With Fix
![fix](https://user-images.githubusercontent.com/9057680/27596628-1b339c0c-5b2e-11e7-90ea-01f65c7a89ba.gif)

# CHANGELOG
 * fix frost-scroll content size being reduced by calling perfect-scrollbar `update` when renders
   * Fixes BPSO-54864


