### PR TITLE
Update version of ember-decorators

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,15 +74,6 @@ function isObject (object) {
   return object !== null && typeof object === 'object'
 }
 
-/**
- * Default the babel options
- * @param {Object} options - the options for this build
- */
-function defaultBabel (options) {
-  options.babel = options.babel || {}
-  options.babel.plugins = options.babel.plugins || []
-}
-
 module.exports = {
   name: 'ember-frost-core',
 
@@ -109,23 +100,6 @@ module.exports = {
       app.import(path.join('vendor', 'svg4everybody.min.js'))
       app.import(path.join('vendor', 'perfect-scrollbar.min.js'))
       app.import(path.join('vendor', 'perfect-scrollbar.min.css'))
-    }
-  },
-
-  init: function (app) {
-    this.options = this.options || {}
-    defaultBabel(this.options)
-
-    if (this.options.babel.plugins.indexOf('transform-decorators-legacy') === -1) {
-      this.options.babel.plugins.push('transform-decorators-legacy')
-    }
-
-    if (this.options.babel.plugins.indexOf('transform-class-properties') === -1) {
-      this.options.babel.plugins.push('transform-class-properties')
-    }
-
-    if (this._super.init) {
-      this._super.init.apply(this, arguments)
     }
   },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-frost-core",
-  "version": "1.23.13",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1725,11 +1725,6 @@
       "requires": {
         "hoek": "4.2.0"
       }
-    },
-    "bower": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.2.tgz",
-      "integrity": "sha1-rfU1KcjUrwLvJPuNU0HBQZ0z4vc="
     },
     "bower-config": {
       "version": "1.4.1",
@@ -6434,9 +6429,9 @@
       }
     },
     "ember-compatibility-helpers": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ember-compatibility-helpers/-/ember-compatibility-helpers-0.1.1.tgz",
-      "integrity": "sha1-cKJsDShxW7sj6xvjQ9cgPkkq+mg=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ember-compatibility-helpers/-/ember-compatibility-helpers-0.1.2.tgz",
+      "integrity": "sha1-jrF2mtdh2yc/1AJCsRcNnzhB0PA=",
       "requires": {
         "babel-plugin-debug-macros": "0.1.11",
         "ember-cli-version-checker": "2.1.0",
@@ -6820,15 +6815,15 @@
       }
     },
     "ember-decorators": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/ember-decorators/-/ember-decorators-1.3.0.tgz",
-      "integrity": "sha1-1cnWA/42TnTKIa4d8fiUHtnNHKs=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/ember-decorators/-/ember-decorators-1.3.1.tgz",
+      "integrity": "sha1-AAJ9pxHCAL3q+eVy6j2WlX4TAT0=",
       "requires": {
         "babel-plugin-transform-class-properties": "6.24.1",
         "babel-plugin-transform-decorators-legacy": "1.3.4",
         "ember-cli-babel": "6.8.2",
         "ember-cli-version-checker": "2.1.0",
-        "ember-compatibility-helpers": "0.1.1",
+        "ember-compatibility-helpers": "0.1.2",
         "ember-macro-helpers": "0.16.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "ember-cli-htmlbars": "^2.0.1",
     "ember-cli-path-utils": "^1.0.0",
     "ember-cli-sass": "7.0.0",
-    "ember-decorators": "^1.3.1",
+    "ember-decorators": "1.3.1",
     "npm-install-security-check": "^1.0.4",
     "promise": "^8.0.1",
     "semver": "^5.4.1"

--- a/package.json
+++ b/package.json
@@ -77,9 +77,6 @@
     "frost"
   ],
   "ember-addon": {
-    "after": [
-      "ember-decorators"
-    ],
     "configPath": "tests/dummy/config"
   },
   "ember-frost-icon-pack": {

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "ember-cli-htmlbars": "^2.0.1",
     "ember-cli-path-utils": "^1.0.0",
     "ember-cli-sass": "7.0.0",
-    "ember-decorators": "1.3.0",
+    "ember-decorators": "^1.3.1",
     "npm-install-security-check": "^1.0.4",
     "promise": "^8.0.1",
     "semver": "^5.4.1"


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* **Updated** version of `ember-decorators`
* **Removed** code setting babel plugins inside `index.js` since it is no longer needed for `ember-decorators'
