### PR TITLE
Reduce height of buttons within info bar and adjust margins and padding

### DIFF
--- a/addon/styles/_frost-button.scss
+++ b/addon/styles/_frost-button.scss
@@ -246,7 +246,9 @@ $frost-color-button-info-content-subtext-color: rgba($frost-color-white, .8);
     flex-direction: column;
     align-items: center;
     width: 75px;
-    height: 75px;
+    height: 60px;
+    margin-right: 5px;
+    padding: 0 5px;
     background-color: $frost-color-button-info-bar-bg;
     color: $frost-color-blue-1;
 
@@ -274,13 +276,12 @@ $frost-color-button-info-content-subtext-color: rgba($frost-color-white, .8);
       box-sizing: border-box;
 
       .text {
-        padding: 0 1px 2px;
         text-align: center;
         vertical-align: middle;
       }
 
       .svg {
-        margin-bottom: 10px;
+        margin-bottom: 5px;
         margin-left: 10px;
 
         .frost-icon {


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Reduced** the height of buttons within an info bar from 75px to 60px
* **Added** a right margin of 5px to buttons within an info bar to give them space from their right boundary
* **Added** a 5px padding to the left and right sides of the info bar buttons so that the text of the buttons is not pushed right up against the boundary of the button
* **Removed** padding on the text within the info bar
* **Reduced** the bottom margin on the SVG elements in buttons within an info bar from 10px to 5px