### PR TITLE
Pin ember-elsewhere to pre-babel 6 version

### DIFF
--- a/blueprints/ember-frost-core/index.js
+++ b/blueprints/ember-frost-core/index.js
@@ -6,7 +6,7 @@ module.exports = {
       {name: 'ember-cli-frost-blueprints', target: '^1.2.1'},
       {name: 'ember-computed-decorators', target: '~0.3.0'},
       {name: 'ember-concurrency', target: '~0.7.19'},
-      {name: 'ember-elsewhere', target: '~1.0.1'},
+      {name: 'ember-elsewhere', target: '1.0.1'},
       {name: 'ember-hook', target: '^1.4.1'},
       {name: 'ember-prop-types', target: '^3.14.1'},
       {name: 'ember-spread', target: '^1.2.2'},

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "ember-concurrency": "~0.7.19",
     "ember-data": "~2.12.0",
     "ember-disable-prototype-extensions": "1.1.0",
-    "ember-elsewhere": "~1.0.1",
+    "ember-elsewhere": "1.0.1",
     "ember-export-application-global": "^1.0.5",
     "ember-frost-test": "^1.0.3",
     "ember-hook": "^1.4.1",


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [X] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* **Updated** pin `ember-elsewhere` to pre-babel 6 version
