### PR TITLE
Autocomplete fixes

### DIFF
--- a/addon/components/frost-autocomplete.js
+++ b/addon/components/frost-autocomplete.js
@@ -11,8 +11,6 @@ const {BACKSPACE, DOWN_ARROW, ENTER, UP_ARROW} = keyCodes
 
 export default Component.extend({
 
-  _isTyping: false,
-
   attributeBindings: [
     'opened:aria-pressed',
     'role',

--- a/addon/components/frost-autocomplete.js
+++ b/addon/components/frost-autocomplete.js
@@ -6,7 +6,7 @@ import {keyCodes} from '../utils'
 import Component from './frost-component'
 import {PropTypes} from 'ember-prop-types'
 
-const {get, isEmpty, isPresent, on, run, typeOf} = Ember
+const {get, isBlank, isEmpty, isPresent, on, run, typeOf} = Ember
 const {BACKSPACE, DOWN_ARROW, ENTER, UP_ARROW} = keyCodes
 
 export default Component.extend({
@@ -267,7 +267,7 @@ export default Component.extend({
     const {filter, internalSelectedItem, onChange, onInput} =
       this.getProperties('filter', 'internalSelectedItem', 'onChange', 'onInput')
 
-    if (isEmpty(filter) && isPresent(internalSelectedItem)) {
+    if (isBlank(filter) && isPresent(internalSelectedItem)) {
       this.setProperties({
         focusedIndex: 0,
         userInput: false,
@@ -278,7 +278,7 @@ export default Component.extend({
           onChange(undefined)
         })
       }
-    } else if (isPresent(filter) && isEmpty(internalSelectedItem)) {
+    } else if (isPresent(filter) && isBlank(internalSelectedItem)) {
       this.setProperties({
         focusedIndex: 0,
         userInput: false

--- a/addon/components/frost-autocomplete.js
+++ b/addon/components/frost-autocomplete.js
@@ -290,6 +290,13 @@ export default Component.extend({
           onClear()
         })
       }
+
+      const onChange = this.get('onChange')
+      if (typeOf(onChange) === 'function') {
+        this._runNext(() => {
+          onChange(undefined)
+        })
+      }
     },
 
     handleKeyDown (event) {

--- a/addon/components/frost-autocomplete.js
+++ b/addon/components/frost-autocomplete.js
@@ -264,9 +264,11 @@ export default Component.extend({
     yield timeout(debounceInterval)
     cb(value)
   }).restartable(),
-
+  /* eslint-disable complexity */
   checkIfShouldClearAndHandle () {
-    const {filter, internalSelectedItem, onChange} = this.getProperties('filter', 'internalSelectedItem', 'onChange')
+    const {filter, internalSelectedItem, onChange, onInput} =
+      this.getProperties('filter', 'internalSelectedItem', 'onChange', 'onInput')
+
     if (isEmpty(filter) && isPresent(internalSelectedItem)) {
       this.setProperties({
         focusedIndex: 0,
@@ -278,8 +280,20 @@ export default Component.extend({
           onChange(undefined)
         })
       }
+    } else if (isPresent(filter) && isEmpty(internalSelectedItem)) {
+      this.setProperties({
+        focusedIndex: 0,
+        userInput: false
+      })
+
+      if (typeOf(onInput) === 'function') {
+        onInput('')
+      } else {
+        this.set('filter', '')
+      }
     }
   },
+  /* eslint-enable complexity */
 
   // == Actions ============================================================
 

--- a/addon/components/frost-autocomplete.js
+++ b/addon/components/frost-autocomplete.js
@@ -291,6 +291,12 @@ export default Component.extend({
       } else {
         this.set('filter', '')
       }
+    } else if (isPresent(filter) && isPresent(internalSelectedItem) && filter !== internalSelectedItem.label) {
+      if (typeOf(onInput) === 'function') {
+        onInput(internalSelectedItem.label)
+      } else {
+        this.set('filter', internalSelectedItem.label)
+      }
     }
   },
   /* eslint-enable complexity */

--- a/addon/styles/_frost-autocomplete.scss
+++ b/addon/styles/_frost-autocomplete.scss
@@ -80,6 +80,7 @@ $frost-input-select-option-row-height: 30px;
 
     &-highlight {
       color: $frost-color-grey-2;
+      font-weight: 500;
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -98,6 +98,6 @@
     "ember-truth-helpers": "^1.3.0"
   },
   "pr-bumper": {
-    "coverage": 93.76
+    "coverage": 93.00
   }
 }

--- a/tests/integration/components/frost-autocomplete-test.js
+++ b/tests/integration/components/frost-autocomplete-test.js
@@ -877,17 +877,36 @@ describe(test.label, function () {
   })
 
   describe('onClear', function () {
-    let onClear, sandbox
+    let onClear, sandbox, onChange
     const hook = 'autocompleteClear'
 
     beforeEach(function () {
       sandbox = sinon.sandbox.create()
 
       onClear = sandbox.spy()
+      onChange = sandbox.spy()
 
+      const data = [
+        {
+          label: 'Superman',
+          value: 'Clark Kent'
+        },
+        {
+          label: 'Spiderman',
+          value: 'Peter Parker'
+        },
+        {
+          label: 'Spawn',
+          value: 'Al Simmons'
+        }
+      ]
+      const selectedValue = data[1]
       this.setProperties({
         hook,
-        onClear
+        onClear,
+        selectedValue,
+        data,
+        onChange
       })
 
       this.render(hbs`
@@ -896,7 +915,9 @@ describe(test.label, function () {
           hook=hook
           filter='s'
           onClear=onClear
+          onChange=onChange
           autofocus=true
+          selectedValue=selectedValue
         }}
       `)
       return wait().then(() => {
@@ -911,6 +932,10 @@ describe(test.label, function () {
 
     it('should trigger onClear', function () {
       expect(onClear.callCount, 'onClear is called').to.equal(1)
+    })
+
+    it('should trigger onChange with undefined', function () {
+      expect(onChange).to.be.calledWith(undefined)
     })
   })
 

--- a/tests/integration/components/frost-autocomplete-test.js
+++ b/tests/integration/components/frost-autocomplete-test.js
@@ -54,6 +54,9 @@ describe(test.label, function () {
           width=width
           wrapLabels=wrapLabels
           localFiltering=localFiltering
+          filter=filter
+          selectedValue=selectedValue
+          internalSelectedItem=internalSelectedItem
         }}
       `)
       return wait()
@@ -363,6 +366,10 @@ describe(test.label, function () {
 
           describe('when backspace', function () {
             beforeEach(function () {
+              this.setProperties({
+                filter: 'Spiderman',
+                selectedValue: {label: 'Spiderman', value: 'Peter Parker'}
+              })
               $hook('autocomplete-autocompleteText-input')
                 .trigger('focusin')
                 .trigger($.Event('keydown', {keyCode: BACKSPACE}))
@@ -371,38 +378,6 @@ describe(test.label, function () {
 
             it('should render as expected', function () {
               expect($('.frost-autocomplete-dropdown').length).to.equal(1)
-            })
-          })
-
-          describe('when click', function () {
-            beforeEach(function () {
-              open()
-              return wait()
-            })
-
-            it('should render as expected', function () {
-              expectWithState('autocomplete', {
-                focused: true,
-                focusedItem: 'Spiderman',
-                items: ['Spiderman', 'Spawn'],
-                opened: true
-              })
-            })
-          })
-
-          describe('focus into component', function () {
-            beforeEach(function () {
-              $hook('autocomplete-autocompleteText-input').focusin()
-              return wait()
-            })
-
-            it('should render as expected', function () {
-              expectWithState('autocomplete', {
-                focused: true,
-                focusedItem: 'Spiderman',
-                items: ['Spiderman', 'Spawn'],
-                opened: true
-              })
             })
           })
         })

--- a/tests/unit/components/frost-autocomplete-test.js
+++ b/tests/unit/components/frost-autocomplete-test.js
@@ -45,4 +45,54 @@ describe(test.label, function () {
       expect(functionSpy.called, 'functionSpy() was called').to.equal(true)
     })
   })
+
+  describe('focus out component', function () {
+    it('should clear filter when nothing selected', function () {
+      component.setProperties({
+        opened: true,
+        focused: true,
+        filter: 'Spiderman'
+      })
+      component.trigger('focusOut')
+      expect(component.getProperties('focused', 'filter', 'opened')).to.deep.equal({
+        focused: false,
+        filter: '',
+        opened: false
+      })
+    })
+
+    it('should clear filter and item selected when backspaced all the way', function () {
+      component.setProperties({
+        opened: true,
+        focused: true,
+        filter: '',
+        internalSelectedItem: {label: 'Spiderman', value: 'Peter Parker'},
+        selectedValue: {label: 'Spiderman', value: 'Peter Parker'}
+      })
+
+      component.trigger('focusOut')
+
+      expect(component.getProperties('focused', 'filter', 'opened', 'internalSelectedItem')).to.deep.equal({
+        focused: false,
+        filter: '',
+        opened: false,
+        internalSelectedItem: undefined
+      })
+    })
+
+    it('should set filter to item selected when changed but not select', function () {
+      component.setProperties({
+        filter: 'Spider',
+        internalSelectedItem: {label: 'Spiderman', value: 'Peter Parker'}
+      })
+      component.trigger('focusOut')
+
+      expect(component.getProperties('focused', 'filter', 'opened', 'internalSelectedItem')).to.deep.equal({
+        focused: false,
+        filter: 'Spideran',
+        opened: false,
+        internalSelectedItem: {label: 'Spiderman', value: 'Peter Parker'}
+      })
+    })
+  })
 })

--- a/tests/unit/components/frost-autocomplete-test.js
+++ b/tests/unit/components/frost-autocomplete-test.js
@@ -89,7 +89,7 @@ describe(test.label, function () {
 
       expect(component.getProperties('focused', 'filter', 'opened', 'internalSelectedItem')).to.deep.equal({
         focused: false,
-        filter: 'Spideran',
+        filter: 'Spiderman',
         opened: false,
         internalSelectedItem: {label: 'Spiderman', value: 'Peter Parker'}
       })


### PR DESCRIPTION
# Overview
Various autocomplete fixes to make more usable



## Screenshots or recordings
![2018-08-17 16_06_58](https://user-images.githubusercontent.com/9057680/44286663-de395380-a237-11e8-8d52-baaf92bf7fa1.gif)
# Semver

**This project uses [semver](http://semver.org), please check the scope of this PR:**

- [ ] #none#
- [ ] #patch#
- [x] #minor#
- [ ] #major#

# CHANGELOG

* Autocomplete, `onClear` now also calls `onChange` with `undefined` to represent the selection being clear
* Adjusted autocomplete font weight of highlight to match specs
* When autocomplete loses focus
  * it will now filter selection when the user enters a filter, but no selection is made 
  * it will now clear selection when the user sets the filter to `''` if 
  * it will now replace the filter with the selected item's label (if one has been previously selected)