### PR TITLE
added onMouseEnter property to frost scroll

### DIFF
--- a/addon/components/frost-scroll.js
+++ b/addon/components/frost-scroll.js
@@ -4,6 +4,7 @@
 import Component from './frost-component'
 import Ember from 'ember'
 const {deprecate, run, typeOf} = Ember
+import {PropTypes} from 'ember-prop-types'
 
 export default Component.extend({
 
@@ -12,7 +13,15 @@ export default Component.extend({
   // == Keyword Properties ====================================================
 
   // == PropTypes =============================================================
+  propTypes: {
+    refreshOnMouseEnter: PropTypes.bool.optional
+  },
 
+  getDefaultProps () {
+    return {
+      refreshOnMouseEnter: false
+    }
+  },
   // == Computed Properties ===================================================
 
   // == Functions =============================================================
@@ -65,6 +74,10 @@ export default Component.extend({
       run.debounce(this, this.onScrollLeft, debouncePeriod, true)
     }
 
+    this._mouseEnterHandler = () => {
+      window.Ps.update(this.get('element'))
+    }
+
     if (typeOf(this.onScrollUp) === 'function') {
       this.$().on('ps-scroll-up', this._scrollUpHandler)
     }
@@ -91,6 +104,10 @@ export default Component.extend({
 
     if (typeOf(this.onScrollLeft) === 'function') {
       this.$().on('ps-scroll-left', this._scrollLeftHandler)
+    }
+
+    if (this.refreshOnMouseEnter) {
+      this.$().on('mouseenter', this._mouseEnterHandler)
     }
 
     if (typeOf(this['on-scroll-y-end']) === 'function') {
@@ -140,6 +157,10 @@ export default Component.extend({
 
     if (typeOf(this.onScrollLeft) === 'function') {
       this.$().off('ps-scroll-left', this._scrollLeftHandler)
+    }
+
+    if (this.refreshOnMouseEnter) {
+      this.$().off('mouseenter', this._mouseEnterHandler)
     }
   },
   /* eslint-enable complexity */

--- a/addon/components/frost-scroll.js
+++ b/addon/components/frost-scroll.js
@@ -14,14 +14,9 @@ export default Component.extend({
 
   // == PropTypes =============================================================
   propTypes: {
-    refreshOnMouseEnter: PropTypes.bool
+    onMouseEnter: PropTypes.func
   },
 
-  getDefaultProps () {
-    return {
-      refreshOnMouseEnter: false
-    }
-  },
   // == Computed Properties ===================================================
 
   // == Functions =============================================================
@@ -75,7 +70,7 @@ export default Component.extend({
     }
 
     this._mouseEnterHandler = () => {
-      window.Ps.update(this.get('element'))
+      this.get('onMouseEnter')(this.get('element'))
     }
 
     if (typeOf(this.onScrollUp) === 'function') {
@@ -106,7 +101,7 @@ export default Component.extend({
       this.$().on('ps-scroll-left', this._scrollLeftHandler)
     }
 
-    if (this.refreshOnMouseEnter) {
+    if (typeOf(this.get('onMouseEnter')) === 'function') {
       this.$().on('mouseenter', this._mouseEnterHandler)
     }
 
@@ -159,7 +154,7 @@ export default Component.extend({
       this.$().off('ps-scroll-left', this._scrollLeftHandler)
     }
 
-    if (this.refreshOnMouseEnter) {
+    if (typeOf(this.get('onMouseEnter')) === 'function') {
       this.$().off('mouseenter', this._mouseEnterHandler)
     }
   },

--- a/addon/components/frost-scroll.js
+++ b/addon/components/frost-scroll.js
@@ -14,7 +14,7 @@ export default Component.extend({
 
   // == PropTypes =============================================================
   propTypes: {
-    refreshOnMouseEnter: PropTypes.bool.optional
+    refreshOnMouseEnter: PropTypes.bool
   },
 
   getDefaultProps () {

--- a/tests/dummy/app/pods/scroll/controller.js
+++ b/tests/dummy/app/pods/scroll/controller.js
@@ -60,6 +60,11 @@ export default Controller.extend({
         autoClear: true,
         clearDuration: 2000
       })
+    },
+
+    onMouseEnterHandler (element) {
+      element.innerHTML = 'mouse entered and will update the scrollbars'
+      window.Ps.update(element)
     }
   }
 })

--- a/tests/dummy/app/pods/scroll/template.hbs
+++ b/tests/dummy/app/pods/scroll/template.hbs
@@ -85,19 +85,20 @@
       </div>
     </div>
     <div class='example'>
-      <div class='title'>Refresh on mouse enter</div>
-      <div style='display: none'>
-        {{! BEGIN-SNIPPET scroll-other-refreshOnMouseEnter }}
+      <div class='title'>onMouseEnter</div>
+      <div class='demo'>
+        {{! BEGIN-SNIPPET scroll-other-onMouseEnter }}
         {{#frost-scroll
           class='full'
-          hook='refreshOnMouseEnter'
-          refreshOnMouseEnter=true
+          hook='OnMouseEnter'
+          onMouseEnter=(action 'onMouseEnterHandler')
         }}
+          <div>Mouse over me!</div>
         {{/frost-scroll}}
         {{! END-SNIPPET }}
       </div>
       <div class='snippet'>
-        {{code-snippet name='scroll-other-refreshOnMouseEnter.hbs'}}
+        {{code-snippet name='scroll-other-onMouseEnter.hbs'}}
       </div>
     </div>
   </div>

--- a/tests/dummy/app/pods/scroll/template.hbs
+++ b/tests/dummy/app/pods/scroll/template.hbs
@@ -84,5 +84,21 @@
         {{code-snippet name='scroll-other-spread.hbs'}}
       </div>
     </div>
+    <div class='example'>
+      <div class='title'>Refresh on mouse enter</div>
+      <div style='display: none'>
+        {{! BEGIN-SNIPPET scroll-other-refreshOnMouseEnter }}
+        {{#frost-scroll
+          class='full'
+          hook='refreshOnMouseEnter'
+          refreshOnMouseEnter=true
+        }}
+        {{/frost-scroll}}
+        {{! END-SNIPPET }}
+      </div>
+      <div class='snippet'>
+        {{code-snippet name='scroll-other-refreshOnMouseEnter.hbs'}}
+      </div>
+    </div>
   </div>
 </div>

--- a/tests/integration/components/frost-scroll-test.js
+++ b/tests/integration/components/frost-scroll-test.js
@@ -167,4 +167,24 @@ describe(test.label, function () {
       'scroll has been rendered'
     ).to.equal(true)
   })
+
+  it('onMouseEnter closure action is called', function () {
+    const externalActionSpy = sinon.spy()
+
+    this.on('externalAction', externalActionSpy)
+
+    this.render(hbs`
+      {{frost-scroll
+        hook='myScroll'
+        onMouseEnter=(action 'externalAction')
+      }}
+    `)
+
+    this.$('.frost-scroll').trigger('mouseenter')
+
+    expect(
+      externalActionSpy.called,
+      'onMouseEnter closure action called on mouseenter'
+    ).to.equal(true)
+  })
 })

--- a/tests/unit/components/frost-scroll-test.js
+++ b/tests/unit/components/frost-scroll-test.js
@@ -234,4 +234,34 @@ describe(test.label, function () {
     $.fn.on.restore()
     $.fn.off.restore()
   })
+
+  it('registers and unregisters "mouseenter" event handlers', function () {
+    const spyOn = sinon.spy($.fn, 'on')
+    const spyOff = sinon.spy($.fn, 'off')
+
+    component.set('onMouseEnter', function () { return })
+
+    this.render()
+
+    spyOn.reset()
+
+    component.trigger('didInsertElement')
+
+    expect(
+      spyOn.calledWith("mouseenter"), // eslint-disable-line
+      'on() was called with "mouseenter" event'
+    ).to.equal(true)
+
+    spyOff.reset()
+
+    component.trigger('willDestroyElement')
+
+    expect(
+      spyOff.calledWith("mouseenter"), // eslint-disable-line
+      'off() was called with "mouseenter" event'
+    ).to.equal(true)
+
+    $.fn.on.restore()
+    $.fn.off.restore()
+  })
 })


### PR DESCRIPTION
issue #496 
- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* **Added** an optional **mouseenter** event for the ps-container to update which can then remove or add scrollbars
