### PR TITLE
Updated  _frost-checkbox.scss to solve cursor shows as pointer even when disabled

### DIFF
--- a/addon/styles/_frost-checkbox.scss
+++ b/addon/styles/_frost-checkbox.scss
@@ -77,8 +77,8 @@ $error-border: 1px solid $frost-color-input-error-border;
           .label {
             svg {
               fill: $frost-color-grey-6;
-              cursor:default; //Solves cursor shows as pointer even when disabled
             }
+            cursor: default;
           }
         }
       }

--- a/addon/styles/_frost-checkbox.scss
+++ b/addon/styles/_frost-checkbox.scss
@@ -77,6 +77,7 @@ $error-border: 1px solid $frost-color-input-error-border;
           .label {
             svg {
               fill: $frost-color-grey-6;
+              cursor:default; //Solves cursor shows as pointer even when disabled
             }
           }
         }


### PR DESCRIPTION
# Overview
Updated  _frost-checkbox.scss to solve cursor shows as pointer even when disabled

## Does this PR close an existing issue?
Yes

## Summary
Cursor was showing as pointer even when the checkbox is disabled. It should just show the default cursor.

## Issue Number(s)

https://github.com/ciena-frost/ember-frost-core/issues/543

* Closes #543

## Screenshots or recordings

![image](https://user-images.githubusercontent.com/13167506/38893054-2c23ddcc-4257-11e8-844b-9489c063f682.png)

## Checklist
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have evaluated if the _README.md_ documentation needs to be updated
* [*] I have evaluated if the _/tests/dummy/_ app needs to be modified
* [ ] I have evaluated if DocBlock headers needed to be added or updated
* [ ] I have verified that lint and tests pass locally with my changes
* [ ] If a fork of a dependent package had to be made to address the issue this PR closes:
* [ ] I noted in the fork's _README.md_ the reason the fork was created
* [ ] I have opened an upstream issue detailing what was deficient about the dependency
* [ ] I have opened an upstream PR addressing this deficiency
* [ ] I have opened an issue in this repository to track this PR and schedule the removal of the usage of the fork


# Semver

**This project uses [semver](http://semver.org), please check the scope of this PR:**

# Semver

- [ ] #none#
- [x] #patch#
- [ ] #minor#
- [ ] #major#

Examples:
* **NONE**
  * _README.md_ changes
  * test additions
  * changes to files that are not used by a consuming application (_.travis.yml_, _.gitignore_, etc)
* **PATCH**
  * backwards-compatible bug fix
    * nothing about how to use the code has changed
    * nothing about the outcome of the code has changed (though it likely corrected it)
  * changes to demo app (_/tests/dummy/_)
* **MINOR**
  * adding functionality in a backwards-compatible manner
    * nothing about how used to use the code has changed but using it in a new way will do new things
    * nothing about the outcome of the code has changed without having to first use it in a new way
    * addition of new CSS selectors
    * addition of new `ember-hook` selectors
* **MAJOR**
  * incompatible API change
    * using the code how used to will cease working
    * using the code how used to will have a different outcome
    * any changes to CSS selector names
    * any removal of CSS selectors
    * any changes to `ember-hook` selectors
    * possibly changes to test helpers (depends on the changes made)
  * any changes to the **_dependencies_** entry in the _package.json_ file

# CHANGELOG

* Closes #543 - Disabled checkbox no longer displays pointer cursor when disabled