### PR TITLE
Place "rootURL" in correct location

### DIFF
--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -4,6 +4,7 @@ module.exports = function (environment) {
     modulePrefix: 'dummy',
     podModulePrefix: 'dummy/pods',
     environment: environment,
+    rootURL: '/',
     locationType: 'hash',
     EmberENV: {
       FEATURES: {
@@ -42,7 +43,6 @@ module.exports = function (environment) {
 
   if (environment === 'test') {
     // Testem prefers this...
-    ENV.rootURL = '/'
     ENV.locationType = 'none'
 
     ENV['ember-cli-mirage'] = {


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* Update location of `rootURL` configuration option messed up during prior Ember CLI upgrade
