### PR TITLE
Replace search icon with round-add icon in info-bar button demo

### DIFF
--- a/tests/dummy/app/pods/button/template.hbs
+++ b/tests/dummy/app/pods/button/template.hbs
@@ -388,7 +388,7 @@
         {{frost-button
           design='info-bar'
           hook='myInfoBarButton'
-          icon='search'
+          icon='round-add'
           text='Text'
         }}
         {{! END-SNIPPET }}
@@ -406,7 +406,7 @@
           design='info-bar'
           disabled=true
           hook='myDisabledInfoBarButton'
-          icon='search'
+          icon='round-add'
           text='Text'
         }}
         {{! END-SNIPPET }}


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

Resolves #494 

# CHANGELOG

* Updated frost-button demo to show round-add icon for info-bar buttons