### PR TITLE
Ensure `included` hook's `_super` call is bound.

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ module.exports = {
       this.app = app = app.app
     }
 
-    this._super.included(app)
+    this._super.included.apply(this, app)
 
     if (app) {
       const robotoPath = path.join('vendor', 'google', 'fonts', 'roboto')


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* **Updated** to ensure that the `included` method's `this._super` call is properly bound to the context (fixes ember-decorators/ember-decorators#173).