### PR TITLE
Add step option to frost-text

### DIFF
--- a/addon/components/frost-text.js
+++ b/addon/components/frost-text.js
@@ -45,6 +45,7 @@ export default Component.extend(FrostEventsProxyMixin, {
     required: PropTypes.bool,
     selectionDirection: PropTypes.string,
     spellcheck: PropTypes.bool,
+    step: PropTypes.string,
     value: PropTypes.string,
     title: PropTypes.string
 
@@ -64,6 +65,7 @@ export default Component.extend(FrostEventsProxyMixin, {
       readonly: false,
       required: false,
       spellcheck: false,
+      step: 'any',
       tabindex: 0,
       type: 'text'
     }

--- a/addon/templates/components/frost-text.hbs
+++ b/addon/templates/components/frost-text.hbs
@@ -24,6 +24,7 @@
   tabindex=tabindex
   title=title
   type=type
+  step=step
   value=value
 
   change=_eventProxy.change


### PR DESCRIPTION
# Overview
Step option to use when `type` is set to `number`

# Semver

- [ ] #none#
- [ ] #patch#
- [x] #minor#
- [ ] #major#

# CHANGELOG

* Add step option to frost-text