### PR TITLE
Fix frost-expand animation target

### DIFF
--- a/addon/components/frost-expand.js
+++ b/addon/components/frost-expand.js
@@ -83,9 +83,9 @@ export default Component.extend({
       const expand = this.get('_expanded')
       const animationDuration = _expanded !== undefined ? this.get('animationDuration') : 0
       if (expand) {
-        this.$().find('.frost-expand-scroll').slideDown(animationDuration)
+        this.$().find('> .frost-expand-scroll').slideDown(animationDuration)
       } else {
-        this.$().find('.frost-expand-scroll').slideUp(animationDuration)
+        this.$().find('> .frost-expand-scroll').slideUp(animationDuration)
       }
     })
   },


### PR DESCRIPTION
# Overview

## Summary
Fixes `frost-expand` animation target so that if there are collapsed `frost-expands` within and the top level is collapsed then expanded, the inner `frost-expand` won't show its content even though it's collapsed.

## Issue Number(s)
* Closes #565 

## Screenshots or recordings
### Before:
![nestedexpandcollapse](https://user-images.githubusercontent.com/12944605/39474325-6f8c09b6-4d21-11e8-9b3f-b6ee9abf342c.gif)

### After:
![nestedexpandfix](https://user-images.githubusercontent.com/12944605/39474343-8c89b504-4d21-11e8-85d7-c5233acf46fd.gif)


## Checklist
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] I have evaluated if the _README.md_ documentation needs to be updated
* [x] I have evaluated if the _/tests/dummy/_ app needs to be modified
* [x] I have evaluated if DocBlock headers needed to be added or updated
* [x] I have verified that lint and tests pass locally with my changes
* [ ] If a fork of a dependent package had to be made to address the issue this PR closes:
  * [ ] I noted in the fork's _README.md_ the reason the fork was created
  * [ ] I have opened an upstream issue detailing what was deficient about the dependency
  * [ ] I have opened an upstream PR addressing this deficiency
  * [ ] I have opened an issue in this repository to track this PR and schedule the removal of the usage of the fork

# Semver

**This project uses [semver](http://semver.org), please check the scope of this PR:**

- [ ] #none#
- [x] #patch#
- [ ] #minor#
- [ ] #major#

# CHANGELOG

* Fix `frost-expand` animation target to target its direct children
