### PR TITLE
Change from Jquery create canvas element to document.create

### DIFF
--- a/addon/utils/text.js
+++ b/addon/utils/text.js
@@ -1,7 +1,7 @@
 import Ember from 'ember'
 const {$} = Ember
 
-const ctx = $('<canvas />').get(0).getContext('2d')
+const ctx = document.createElement('canvas').getContext('2d')
 
 /**
  * Get width of text for a specific font


### PR DESCRIPTION
JQuery create behaves strangley in Firefox sometimes where it seems like the canvas doesn't have a surface

**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* The JQuery creation of a canvas element was behaving oddly in some apps on Firefox.