### PR TITLE
Fix autocomplete issues with copy+paste

### DIFF
--- a/addon/components/frost-autocomplete.js
+++ b/addon/components/frost-autocomplete.js
@@ -346,6 +346,16 @@ export default Component.extend({
       }
     },
 
+    // handlePaste (event) {
+    //   console.log('handle paste', event)
+    //   if (event.keyCode !== ENTER) {
+    //     this.setProperties({
+    //       userInput: true,
+    //       opened: true
+    //     })
+    //   }
+    // },
+
     handleKeyPress (event) {
       if (event.keyCode !== ENTER) {
         this.setProperties({
@@ -362,6 +372,13 @@ export default Component.extend({
       const onInput = this.get('onInput')
 
       const filter = e.target.value
+
+      if (!isBlank(filter)) {
+        this.setProperties({
+          userInput: true,
+          opened: true
+        })
+      }
 
       if (typeOf(onInput) === 'function') {
         inputTask.perform(onInput, filter)

--- a/addon/components/frost-autocomplete.js
+++ b/addon/components/frost-autocomplete.js
@@ -346,16 +346,6 @@ export default Component.extend({
       }
     },
 
-    // handlePaste (event) {
-    //   console.log('handle paste', event)
-    //   if (event.keyCode !== ENTER) {
-    //     this.setProperties({
-    //       userInput: true,
-    //       opened: true
-    //     })
-    //   }
-    // },
-
     handleKeyPress (event) {
       if (event.keyCode !== ENTER) {
         this.setProperties({

--- a/tests/integration/components/frost-autocomplete-test.js
+++ b/tests/integration/components/frost-autocomplete-test.js
@@ -317,7 +317,7 @@ describe(test.label, function () {
         })
       })
 
-      describe('when filter present', function () {
+      describe('when filter present and keypress', function () {
         beforeEach(function () {
           $hook('autocomplete-autocompleteText-input').val('sp').trigger('input').trigger('keypress')
           return wait()
@@ -551,6 +551,26 @@ describe(test.label, function () {
               opened: true
             })
           })
+        })
+      })
+
+      describe('when filter present and just input triggered', function () {
+        beforeEach(function () {
+          $hook('autocomplete-autocompleteText-input').val('sp').trigger('input')
+          return wait()
+        })
+
+        it('should render as expect', function () {
+          expectWithState('autocomplete', {
+            focused: true,
+            focusedItem: 'Spiderman',
+            items: ['Spiderman', 'Spawn'],
+            opened: true
+          })
+        })
+
+        it('should only have one focused item', function () {
+          expect($('.frost-autocomplete-list-item-focused')).to.have.length(1)
         })
       })
     })


### PR DESCRIPTION
# Overview
 Fixes issues with copy+paste, Ctrl+Z (anything that provides input but doesn't fire `keyPress`)
## Screenshots or recordings

### Issue

![image](https://user-images.githubusercontent.com/9057680/44481149-16171100-a613-11e8-97fa-bc37ad2cf0c0.png)

### After fix

![image](https://user-images.githubusercontent.com/9057680/44481388-a6555600-a613-11e8-98da-83498193b145.png)


# Semver

- [ ] #none#
- [x] #patch#
- [ ] #minor#
- [ ] #major#


# CHANGELOG

*  **Fixes** autocomplete issues with copy+paste, Ctrl+Z (anything that provides input but doesn't fire `keyPress`)

