### PR TITLE
Float ember-disable-prototype-extensions devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "ember-cli-uglify": "^1.2.0",
     "ember-code-snippet": "1.7.0",
     "ember-data": "~2.12.0",
-    "ember-disable-prototype-extensions": "1.1.0",
+    "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
     "ember-frost-test": "^2.1.2",
     "ember-load-initializers": "^0.6.0",


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* Float `ember-disable-prototype-extensions` _devDependency_ to bring inline with semver range of other repos