### PR TITLE
Bring in run loop aware changes #511 to master

### DIFF
--- a/addon/components/frost-scroll.js
+++ b/addon/components/frost-scroll.js
@@ -72,9 +72,7 @@ export default Component.extend({
     }
 
     this._mouseEnterHandler = () => {
-      run(() => {
-        this.get('onMouseEnter')(this.get('element'))
-      })
+      this.get('onMouseEnter')(this.get('element'))
     }
 
     if (typeOf(this.onScrollUp) === 'function') {

--- a/addon/components/frost-scroll.js
+++ b/addon/components/frost-scroll.js
@@ -70,9 +70,7 @@ export default Component.extend({
     }
 
     this._mouseEnterHandler = () => {
-      run(() => {
-        this.get('onMouseEnter')(this.get('element'))
-      })
+      this.get('onMouseEnter')(this.get('element'))
     }
 
     if (typeOf(this.onScrollUp) === 'function') {

--- a/addon/components/frost-scroll.js
+++ b/addon/components/frost-scroll.js
@@ -70,7 +70,9 @@ export default Component.extend({
     }
 
     this._mouseEnterHandler = () => {
-      this.get('onMouseEnter')(this.get('element'))
+      run(() => {
+        this.get('onMouseEnter')(this.get('element'))
+      })
     }
 
     if (typeOf(this.onScrollUp) === 'function') {

--- a/addon/components/frost-select-dropdown.js
+++ b/addon/components/frost-select-dropdown.js
@@ -2,7 +2,6 @@
  * Component definition for frost-select-dropdown component
  */
 import Ember from 'ember'
-const {$, deprecate, get, isArray, isEmpty, merge} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import {task, timeout} from 'ember-concurrency'
 import {PropTypes} from 'ember-prop-types'
@@ -13,6 +12,7 @@ import {keyCodes} from '../utils'
 import {trimLongDataInElement} from '../utils/text'
 import Component from './frost-component'
 
+const {$, deprecate, get, isArray, isEmpty, merge, run} = Ember
 const {DOWN_ARROW, ENTER, ESCAPE, TAB, UP_ARROW} = keyCodes
 
 const BORDER_HEIGHT = 1
@@ -254,14 +254,18 @@ export default Component.extend({
     Array.from(listItemElements).forEach((li, index) => {
       $(li)
         .mousedown(() => {
-          if (this.isDestroyed || this.isDestroying) return
-          const value = this.get(`items.${index}.value`)
-          this.set('focusedIndex', index)
-          this.send('selectItem', value)
+          run(() => {
+            if (this.isDestroyed || this.isDestroying) return
+            const value = this.get(`items.${index}.value`)
+            this.set('focusedIndex', index)
+            this.send('selectItem', value)
+          })
         })
         .mouseenter(() => {
-          if (this.isDestroyed || this.isDestroying) return
-          this.set('focusedIndex', index)
+          run(() => {
+            if (this.isDestroyed || this.isDestroying) return
+            this.set('focusedIndex', index)
+          })
         })
     })
   },
@@ -496,35 +500,38 @@ export default Component.extend({
     $('.frost-select-dropdown .frost-text-input').focus() // Focus on filter
 
     this._updateHandler = () => {
-      this._lastInteraction = Date.now()
+      run(() => {
+        this._lastInteraction = Date.now()
 
-      if (!this._isUpdating) {
-        this.get('updateTask').perform()
-      }
+        if (!this._isUpdating) {
+          this.get('updateTask').perform()
+        }
+      })
     }
 
     /* eslint-disable complexity */
     this._keyDownHandler = (e) => {
-      if (this.isDestroyed || this.isDestroying) return
+      run(() => {
+        if (this.isDestroyed || this.isDestroying) return
 
-      if ([DOWN_ARROW, UP_ARROW].indexOf(e.keyCode) !== -1) {
-        e.preventDefault() // Keep arrow keys from scrolling document
-        this._handleArrowKey(e.keyCode === UP_ARROW)
-      }
+        if ([DOWN_ARROW, UP_ARROW].indexOf(e.keyCode) !== -1) {
+          e.preventDefault() // Keep arrow keys from scrolling document
+          this._handleArrowKey(e.keyCode === UP_ARROW)
+        }
 
-      switch (e.keyCode) {
-        case ENTER:
-          this._handleEnterKey()
-          return
+        switch (e.keyCode) {
+          case ENTER:
+            this._handleEnterKey()
+            return
 
-        case ESCAPE:
-          this.get('onClose')()
-          return
+          case ESCAPE:
+            this.get('onClose')()
+            return
 
-        case TAB:
-          this.get('onClose')()
-          return
-      }
+          case TAB:
+            this.get('onClose')()
+        }
+      })
     }
     /* eslint-enable complexity */
 

--- a/tests/integration/components/frost-select-test.js
+++ b/tests/integration/components/frost-select-test.js
@@ -210,7 +210,7 @@ describe(test.label, function () {
       // FIXME: tests for tabbing into components isn't working anymore, despite the fact that
       // code changes shouldn't have affected it, AFAIK, probably need to look into alternative ways of
       // testing this (ARM 2016-12-05)
-      describe.skip('tab into component', function () {
+      describe('tab into component', function () {
         beforeEach(function () {
           // In case you are wondering what the hell is going on here there is no
           // way to trigger a generic tab event on the document to move focus on to
@@ -456,7 +456,7 @@ describe(test.label, function () {
         // FIXME: tests for tabbing into components isn't working anymore, despite the fact that
         // code changes shouldn't have affected it, AFAIK, probably need to look into alternative ways of
         // testing this (ARM 2016-12-05)
-        describe.skip('tab into component', function () {
+        describe('tab into component', function () {
           beforeEach(function () {
             // In case you are wondering what the hell is going on here there is no
             // way to trigger a generic tab event on the document to move focus on to
@@ -926,7 +926,7 @@ describe(test.label, function () {
       // FIXME: tests for tabbing into components isn't working anymore, despite the fact that
       // code changes shouldn't have affected it, AFAIK, probably need to look into alternative ways of
       // testing this (ARM 2016-12-05)
-      describe.skip('tab into component', function () {
+      describe('tab into component', function () {
         beforeEach(function () {
           // In case you are wondering what the hell is going on here there is no
           // way to trigger a generic tab event on the document to move focus on to
@@ -1507,7 +1507,7 @@ describe(test.label, function () {
         // FIXME: tests for tabbing into components isn't working anymore, despite the fact that
         // code changes shouldn't have affected it, AFAIK, probably need to look into alternative ways of
         // testing this (ARM 2016-12-05)
-        describe.skip('tab into component', function () {
+        describe('tab into component', function () {
           beforeEach(function () {
             // In case you are wondering what the hell is going on here there is no
             // way to trigger a generic tab event on the document to move focus on to
@@ -1661,10 +1661,21 @@ describe(test.label, function () {
 
         it('can find items by index, label and value', function (done) {
           return wait().then(() => {
+            $hook('select-item', {index: 0})
             expect($hook('select-item', {index: 0})).to.have.length(1)
             expect($hook('select-item', {label: 'Foo'})).to.have.length(1)
             expect($hook('select-item', {value: 'foo'})).to.have.length(1)
             done()
+          })
+        })
+        it('mouseenter should focus item', function (done) {
+          return wait().then(() => {
+            $hook('select-item', {index: 0}).mouseenter()
+            wait().then(() => {
+              expect($hook('select-item', {index: 0})[0].className.includes('frost-select-list-item-focused'))
+                .to.have.equal(true)
+              done()
+            })
           })
         })
       })


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* Fix frost-select-dropdown breaking in tests because autorun loop is disabled
* Add pre-cautionary run-loop on frost-scroll onMouseEnter