### PR TITLE
changed autocomplete input text and placeholder

### DIFF
--- a/addon/styles/_frost-autocomplete.scss
+++ b/addon/styles/_frost-autocomplete.scss
@@ -9,6 +9,11 @@ $frost-input-select-option-row-height: 30px;
 
     input {
       height: 100%;
+      font-size: $frost-font-s;
+
+      &::placeholder {
+        color: $frost-color-grey-5;
+      }
     }
   }
 


### PR DESCRIPTION
# Summary
Changed the font size to be "small" for auto complete text input and its placeholder, placeholder color was also changed

![screen shot 2018-05-30 at 2 04 28 pm](https://user-images.githubusercontent.com/26879720/40738773-7385928c-6412-11e8-8493-fb161613fe51.png)

![screen shot 2018-05-30 at 2 04 46 pm](https://user-images.githubusercontent.com/26879720/40738774-73979c2a-6412-11e8-9cfa-a4b6fae16cc1.png)

- [ ] #none#
- [x] #patch#
- [ ] #minor#
- [ ] #major#

* Closes #573

# CHANGELOG
* **Changed** styling for autocomplete input text and placeholder
